### PR TITLE
Make Unit Tests Hermetic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,18 @@
             <version>2.8.1</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-testing</artifactId>
+            <version>1.25.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.1.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/src/main/java/io/xpring/xrpl/XpringClient.java
+++ b/src/main/java/io/xpring/xrpl/XpringClient.java
@@ -1,6 +1,5 @@
 package io.xpring.xrpl;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.xpring.proto.AccountInfo;
@@ -117,8 +116,7 @@ public class XpringClient {
      *
      * @return A {@link BigInteger} representing a `fee` for submitting a transaction to the ledger.
      */
-    @VisibleForTesting
-    BigInteger getCurrentFeeInDrops() {
+    private BigInteger getCurrentFeeInDrops() {
         Fee getFeeResult = stub.getFee(GetFeeRequest.newBuilder().build());
         return new BigInteger(getFeeResult.getAmount().getDrops());
     }
@@ -130,8 +128,7 @@ public class XpringClient {
      *
      * @return An {@link AccountInfo} containing data about the given address.
      */
-    @VisibleForTesting
-    AccountInfo getAccountInfo(final String xrplAddress) {
+    private AccountInfo getAccountInfo(final String xrplAddress) {
         return stub.getAccountInfo(
             GetAccountInfoRequest.newBuilder().setAddress(xrplAddress).build()
         );

--- a/src/test/java/io/xpring/xrpl/XpringClientTest.java
+++ b/src/test/java/io/xpring/xrpl/XpringClientTest.java
@@ -2,14 +2,21 @@ package io.xpring.xrpl;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-import io.xpring.proto.AccountInfo;
-import io.xpring.proto.SubmitSignedTransactionResponse;
+import io.xpring.Utils;
+import io.xpring.proto.*;
 import io.xpring.Wallet;
 import io.xpring.XpringKitException;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import io.grpc.testing.GrpcCleanupRule;
+import io.grpc.inprocess.InProcessServerBuilder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import io.grpc.ManagedChannel;
+import io.grpc.inprocess.InProcessChannelBuilder;
 
 import java.math.BigInteger;
 
@@ -17,43 +24,91 @@ import java.math.BigInteger;
  * Unit tests for {@link XpringClient}.
  */
 public class XpringClientTest {
+    @Rule
+    public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
 
+    /** The XpringClient under test. */
+    private XpringClient client;
+
+    /** An address on the XRP Ledger. */
     private static final String XRPL_ADDRESS = "rD7zai6QQQVvWc39ZVAhagDgtH5xwEoeXD";
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
-    
-    private XpringClient xpringClient;
 
+    /** Mocked values in responses from the gRPC server. */
+    private static final String DROPS_OF_XRP_IN_ACCOUNT = "10";
+    private static final String DROPS_OF_XRP_FOR_FEE = "20";
+    private static final String TRANSACTION_BLOB = "DEADBEEF";
+
+    /** A mock implementation of the gRPC server. */
+    private final XRPLedgerAPIGrpc.XRPLedgerAPIImplBase serviceImpl =
+            mock(XRPLedgerAPIGrpc.XRPLedgerAPIImplBase.class, delegatesTo(
+                new XRPLedgerAPIGrpc.XRPLedgerAPIImplBase() {
+                    @Override
+                    public void getAccountInfo(io.xpring.proto.GetAccountInfoRequest request,
+                                               io.grpc.stub.StreamObserver<io.xpring.proto.AccountInfo> responseObserver) {
+                        XRPAmount balanceAmount = XRPAmount.newBuilder().setDrops(DROPS_OF_XRP_IN_ACCOUNT).build();
+                        AccountInfo accountInfo = AccountInfo.newBuilder().setBalance(balanceAmount).build();
+
+                        responseObserver.onNext(accountInfo);
+                        responseObserver.onCompleted();
+                    }
+
+                    @Override
+                    public void getFee(io.xpring.proto.GetFeeRequest request,
+                                       io.grpc.stub.StreamObserver<io.xpring.proto.Fee> responseObserver) {
+                        XRPAmount feeAmount = XRPAmount.newBuilder().setDrops(DROPS_OF_XRP_FOR_FEE).build();
+                        Fee fee = Fee.newBuilder().setAmount(feeAmount).build();
+
+                        responseObserver.onNext(fee);
+                        responseObserver.onCompleted();
+                    }
+
+                    @Override
+                    public void submitSignedTransaction(io.xpring.proto.SubmitSignedTransactionRequest request,
+                                                        io.grpc.stub.StreamObserver<io.xpring.proto.SubmitSignedTransactionResponse> responseObserver) {
+                        SubmitSignedTransactionResponse response = SubmitSignedTransactionResponse.newBuilder().setTransactionBlob(TRANSACTION_BLOB).build();
+
+                        responseObserver.onNext(response);
+                        responseObserver.onCompleted();
+                    }
+                }
+            )
+    );
+
+    /** Mocks gRPC networking inside of XpringClient. */
     @Before
-    public void setUp() {
-        this.xpringClient = new XpringClient();
+    public void setUp() throws Exception {
+        // Generate a unique in-process server name.
+        String serverName = InProcessServerBuilder.generateName();
+
+        // Create a server, add service, start, and register for automatic graceful shutdown.
+        grpcCleanup.register(InProcessServerBuilder
+                .forName(serverName).directExecutor().addService(serviceImpl).build().start());
+
+        // Create a client channel and register for automatic graceful shutdown.
+        ManagedChannel channel = grpcCleanup.register(
+                InProcessChannelBuilder.forName(serverName).directExecutor().build());
+
+        // Create a new XpringClient using the in-process channel;
+        client = new XpringClient(channel);
     }
 
     @Test
     public void getBalanceTest() {
-        BigInteger balance = xpringClient.getBalance(XRPL_ADDRESS);
-        assertThat(balance).isGreaterThan(BigInteger.ONE).withFailMessage("Balance should have been positive");
+        // GIVEN a XpringClient with mocked networking WHEN the balance is retrieved.
+        BigInteger balance = client.getBalance(XRPL_ADDRESS);
+
+        // THEN the balance returned is the the same as the mocked response.
+        assertThat(balance.toString()).isEqualTo(DROPS_OF_XRP_IN_ACCOUNT);
     }
 
     @Test
-    public void getFeeTest() {
-        BigInteger balance = xpringClient.getCurrentFeeInDrops();
-        assertThat(balance).isGreaterThan(BigInteger.ONE).withFailMessage("Fee should have been positive");
-    }
-
-    @Test
-    public void getAccountInfo() {
-        AccountInfo accountInfo = xpringClient.getAccountInfo(XRPL_ADDRESS);
-        assertThat(new BigInteger(accountInfo.getBalance().getDrops()))
-            .isGreaterThan(BigInteger.ONE)
-            .withFailMessage("Balance should have been positive");
-    }
-
-    @Test
-    public void sendXRPTest() throws XpringKitException {
-        BigInteger amount = new BigInteger("1");
+    public void submitTransactionTest() throws XpringKitException {
+        // GIVEN a XpringClient with mocked networking WHEN a transaction is sent.
         Wallet wallet = new Wallet("snYP7oArxKepd3GPDcrjMsJYiJeJB");
+        String transactionHash = client.send(new BigInteger("30"), XRPL_ADDRESS, wallet);
 
-        String transactionHash = xpringClient.send(amount, "rsegqrgSP8XmhCYwL9enkZ9BNDNawfPZnn", wallet);
-        assertThat(transactionHash).isNotNull();
+        // THEN the transaction hash is the same as the hash of the mocked transaction blob in the response.
+        String expectedTransactionHash = Utils.toTransactionHash(TRANSACTION_BLOB);
+        assertThat(transactionHash).isEqualTo(expectedTransactionHash);
     }
 }


### PR DESCRIPTION
`XpringClient` currently unit tests itself against a live remote service. This makes it impossible to simulate failures, and introduces the possibility of flaky tests if there are problems with the remote service. 

As [recommended by the gRPC team](https://github.com/grpc/grpc-java/issues/2160#issuecomment-239891964), use a mocked `XRPLedgerAPIImplBase ` and an `InProcessChannel` to simulate responses from the server. 

This PR only updates the existing tests which always succeeded. Future PRs will:
1) Fake failed requests / responses from the mocked `XRPLedgerAPIImplBase` and ensure errors are propagated correctly ([Asana](https://app.asana.com/0/1143722888069470/1145391289471595))
2) Add proper integration tests that sanity check us ([Asana](https://app.asana.com/0/1143722888069470/1148605104131075)) 