### PR TITLE
Implement a decorator pattern for XpringClient

### DIFF
--- a/src/main/java/io/xpring/xrpl/DefaultXpringClient.java
+++ b/src/main/java/io/xpring/xrpl/DefaultXpringClient.java
@@ -1,0 +1,153 @@
+package io.xpring.xrpl;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.xpring.proto.*;
+import io.xpring.proto.XRPLedgerAPIGrpc.XRPLedgerAPIBlockingStub;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigInteger;
+import java.util.Objects;
+
+/**
+ * A client that can submit transactions to the XRP Ledger.
+ *
+ * @see "https://xrpl.org"
+ */
+public class DefaultXpringClient implements XpringClientDecorator {
+    // TODO: Use TLS!
+    public static final String XPRING_TECH_GRPC_URL = "grpc.xpring.tech:80";
+
+    // A margin to pad the current ledger sequence with when submitting transactions.
+    private static final int LEDGER_SEQUENCE_MARGIN = 10;
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    // Channel is the abstraction to connect to a service endpoint
+    private final XRPLedgerAPIBlockingStub stub;
+
+    /**
+     * No-args Constructor.
+     */
+    public DefaultXpringClient() {
+        this(ManagedChannelBuilder
+            .forTarget(XPRING_TECH_GRPC_URL)
+            // Let's use plaintext communication because we don't have certs
+            // TODO: Use TLS!
+            .usePlaintext(true)
+            .build()
+        );
+    }
+
+    /**
+     * Required-args Constructor, currently for testing.
+     *
+     * @param channel A {@link ManagedChannel}.
+     */
+    DefaultXpringClient(final ManagedChannel channel) {
+        // It is up to the client to determine whether to block the call. Here we create a blocking stub, but an async
+        // stub, or an async stub with Future are always possible.
+        this.stub = XRPLedgerAPIGrpc.newBlockingStub(channel);
+    }
+
+    /**
+     * Get the balance of the specified account on the XRP Ledger.
+     *
+     * @param xrplAccountAddress The X-Address to retrieve the balance for.
+     * @return A {@link BigInteger} with the number of drops in this account.
+     * @throws XpringKitException If the given inputs were invalid.
+     */
+    public BigInteger getBalance(final String xrplAccountAddress) throws XpringKitException {
+        if (!Utils.isValidXAddress(xrplAccountAddress)) {
+            throw XpringKitException.xAddressRequiredException;
+        }
+
+        Objects.requireNonNull(xrplAccountAddress, "xrplAccountAddress must not be null");
+
+        AccountInfo result = stub
+            .getAccountInfo(GetAccountInfoRequest.newBuilder().setAddress(xrplAccountAddress).build());
+
+        logger.debug(
+            "Account balance successfully retrieved. accountAddress={} balance={}",
+            xrplAccountAddress, result.getBalance().toString()
+        );
+
+        return new BigInteger(result.getBalance().getDrops());
+    }
+
+    /**
+     * Transact XRP between two accounts on the ledger.
+     *
+     * @param amount The number of drops of XRP to send.
+     * @param destinationAddress The X-Address to send the XRP to.
+     * @param sourceWallet The {@link Wallet} which holds the XRP.
+     * @return A transaction hash for the payment.
+     * @throws XpringKitException If the given inputs were invalid.
+     */
+    public String send(
+        final BigInteger amount,
+        final String destinationAddress,
+        final Wallet sourceWallet
+    ) throws XpringKitException {
+        if (!Utils.isValidXAddress(destinationAddress)) {
+            throw XpringKitException.xAddressRequiredException;
+        }
+
+        AccountInfo accountInfo = this.getAccountInfo(sourceWallet.getAddress());
+        BigInteger currentFeeInDrops = this.getCurrentFeeInDrops();
+        int lastValidatedLedgerSequence = this.getLatestValidatedLedgerSequence();
+
+        Transaction transaction = Transaction.newBuilder()
+                .setAccount(sourceWallet.getAddress())
+                .setFee(XRPAmount.newBuilder().setDrops(currentFeeInDrops.toString()).build())
+                .setSequence(accountInfo.getSequence())
+                .setPayment(Payment.newBuilder()
+                .setDestination(destinationAddress)
+                .setXrpAmount(XRPAmount.newBuilder().setDrops(amount.toString()).build()).build())
+                .setSigningPublicKeyHex(sourceWallet.getPublicKey()).setLastLedgerSequence(lastValidatedLedgerSequence + LEDGER_SEQUENCE_MARGIN)
+            .build();
+
+        SignedTransaction signedTransaction = Signer.signTransaction(transaction, sourceWallet);
+
+        SubmitSignedTransactionRequest submitSignedTransactionRequest = SubmitSignedTransactionRequest.newBuilder()
+                .setSignedTransaction(signedTransaction).build();
+
+        SubmitSignedTransactionResponse response = stub.submitSignedTransaction(submitSignedTransactionRequest);
+        return Utils.toTransactionHash(response.getTransactionBlob());
+    }
+
+    /**
+     * Retrieve the current fee to submit a transaction to the XRP Ledger.
+     *
+     * @return A {@link BigInteger} representing a `fee` for submitting a transaction to the ledger.
+     */
+    private BigInteger getCurrentFeeInDrops() {
+        Fee getFeeResult = stub.getFee(GetFeeRequest.newBuilder().build());
+        return new BigInteger(getFeeResult.getAmount().getDrops());
+    }
+
+    /**
+     * Retrieve an `AccountInfo` for an address on the XRP Ledger.
+     *
+     * @param xrplAddress The address to retrieve information about.
+     *
+     * @return An {@link AccountInfo} containing data about the given address.
+     */
+    private AccountInfo getAccountInfo(final String xrplAddress) {
+        return stub.getAccountInfo(
+            GetAccountInfoRequest.newBuilder().setAddress(xrplAddress).build()
+        );
+    }
+
+    /**
+     * Retrieve the latest validated ledger sequence on the XRP Ledger.
+     *
+     * @return A long representing the sequence of the most recently validated ledger.
+     */
+    private int getLatestValidatedLedgerSequence() {
+        GetLatestValidatedLedgerSequenceRequest request = GetLatestValidatedLedgerSequenceRequest.newBuilder().build();
+        LedgerSequence ledgerSequence = stub.getLatestValidatedLedgerSequence(request);
+        return ledgerSequence.getIndex();
+    }
+}

--- a/src/main/java/io/xpring/xrpl/XpringClientDecorator.java
+++ b/src/main/java/io/xpring/xrpl/XpringClientDecorator.java
@@ -2,6 +2,9 @@ package io.xpring.xrpl;
 
 import java.math.BigInteger;
 
+/**
+ * An common interface shared between XpringClient and the internal hierarchy of decorators.
+ */
 public interface XpringClientDecorator {
     /**
      * Get the balance of the specified account on the XRP Ledger.

--- a/src/main/java/io/xpring/xrpl/XpringClientDecorator.java
+++ b/src/main/java/io/xpring/xrpl/XpringClientDecorator.java
@@ -2,21 +2,7 @@ package io.xpring.xrpl;
 
 import java.math.BigInteger;
 
-/**
- * A client that can submit transactions to the XRP Ledger.
- *
- * @see "https://xrpl.org"
- */
-public class XpringClient implements XpringClientDecorator {
-    private XpringClientDecorator decoratedClient;
-
-    /**
-     * Initialize a new client with the given options.
-     */
-    public XpringClient() {
-        this.decoratedClient = new DefaultXpringClient();
-    }
-
+public interface XpringClientDecorator {
     /**
      * Get the balance of the specified account on the XRP Ledger.
      *
@@ -24,9 +10,7 @@ public class XpringClient implements XpringClientDecorator {
      * @return A {@link BigInteger} with the number of drops in this account.
      * @throws XpringKitException If the given inputs were invalid.
      */
-    public BigInteger getBalance(final String xrplAccountAddress) throws XpringKitException {
-        return decoratedClient.getBalance(xrplAccountAddress);
-    }
+    public BigInteger getBalance(final String xrplAccountAddress) throws XpringKitException;
 
     /**
      * Transact XRP between two accounts on the ledger.
@@ -38,10 +22,8 @@ public class XpringClient implements XpringClientDecorator {
      * @throws XpringKitException If the given inputs were invalid.
      */
     public String send(
-        final BigInteger amount,
-        final String destinationAddress,
-        final Wallet sourceWallet
-    ) throws XpringKitException {
-        return decoratedClient.send(amount, destinationAddress, sourceWallet);
-    }
+            final BigInteger amount,
+            final String destinationAddress,
+            final Wallet sourceWallet
+    ) throws XpringKitException;
 }

--- a/src/test/java/io/xpring/xrpl/DefaultXpringClientTest.java
+++ b/src/test/java/io/xpring/xrpl/DefaultXpringClientTest.java
@@ -53,15 +53,15 @@ class GRPCResult<T> {
 /**
  * Unit tests for {@link XpringClient}.
  */
-public class XpringClientTest {
+public class DefaultXpringClientTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
     @Rule
     public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
 
-    /** The XpringClient under test. */
-    private XpringClient client;
+    /** The DefaultXpringClient under test. */
+    private DefaultXpringClient client;
 
     /** An address on the XRP Ledger. */
     private static final String XRPL_ADDRESS = "XVwDxLQ4SN9pEBQagTNHwqpFkPgGppXqrMoTmUcSKdCtcK5";
@@ -81,7 +81,7 @@ public class XpringClientTest {
     @Test
     public void getBalanceTest() throws IOException, XpringKitException {
         // GIVEN a XpringClient with mocked networking which will succeed.
-        XpringClient client = getClient();
+        DefaultXpringClient client = getClient();
 
         // WHEN the balance is retrieved.
         BigInteger balance = client.getBalance(XRPL_ADDRESS);
@@ -94,7 +94,7 @@ public class XpringClientTest {
     public void getBalanceWithClassicAddressTest() throws IOException, XpringKitException {
         // GIVEN a classic address.
         ClassicAddress classicAddress = Utils.decodeXAddress(XRPL_ADDRESS);
-        XpringClient client = getClient();
+        DefaultXpringClient client = getClient();
 
         // WHEN the balance for the classic address is retrieved THEN an error is thrown.
         expectedException.expect(XpringKitException.class);
@@ -105,7 +105,7 @@ public class XpringClientTest {
     public void getBalanceTestWithFailedAccountInfo() throws IOException, XpringKitException {
         // GIVEN a XpringClient with mocked networking which will fail to retrieve account info.
         GRPCResult<AccountInfo> accountInfoResult = GRPCResult.error(GENERIC_ERROR);
-        XpringClient client = getClient(
+        DefaultXpringClient client = getClient(
                 accountInfoResult,
                 GRPCResult.ok(makeFee(DROPS_OF_XRP_FOR_FEE)),
                 GRPCResult.ok(makeSubmitSignedTransactionResponse(TRANSACTION_BLOB)),
@@ -120,7 +120,7 @@ public class XpringClientTest {
     @Test
     public void submitTransactionTest() throws IOException, XpringKitException {
         // GIVEN a XpringClient with mocked networking which will succeed.
-        XpringClient client = getClient();
+        DefaultXpringClient client = getClient();
         Wallet wallet = new Wallet(WALLET_SEED);
 
         // WHEN a transaction is sent.
@@ -134,7 +134,7 @@ public class XpringClientTest {
     @Test
     public void submitTransactionWithClassicAddress() throws IOException, XpringKitException {
         // GIVEN a classic address.
-        XpringClient client = getClient();
+        DefaultXpringClient client = getClient();
         ClassicAddress classicAddress = Utils.decodeXAddress(XRPL_ADDRESS);
         Wallet wallet = new Wallet(WALLET_SEED);
 
@@ -147,7 +147,7 @@ public class XpringClientTest {
     public void submitTransactionWithFailedAccountInfo() throws IOException, XpringKitException {
         // GIVEN a XpringClient which will fail to return account info.
         GRPCResult<AccountInfo> accountInfoResult = GRPCResult.error(GENERIC_ERROR);
-        XpringClient client = getClient(
+        DefaultXpringClient client = getClient(
                 accountInfoResult,
                 GRPCResult.ok(makeFee(DROPS_OF_XRP_FOR_FEE)),
                 GRPCResult.ok(makeSubmitSignedTransactionResponse(TRANSACTION_BLOB)),
@@ -164,7 +164,7 @@ public class XpringClientTest {
     public void submitTransactionWithFailedFee() throws IOException, XpringKitException {
         // GIVEN a XpringClient which will fail to retrieve a fee.
         GRPCResult<Fee> feeResult = GRPCResult.error(GENERIC_ERROR);
-        XpringClient client = getClient(
+        DefaultXpringClient client = getClient(
                 GRPCResult.ok(makeAccountInfo(DROPS_OF_XRP_IN_ACCOUNT)),
                 feeResult,
                 GRPCResult.ok(makeSubmitSignedTransactionResponse(TRANSACTION_BLOB)),
@@ -181,7 +181,7 @@ public class XpringClientTest {
     public void submitTransactionWithFailedLatestValidatedLedgerSequence() throws IOException, XpringKitException {
         // GIVEN a XpringClient which will fail to retrieve a fee.
         GRPCResult<LedgerSequence> ledgerSequence = GRPCResult.error(GENERIC_ERROR);
-        XpringClient client = getClient(
+        DefaultXpringClient client = getClient(
                 GRPCResult.ok(makeAccountInfo(DROPS_OF_XRP_IN_ACCOUNT)),
                 GRPCResult.ok(makeFee(DROPS_OF_XRP_FOR_FEE)),
                 GRPCResult.ok(makeSubmitSignedTransactionResponse(TRANSACTION_BLOB)),
@@ -198,7 +198,7 @@ public class XpringClientTest {
     public void submitTransactionWithFailedSubmit() throws IOException, XpringKitException {
         // GIVEN a XpringClient which will fail to submit a transaction.
         GRPCResult<SubmitSignedTransactionResponse> submitResult = GRPCResult.error(GENERIC_ERROR);
-        XpringClient client = getClient(
+        DefaultXpringClient client = getClient(
                 GRPCResult.ok(makeAccountInfo(DROPS_OF_XRP_IN_ACCOUNT)),
                 GRPCResult.ok(makeFee(DROPS_OF_XRP_FOR_FEE)),
                 submitResult,
@@ -214,7 +214,7 @@ public class XpringClientTest {
     /**
      * Convenience method to get a XpringClient which has successful network calls.
      */
-    private XpringClient getClient() throws IOException {
+    private DefaultXpringClient getClient() throws IOException {
         return getClient(
                 GRPCResult.ok(makeAccountInfo(DROPS_OF_XRP_IN_ACCOUNT)),
                 GRPCResult.ok(makeFee(DROPS_OF_XRP_FOR_FEE)),
@@ -226,7 +226,7 @@ public class XpringClientTest {
     /**
      * Return a XpringClient which returns the given results for network calls.
      */
-    private XpringClient getClient(GRPCResult<AccountInfo> accountInfoResult, GRPCResult<Fee> feeResult, GRPCResult<SubmitSignedTransactionResponse> submitResult, GRPCResult<LedgerSequence> latestValidatedLedgerSequenceResult) throws IOException {
+    private DefaultXpringClient getClient(GRPCResult<AccountInfo> accountInfoResult, GRPCResult<Fee> feeResult, GRPCResult<SubmitSignedTransactionResponse> submitResult, GRPCResult<LedgerSequence> latestValidatedLedgerSequenceResult) throws IOException {
         XRPLedgerAPIGrpc.XRPLedgerAPIImplBase serviceImpl = getService(accountInfoResult, feeResult, submitResult, latestValidatedLedgerSequenceResult);
 
         // Generate a unique in-process server name.
@@ -241,7 +241,7 @@ public class XpringClientTest {
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
 
         // Create a new XpringClient using the in-process channel;
-        return new XpringClient(channel);
+        return new DefaultXpringClient(channel);
     }
 
     /**

--- a/src/test/java/io/xpring/xrpl/DefaultXpringClientTest.java
+++ b/src/test/java/io/xpring/xrpl/DefaultXpringClientTest.java
@@ -51,7 +51,7 @@ class GRPCResult<T> {
 }
 
 /**
- * Unit tests for {@link XpringClient}.
+ * Unit tests for {@link DefaultXpringClient}.
  */
 public class DefaultXpringClientTest {
     @Rule
@@ -80,7 +80,7 @@ public class DefaultXpringClientTest {
 
     @Test
     public void getBalanceTest() throws IOException, XpringKitException {
-        // GIVEN a XpringClient with mocked networking which will succeed.
+        // GIVEN a DefaultXpringClient with mocked networking which will succeed.
         DefaultXpringClient client = getClient();
 
         // WHEN the balance is retrieved.


### PR DESCRIPTION
`DefaultXpringClient`: Rename of the `XpringClient`, provides base for the decorator pattern.
`XpringClient`: Top level wrapper around all decorators. Will instantiate appropriate functionality for advanced features (reliable transaction submission, queueing)
`XpringClientDecorator`: Decorator Interface (`XpringClient` and `DefaultXpringClient` conform)
`XpringClientTests` -> `XpringClientTest`: Rebase tests for renamed class

This pattern was discussed internally at our design review for reliable transaction submission. 