### PR TITLE
Don't track master branches in Submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "xpring-common-protocol-buffers"]
 	path = xpring-common-protocol-buffers
 	url = git@github.com:xpring-eng/xpring-common-protocol-buffers.git
-	branch = master
 [submodule "xpring-common-js"]
 	path = xpring-common-js
 	url = git@github.com:xpring-eng/xpring-common-js.git

--- a/README.md
+++ b/README.md
@@ -198,11 +198,7 @@ Utils.isValidAddress(bitcoinAddress); // returns false
 To get set up for development on XpringJ, run the following commands:
 
 ```shell
-# Clone repository
-$ git clone https://github.com/xpring-eng/xpring4j.git
+# Clone repository and submodules
+$ git clone --recursive https://github.com/xpring-eng/xpring4j.git
 $ cd xpring4j
-
-# Pull submodules
-$ git submodule init
-$ git submodule update --remote --recursive --init
 ```


### PR DESCRIPTION
Don't pull submodules from HEAD. This effectively locks submodules at a commit, which means that submodule libraries can be upgraded. 

In the long term, this project may move to a mono repo approach, which is perhaps a less confusing solution to this problem. 