### PR TITLE
Remove print statement on unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           name: "Pull Submodules"
           command: |
             git submodule init
-            git submodule update --remote
+            git submodule update
       - protobuf/install
 
       - run: mvn clean test jacoco:report coveralls:report -DrepoToken=$COVERALLS_TOKEN

--- a/src/test/java/io/xpring/xrpl/XpringClientTest.java
+++ b/src/test/java/io/xpring/xrpl/XpringClientTest.java
@@ -54,6 +54,6 @@ public class XpringClientTest {
         Wallet wallet = new Wallet("snYP7oArxKepd3GPDcrjMsJYiJeJB");
 
         SubmitSignedTransactionResponse response = xpringClient.send(amount, "rsegqrgSP8XmhCYwL9enkZ9BNDNawfPZnn", wallet);
-        assertThat(response.getEngineResultMessage()).isEqual("The transaction was applied. Only final in a validated ledger.");
+        assertThat(response.getEngineResultMessage()).isEqualTo("The transaction was applied. Only final in a validated ledger.");
     }
 }

--- a/src/test/java/io/xpring/xrpl/XpringClientTest.java
+++ b/src/test/java/io/xpring/xrpl/XpringClientTest.java
@@ -54,7 +54,6 @@ public class XpringClientTest {
         Wallet wallet = new Wallet("snYP7oArxKepd3GPDcrjMsJYiJeJB");
 
         SubmitSignedTransactionResponse response = xpringClient.send(amount, "rsegqrgSP8XmhCYwL9enkZ9BNDNawfPZnn", wallet);
-
-        System.out.println(response.getEngineResultMessage());
+        assertThat(response.getEngineResultMessage()).isEqual("The transaction was applied. Only final in a validated ledger.");
     }
 }


### PR DESCRIPTION
Replace with an equality check. Still very brittle, but somewhat better. 

In the future we should find a way to mock network interactions so that this test is hermetic. Filed an Asana task to track.

This PR also fixes CI which was pulling protocol buffers from master. 