### PR TITLE
Pull pom.xml changes off 1.0.0 branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           name: "Pull Submodules"
           command: |
             git submodule init
-            git submodule update --remote
+            git submodule update
       - protobuf/install
 
       - run: mvn clean test jacoco:report coveralls:report -DrepoToken=$COVERALLS_TOKEN

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.xpring</groupId>
     <artifactId>xpring4j</artifactId>
-    <version>SNAPSHOT</version>
+    <version>HEAD-SNAPSHOT</version>
     <name>xpring4j</name>
     <url>https://github.com/xpring-eng/xpring4j</url>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
     <artifactId>xpring4j</artifactId>
     <version>1.0.0</version>
     <name>xpring4j</name>
+    <url>https://github.com/xpring-eng/xpring4j</url>
     <description>
         Xpring4j provides a Java based SDK for interacting with Xpring Platform (XRP/ILP)
     </description>
@@ -278,12 +279,36 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.3</version>
+                <configuration>
+                    <excludePackageNames>
+                        <!--
+                        The protocol buffer compiler doesn't generate javadoc. Exclude all protocol buffers from documentation.
+                        TODO(keefer): Protocol buffers should be in a separate package. Update this when there is a separate java package.
+                        -->
+                        io.xpring:io.xpring.xrpl
+                    </excludePackageNames>
+                    <source>8</source>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.xpring</groupId>
     <artifactId>xpring4j</artifactId>
-    <version>1.0.0</version>
+    <version>SNAPSHOT</version>
     <name>xpring4j</name>
     <url>https://github.com/xpring-eng/xpring4j</url>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,11 @@
 
     <groupId>io.xpring</groupId>
     <artifactId>xpring4j</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0</version>
+    <name>xpring4j</name>
+    <description>
+        Xpring4j provides a Java based SDK for interacting with Xpring Platform (XRP/ILP)
+    </description>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -16,6 +20,33 @@
         <slf4j.version>1.7.28</slf4j.version>
         <graalvm.version>1.0.0-rc10</graalvm.version>
     </properties>
+
+    <scm>
+        <connection>scm:git:git@github.com:xpring-eng/xpring4j.git</connection>
+        <url>scm:git:git@github.com:xpring-eng/xpring4j.git</url>
+        <developerConnection>scm:git:git@github.com:xpring-eng/xpring4j.git</developerConnection>
+    </scm>
+
+    <licenses>
+        <license>
+            <name>MIT</name>
+            <url>http://github.com/xpring-eng/xpring4j/blob/master/LICENSE</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>keefertaylor</id>
+            <name>Keefer Taylor</name>
+            <email>keefer@ripple.com</email>
+            <url>http://xpring.io</url>
+            <roles>
+                <role>developer</role>
+            </roles>
+            <timezone>-3</timezone>
+        </developer>
+    </developers>
 
     <dependencies>
         <dependency>
@@ -233,14 +264,64 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.3</version>
+                <configuration>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <releaseProfiles>release</releaseProfiles>
+                    <goals>deploy</goals>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.3</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.1.2</version>
+            </plugin>
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <distributionManagement>
         <repository>
-            <id>github</id>
-            <name>GitHub OWNER Apache Maven Packages</name>
-            <url>https://maven.pkg.github.com/xpring-eng/xpring4j</url>
+            <id>ossrh</id>
+            <name>ossrh</name>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
         </repository>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <name>ossrh</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
     </distributionManagement>
 </project>

--- a/src/main/java/io/xpring/javascript/JavaScriptLoader.java
+++ b/src/main/java/io/xpring/javascript/JavaScriptLoader.java
@@ -54,6 +54,8 @@ public class JavaScriptLoader {
 
     /**
      * Load a JavaScript Context that contains all the JavaScript code for the Xpring ecosystem.
+     *
+     * @return a new JavaScript context.
      */
     public static Context getContext() {
         return context;
@@ -62,7 +64,9 @@ public class JavaScriptLoader {
     /**
      * Load a class or function from the default entry point on the given JSContext.
      *
-     * This method loads value from `EntryPoint.default.<value>`.
+     * This method loads value from `EntryPoint.default.$value`.
+     *
+     * @throws JavaScriptLoaderException An exception if the javascript could not be loaded.
      *
      * @param resourceName: The name of the resource to load.
      * @param context:      The context load from.
@@ -83,6 +87,8 @@ public class JavaScriptLoader {
     /**
      * Load a class or function as a keyed subscript from the given value.
      *
+     * @throws JavaScriptLoaderException An exception if the javascript could not be loaded.
+     *
      * @param resourceName: The name of the resource to load.
      * @param value:        The value to load a resource from.
      *
@@ -97,4 +103,3 @@ public class JavaScriptLoader {
         return resource;
     }
 }
-

--- a/src/main/java/io/xpring/javascript/JavaScriptLoader.java
+++ b/src/main/java/io/xpring/javascript/JavaScriptLoader.java
@@ -71,7 +71,7 @@ public class JavaScriptLoader {
      *
      * @return A `Value` referring to the requested resource.
      *
-     * @throws JavaScriptLoaderException An exception if the javascript could not be loaded.
+     * @throws {@link JavaScriptLoaderException} An exception if the javascript could not be loaded.
      */
     public static Value loadResource(String resourceName, Context context) throws JavaScriptLoaderException {
         Value root = context.getBindings(javaScriptLanguageIdentifier).getMember("EntryPoint").getMember("default");
@@ -90,9 +90,9 @@ public class JavaScriptLoader {
      * @param resourceName: The name of the resource to load.
      * @param value:        The value to load a resource from.
      *
-     * @return A `Value` referring to the requested resource.
+     * @return A {@link Value} referring to the requested resource.
      *
-     * @throws JavaScriptLoaderException An exception if the javascript could not be loaded.
+     * @throws {@link JavaScriptLoaderException} An exception if the javascript could not be loaded.
      */
     public static Value loadResource(String resourceName, Value value) throws JavaScriptLoaderException {
         Value resource = value.getMember(resourceName);

--- a/src/main/java/io/xpring/javascript/JavaScriptLoader.java
+++ b/src/main/java/io/xpring/javascript/JavaScriptLoader.java
@@ -66,12 +66,12 @@ public class JavaScriptLoader {
      *
      * This method loads value from `EntryPoint.default.$value`.
      *
-     * @throws JavaScriptLoaderException An exception if the javascript could not be loaded.
-     *
      * @param resourceName: The name of the resource to load.
      * @param context:      The context load from.
      *
      * @return A `Value` referring to the requested resource.
+     *
+     * @throws JavaScriptLoaderException An exception if the javascript could not be loaded.
      */
     public static Value loadResource(String resourceName, Context context) throws JavaScriptLoaderException {
         Value root = context.getBindings(javaScriptLanguageIdentifier).getMember("EntryPoint").getMember("default");
@@ -87,12 +87,12 @@ public class JavaScriptLoader {
     /**
      * Load a class or function as a keyed subscript from the given value.
      *
-     * @throws JavaScriptLoaderException An exception if the javascript could not be loaded.
-     *
      * @param resourceName: The name of the resource to load.
      * @param value:        The value to load a resource from.
      *
      * @return A `Value` referring to the requested resource.
+     *
+     * @throws JavaScriptLoaderException An exception if the javascript could not be loaded.
      */
     public static Value loadResource(String resourceName, Value value) throws JavaScriptLoaderException {
         Value resource = value.getMember(resourceName);

--- a/src/main/java/io/xpring/javascript/JavaScriptSigner.java
+++ b/src/main/java/io/xpring/javascript/JavaScriptSigner.java
@@ -30,12 +30,12 @@ public class JavaScriptSigner {
     /**
      * Sign the given transaction with the given wallet.
      *
-     * @throws JavaScriptLoaderException An exception if the javascript could not be loaded.
-     *
      * @param transaction The transaction to sign.
      * @param wallet The wallet that will sign the transaction.
      *
      * @return A `SignedTransaction`.
+     *
+     * @throws JavaScriptLoaderException An exception if the javascript could not be loaded.
      */
     public SignedTransaction signTransaction(Transaction transaction, Wallet wallet) throws JavaScriptLoaderException {
         // Convert Java objects into JavaScript objects.
@@ -56,11 +56,11 @@ public class JavaScriptSigner {
     /**
      * Convert a JavaScript SignedTransaction to a native SignedTransaction.
      *
-     * @throws InvalidProtocolBufferException An exception if the javascript protocol buffer was invalid or could not be converted.
-     *
      * @param javaScriptSignedTransaction A reference to a SignedTransaction in JavaScript .
      *
      * @return A `SignedTransaction` from the JavaScript based input.
+     *
+     * @throws InvalidProtocolBufferException An exception if the javascript protocol buffer was invalid or could not be converted.
      */
     private SignedTransaction valueToSignedTransaction(Value javaScriptSignedTransaction) throws InvalidProtocolBufferException {
         Value javaScriptSignedTransactionBytes = javaScriptSignedTransaction.invokeMember("serializeBinary");

--- a/src/main/java/io/xpring/javascript/JavaScriptSigner.java
+++ b/src/main/java/io/xpring/javascript/JavaScriptSigner.java
@@ -29,8 +29,12 @@ public class JavaScriptSigner {
 
     /**
      * Sign the given transaction with the given wallet.
+     *
+     * @throws JavaScriptLoaderException An exception if the javascript could not be loaded.
+     *
      * @param transaction The transaction to sign.
      * @param wallet The wallet that will sign the transaction.
+     *
      * @return A `SignedTransaction`.
      */
     public SignedTransaction signTransaction(Transaction transaction, Wallet wallet) throws JavaScriptLoaderException {
@@ -51,6 +55,12 @@ public class JavaScriptSigner {
 
     /**
      * Convert a JavaScript SignedTransaction to a native SignedTransaction.
+     *
+     * @throws InvalidProtocolBufferException An exception if the javascript protocol buffer was invalid or could not be converted.
+     *
+     * @param javaScriptSignedTransaction A reference to a SignedTransaction in JavaScript .
+     *
+     * @return A `SignedTransaction` from the JavaScript based input.
      */
     private SignedTransaction valueToSignedTransaction(Value javaScriptSignedTransaction) throws InvalidProtocolBufferException {
         Value javaScriptSignedTransactionBytes = javaScriptSignedTransaction.invokeMember("serializeBinary");
@@ -61,6 +71,10 @@ public class JavaScriptSigner {
 
     /**
      * Convert a Wallet to a JavaScript Value reference.
+     *
+     * @param wallet The wallet to convert.
+     *
+     * @return A reference to the analagous wallet in JavaScript.
      */
     private Value walletToJavaScriptValue(Wallet wallet) {
         String publicKeyHex = wallet.getPublicKey();
@@ -70,6 +84,10 @@ public class JavaScriptSigner {
 
     /**
      * Convert a Transaction to a JavaScript Value reference.
+     *
+     * @param transaction The Transaction to convert.
+     *
+     * @return A reference to the analagous transaction in JavaScript.
      */
     private Value transactionToJavaScriptValue(Transaction transaction) {
         byte [] transactionBytes = transaction.toByteArray();

--- a/src/main/java/io/xpring/javascript/JavaScriptSigner.java
+++ b/src/main/java/io/xpring/javascript/JavaScriptSigner.java
@@ -30,12 +30,12 @@ public class JavaScriptSigner {
     /**
      * Sign the given transaction with the given wallet.
      *
-     * @param transaction The transaction to sign.
-     * @param wallet The wallet that will sign the transaction.
+     * @param transaction The {@link Transaction} to sign.
+     * @param wallet The {@link Wallet} that will sign the transaction.
      *
-     * @return A `SignedTransaction`.
+     * @return A {@link SignedTransaction}.
      *
-     * @throws JavaScriptLoaderException An exception if the javascript could not be loaded.
+     * @throws {@link JavaScriptLoaderException} An exception if the javascript could not be loaded.
      */
     public SignedTransaction signTransaction(Transaction transaction, Wallet wallet) throws JavaScriptLoaderException {
         // Convert Java objects into JavaScript objects.
@@ -54,13 +54,13 @@ public class JavaScriptSigner {
     }
 
     /**
-     * Convert a JavaScript SignedTransaction to a native SignedTransaction.
+     * Convert a JavaScript SignedTransaction to a native {@link SignedTransaction}.
      *
-     * @param javaScriptSignedTransaction A reference to a SignedTransaction in JavaScript .
+     * @param javaScriptSignedTransaction A reference to a SignedTransaction in JavaScript.
      *
-     * @return A `SignedTransaction` from the JavaScript based input.
+     * @return A {@link SignedTransaction} from the JavaScript based input.
      *
-     * @throws InvalidProtocolBufferException An exception if the javascript protocol buffer was invalid or could not be converted.
+     * @throws {@link InvalidProtocolBufferException} An exception if the javascript protocol buffer was invalid or could not be converted.
      */
     private SignedTransaction valueToSignedTransaction(Value javaScriptSignedTransaction) throws InvalidProtocolBufferException {
         Value javaScriptSignedTransactionBytes = javaScriptSignedTransaction.invokeMember("serializeBinary");
@@ -72,7 +72,7 @@ public class JavaScriptSigner {
     /**
      * Convert a Wallet to a JavaScript Value reference.
      *
-     * @param wallet The wallet to convert.
+     * @param wallet The {@link Wallet} to convert.
      *
      * @return A reference to the analagous wallet in JavaScript.
      */
@@ -85,7 +85,7 @@ public class JavaScriptSigner {
     /**
      * Convert a Transaction to a JavaScript Value reference.
      *
-     * @param transaction The Transaction to convert.
+     * @param transaction The {@link Transaction} to convert.
      *
      * @return A reference to the analagous transaction in JavaScript.
      */

--- a/src/main/java/io/xpring/javascript/JavaScriptUtils.java
+++ b/src/main/java/io/xpring/javascript/JavaScriptUtils.java
@@ -9,7 +9,7 @@ public class JavaScriptUtils {
     private Value javaScriptUtils;
 
     /**
-     * @throws JavaScriptLoaderException If the underlying JavaScript was missing or malformed.
+     * @throws {@link JavaScriptLoaderException} If the underlying JavaScript was missing or malformed.
      */
     public JavaScriptUtils() throws JavaScriptLoaderException {
         Context context = JavaScriptLoader.getContext();

--- a/src/main/java/io/xpring/javascript/JavaScriptWallet.java
+++ b/src/main/java/io/xpring/javascript/JavaScriptWallet.java
@@ -15,6 +15,8 @@ public class JavaScriptWallet {
 
     /**
      * Initialize a new JavaScriptWallet.
+     *
+     * @param javaScriptWallet A reference to a JavaScript based wallet.
      */
     public JavaScriptWallet(Value javaScriptWallet) {
         this.javaScriptWallet = javaScriptWallet;
@@ -22,6 +24,8 @@ public class JavaScriptWallet {
 
     /**
      * Returns the address of this `JavaScriptWallet`.
+     *
+     * @return The address of the wallet.
      */
     public String getAddress() {
         return javaScriptWallet.invokeMember("getAddress").asString();
@@ -29,6 +33,8 @@ public class JavaScriptWallet {
 
     /**
      * Returns the public key of this `JavaScriptWallet`.
+     *
+     * @return A hexadecimal encoded representation of the wallet's public key.
      */
     public String getPublicKey() {
         return javaScriptWallet.invokeMember("getPublicKey").asString();
@@ -36,6 +42,8 @@ public class JavaScriptWallet {
 
     /**
      * Returns the private key of this `JavaScriptWallet`.
+     *
+     * @return A hexadecimal encoded representation of the wallet's private key.
      */
     public String getPrivateKey() {
         return javaScriptWallet.invokeMember("getPrivateKey").asString();
@@ -43,6 +51,8 @@ public class JavaScriptWallet {
 
     /**
      * Sign the given input.
+     *
+     * @throws XpringKitException If the input was not valid.
      *
      * @param input The input to sign.
      *

--- a/src/main/java/io/xpring/javascript/JavaScriptWallet.java
+++ b/src/main/java/io/xpring/javascript/JavaScriptWallet.java
@@ -52,11 +52,11 @@ public class JavaScriptWallet {
     /**
      * Sign the given input.
      *
-     * @throws XpringKitException If the input was not valid.
-     *
      * @param input The input to sign.
      *
      * @return A hexadecimal encoded signature.
+     *
+     * @throws InvalidProtocolBufferException An exception if the javascript protocol buffer was invalid or could not be converted.
      */
     public String sign(String input) throws XpringKitException {
         Value javaScriptSignature = javaScriptWallet.invokeMember("sign", input);

--- a/src/main/java/io/xpring/javascript/JavaScriptWallet.java
+++ b/src/main/java/io/xpring/javascript/JavaScriptWallet.java
@@ -23,7 +23,7 @@ public class JavaScriptWallet {
     }
 
     /**
-     * Returns the address of this `JavaScriptWallet`.
+     * Returns the address of this JavaScriptWallet.
      *
      * @return The address of the wallet.
      */
@@ -32,7 +32,7 @@ public class JavaScriptWallet {
     }
 
     /**
-     * Returns the public key of this `JavaScriptWallet`.
+     * Returns the public key of this JavaScriptWallet.
      *
      * @return A hexadecimal encoded representation of the wallet's public key.
      */
@@ -41,7 +41,7 @@ public class JavaScriptWallet {
     }
 
     /**
-     * Returns the private key of this `JavaScriptWallet`.
+     * Returns the private key of this JavaScriptWallet.
      *
      * @return A hexadecimal encoded representation of the wallet's private key.
      */

--- a/src/main/java/io/xpring/javascript/JavaScriptWalletGenerationResult.java
+++ b/src/main/java/io/xpring/javascript/JavaScriptWalletGenerationResult.java
@@ -2,18 +2,18 @@ package io.xpring.javascript;
 
 /** Contains JavaScript artifacts of generating a new Wallet. */
 public class JavaScriptWalletGenerationResult {
-    /** The mnemonic of the newly generated Wallet. */
+    /** The mnemonic of the newly generated {@link Wallet}. */
     private String mnemonic;
     public String getMnemonic() { return mnemonic; }
 
-    /** The derivation path of the newly generated Wallet. */
+    /** The derivation path of the newly generated {@link Wallet}. */
     private String derivationPath;
     public String getDerivationPath() { return derivationPath; }
 
-    /** The newly generated Wallet. */
+    /** The newly generated {@link Wallet}. */
     private JavaScriptWallet wallet;
     public JavaScriptWallet getWallet()  { return wallet; }
-    
+
     public JavaScriptWalletGenerationResult(String mnemonic, String derivationPath, JavaScriptWallet wallet) {
         this.mnemonic = mnemonic;
         this.derivationPath = derivationPath;

--- a/src/main/java/io/xpring/javascript/JavaScriptWalletGenerationResult.java
+++ b/src/main/java/io/xpring/javascript/JavaScriptWalletGenerationResult.java
@@ -13,8 +13,7 @@ public class JavaScriptWalletGenerationResult {
     /** The newly generated Wallet. */
     private JavaScriptWallet wallet;
     public JavaScriptWallet getWallet()  { return wallet; }
-
-
+    
     public JavaScriptWalletGenerationResult(String mnemonic, String derivationPath, JavaScriptWallet wallet) {
         this.mnemonic = mnemonic;
         this.derivationPath = derivationPath;


### PR DESCRIPTION
A bunch of changes got made on the 1.0.0 branch to accommodate publishing to Maven Central. 

Pull them back to this branch in order to cut a new release with Neil's fix. 

A few notes:
- Documentation updates where required in order to make the JavaDoc plugin happy. 
- AFAICT, the protocol buffer compiler does not generate JavaDoc and the JavaDoc plugin only allows excludes by packages. Because of this, a large bit of code is excluded. I added a TODO and task in Asana to track and fix this.
- Updated CI config to drop `--remote` which leaves the submodule at the pinned state, rather than pulling from head on master. 