### PR TITLE
Implement Transaction Status RPC

### DIFF
--- a/src/main/java/io/xpring/xrpl/TransactionStatus.java
+++ b/src/main/java/io/xpring/xrpl/TransactionStatus.java
@@ -1,0 +1,16 @@
+package io.xpring.xrpl;
+
+/** Represents statuses of transactions. */
+public enum TransactionStatus {
+    /** The transaction was included in a finalized ledger and failed. */
+    FAILED,
+
+    /** The transaction is not included in a finalized ledger. */
+    PENDING,
+
+    /** The transaction was included in a finalized ledger and succeeded. */
+    SUCCEEDED,
+
+    /** The transaction status is unknown. */
+    UNKNOWN;
+}

--- a/src/main/java/io/xpring/xrpl/XpringClient.java
+++ b/src/main/java/io/xpring/xrpl/XpringClient.java
@@ -80,7 +80,7 @@ public class XpringClient {
      * Retrieve the transaction status for a given transaction hash.
      *
      * @param transactionHash The hash of the transaction.
-     * @returns The status of the given transaction.
+     * @return The status of the given transaction.
      */
     public TransactionStatus getTransactionStatus(String transactionHash) {
         Objects.requireNonNull(transactionHash);

--- a/src/main/java/io/xpring/xrpl/XpringClient.java
+++ b/src/main/java/io/xpring/xrpl/XpringClient.java
@@ -32,11 +32,11 @@ public class XpringClient {
      */
     public XpringClient() {
         this(ManagedChannelBuilder
-            .forTarget(XPRING_TECH_GRPC_URL)
-            // Let's use plaintext communication because we don't have certs
-            // TODO: Use TLS!
-            .usePlaintext(true)
-            .build()
+                .forTarget(XPRING_TECH_GRPC_URL)
+                // Let's use plaintext communication because we don't have certs
+                // TODO: Use TLS!
+                .usePlaintext(true)
+                .build()
         );
     }
 
@@ -66,20 +66,20 @@ public class XpringClient {
         Objects.requireNonNull(xrplAccountAddress, "xrplAccountAddress must not be null");
 
         AccountInfo result = stub
-            .getAccountInfo(GetAccountInfoRequest.newBuilder().setAddress(xrplAccountAddress).build());
+                .getAccountInfo(GetAccountInfoRequest.newBuilder().setAddress(xrplAccountAddress).build());
 
         logger.debug(
-            "Account balance successfully retrieved. accountAddress={} balance={}",
-            xrplAccountAddress, result.getBalance().toString()
+                "Account balance successfully retrieved. accountAddress={} balance={}",
+                xrplAccountAddress, result.getBalance().toString()
         );
 
         return new BigInteger(result.getBalance().getDrops());
     }
 
     /**
-     *  Retrieve the transaction status for a given transaction hash.
+     * Retrieve the transaction status for a given transaction hash.
      *
-     * @param transactionHash: The hash of the transaction.
+     * @param transactionHash The hash of the transaction.
      * @returns The status of the given transaction.
      */
     public TransactionStatus getTransactionStatus(String transactionHash) {
@@ -96,19 +96,19 @@ public class XpringClient {
     }
 
 
-        /**
-         * Transact XRP between two accounts on the ledger.
-         *
-         * @param amount The number of drops of XRP to send.
-         * @param destinationAddress The X-Address to send the XRP to.
-         * @param sourceWallet The {@link Wallet} which holds the XRP.
-         * @return A transaction hash for the payment.
-         * @throws XpringKitException If the given inputs were invalid.
-         */
+    /**
+     * Transact XRP between two accounts on the ledger.
+     *
+     * @param amount The number of drops of XRP to send.
+     * @param destinationAddress The X-Address to send the XRP to.
+     * @param sourceWallet The {@link Wallet} which holds the XRP.
+     * @return A transaction hash for the payment.
+     * @throws XpringKitException If the given inputs were invalid.
+     * */
     public String send(
-        final BigInteger amount,
-        final String destinationAddress,
-        final Wallet sourceWallet
+            final BigInteger amount,
+            final String destinationAddress,
+            final Wallet sourceWallet
     ) throws XpringKitException {
         if (!Utils.isValidXAddress(destinationAddress)) {
             throw XpringKitException.xAddressRequiredException;
@@ -123,10 +123,10 @@ public class XpringClient {
                 .setFee(XRPAmount.newBuilder().setDrops(currentFeeInDrops.toString()).build())
                 .setSequence(accountInfo.getSequence())
                 .setPayment(Payment.newBuilder()
-                .setDestination(destinationAddress)
-                .setXrpAmount(XRPAmount.newBuilder().setDrops(amount.toString()).build()).build())
+                        .setDestination(destinationAddress)
+                        .setXrpAmount(XRPAmount.newBuilder().setDrops(amount.toString()).build()).build())
                 .setSigningPublicKeyHex(sourceWallet.getPublicKey()).setLastLedgerSequence(lastValidatedLedgerSequence + LEDGER_SEQUENCE_MARGIN)
-            .build();
+                .build();
 
         SignedTransaction signedTransaction = Signer.signTransaction(transaction, sourceWallet);
 
@@ -156,7 +156,7 @@ public class XpringClient {
      */
     private AccountInfo getAccountInfo(final String xrplAddress) {
         return stub.getAccountInfo(
-            GetAccountInfoRequest.newBuilder().setAddress(xrplAddress).build()
+                GetAccountInfoRequest.newBuilder().setAddress(xrplAddress).build()
         );
     }
 

--- a/src/main/java/io/xpring/xrpl/XpringClient.java
+++ b/src/main/java/io/xpring/xrpl/XpringClient.java
@@ -83,6 +83,7 @@ public class XpringClient {
      * @returns The status of the given transaction.
      */
     public TransactionStatus getTransactionStatus(String transactionHash) {
+        Objects.requireNonNull(transactionHash);
         GetTransactionStatusRequest transactionStatusRequest = GetTransactionStatusRequest.newBuilder().setTransactionHash(transactionHash).build();
 
         io.xpring.proto.TransactionStatus transactionStatus = stub.getTransactionStatus(transactionStatusRequest);

--- a/src/main/java/io/xpring/xrpl/XpringClient.java
+++ b/src/main/java/io/xpring/xrpl/XpringClient.java
@@ -77,14 +77,34 @@ public class XpringClient {
     }
 
     /**
-     * Transact XRP between two accounts on the ledger.
+     *  Retrieve the transaction status for a given transaction hash.
      *
-     * @param amount The number of drops of XRP to send.
-     * @param destinationAddress The X-Address to send the XRP to.
-     * @param sourceWallet The {@link Wallet} which holds the XRP.
-     * @return A transaction hash for the payment.
-     * @throws XpringKitException If the given inputs were invalid.
+     * @param transactionHash: The hash of the transaction.
+     * @returns The status of the given transaction.
      */
+    public TransactionStatus getTransactionStatus(String transactionHash) {
+        GetTransactionStatusRequest transactionStatusRequest = GetTransactionStatusRequest.newBuilder().setTransactionHash(transactionHash).build();
+
+        io.xpring.proto.TransactionStatus transactionStatus = stub.getTransactionStatus(transactionStatusRequest);
+
+        // Return PENDING if the transaction is not validated.
+        if (!transactionStatus.getValidated()) {
+            return TransactionStatus.PENDING;
+        }
+
+        return transactionStatus.getTransactionStatusCode().startsWith("tes") ? TransactionStatus.SUCCEEDED : TransactionStatus.FAILED;
+    }
+
+
+        /**
+         * Transact XRP between two accounts on the ledger.
+         *
+         * @param amount The number of drops of XRP to send.
+         * @param destinationAddress The X-Address to send the XRP to.
+         * @param sourceWallet The {@link Wallet} which holds the XRP.
+         * @return A transaction hash for the payment.
+         * @throws XpringKitException If the given inputs were invalid.
+         */
     public String send(
         final BigInteger amount,
         final String destinationAddress,

--- a/src/test/java/io/xpring/xrpl/IntegrationTests.java
+++ b/src/test/java/io/xpring/xrpl/IntegrationTests.java
@@ -23,12 +23,9 @@ public class IntegrationTests {
     /** Drops of XRP to send. */
     private static final BigInteger AMOUNT = new BigInteger("1");
 
-    /** Mocked values in responses from the gRPC server. */
-    private static final String DROPS_OF_XRP_IN_ACCOUNT = "10";
-    private static final String DROPS_OF_XRP_FOR_FEE = "20";
-    private static final String TRANSACTION_BLOB = "DEADBEEF";
+    /** Hash of a successful transaction. */
+    private static final String TRANSACTION_HASH = "2CBBD2523478848DA256F8EBFCBD490DD6048A4A5094BF8E3034F57EA6AA0522";
 
-    /** Mocks gRPC networking inside of XpringClient. */
     @Before
     public void setUp() throws Exception {
         this.xpringClient = new XpringClient();
@@ -38,6 +35,12 @@ public class IntegrationTests {
     public void getBalanceTest() throws XpringKitException {
         BigInteger balance = xpringClient.getBalance(XRPL_ADDRESS);
         assertThat(balance).isGreaterThan(BigInteger.ONE).withFailMessage("Balance should have been positive");
+    }
+
+    @Test
+    public void getTransactionStatusTest() {
+        TransactionStatus transactionStatus = xpringClient.getTransactionStatus(TRANSACTION_HASH);
+        assertThat(transactionStatus).isEqualTo(TransactionStatus.SUCCEEDED);
     }
 
     @Test

--- a/src/test/java/io/xpring/xrpl/XpringClientTest.java
+++ b/src/test/java/io/xpring/xrpl/XpringClientTest.java
@@ -71,6 +71,9 @@ public class XpringClientTest {
     private static final String DROPS_OF_XRP_FOR_FEE = "20";
     private static final String TRANSACTION_BLOB = "DEADBEEF";
     private static final String GENERIC_ERROR = "Mocked network error";
+    private static final String TRANSACTION_STATUS_SUCCESS = "tesSUCCESS";
+    private static final String TRANSACTION_STATUS_FAILURE = "tecFAILURE";
+    private static final String TRANSACTION_HASH = "DEADBEEF";
 
     /** The seed for a wallet with funds on the XRP Ledger test net. */
     private static final String WALLET_SEED = "snYP7oArxKepd3GPDcrjMsJYiJeJB";
@@ -109,7 +112,8 @@ public class XpringClientTest {
                 accountInfoResult,
                 GRPCResult.ok(makeFee(DROPS_OF_XRP_FOR_FEE)),
                 GRPCResult.ok(makeSubmitSignedTransactionResponse(TRANSACTION_BLOB)),
-                GRPCResult.ok(makeLedgerSequence())
+                GRPCResult.ok(makeLedgerSequence()),
+                GRPCResult.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS))
         );
 
         // WHEN the balance is retrieved THEN an error is thrown.
@@ -151,7 +155,8 @@ public class XpringClientTest {
                 accountInfoResult,
                 GRPCResult.ok(makeFee(DROPS_OF_XRP_FOR_FEE)),
                 GRPCResult.ok(makeSubmitSignedTransactionResponse(TRANSACTION_BLOB)),
-                GRPCResult.ok(makeLedgerSequence())
+                GRPCResult.ok(makeLedgerSequence()),
+                GRPCResult.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS))
         );
         Wallet wallet = new Wallet(WALLET_SEED);
 
@@ -168,7 +173,8 @@ public class XpringClientTest {
                 GRPCResult.ok(makeAccountInfo(DROPS_OF_XRP_IN_ACCOUNT)),
                 feeResult,
                 GRPCResult.ok(makeSubmitSignedTransactionResponse(TRANSACTION_BLOB)),
-                GRPCResult.ok(makeLedgerSequence())
+                GRPCResult.ok(makeLedgerSequence()),
+                GRPCResult.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS))
         );
         Wallet wallet = new Wallet(WALLET_SEED);
 
@@ -185,7 +191,8 @@ public class XpringClientTest {
                 GRPCResult.ok(makeAccountInfo(DROPS_OF_XRP_IN_ACCOUNT)),
                 GRPCResult.ok(makeFee(DROPS_OF_XRP_FOR_FEE)),
                 GRPCResult.ok(makeSubmitSignedTransactionResponse(TRANSACTION_BLOB)),
-                ledgerSequence
+                ledgerSequence,
+                GRPCResult.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS))
         );
         Wallet wallet = new Wallet(WALLET_SEED);
 
@@ -202,13 +209,90 @@ public class XpringClientTest {
                 GRPCResult.ok(makeAccountInfo(DROPS_OF_XRP_IN_ACCOUNT)),
                 GRPCResult.ok(makeFee(DROPS_OF_XRP_FOR_FEE)),
                 submitResult,
-                GRPCResult.ok(makeLedgerSequence())
+                GRPCResult.ok(makeLedgerSequence()),
+                GRPCResult.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS))
         );
         Wallet wallet = new Wallet(WALLET_SEED);
 
         // WHEN XRP is sent then THEN an error is thrown.
         expectedException.expect(Exception.class);
         client.send(AMOUNT, XRPL_ADDRESS, wallet);
+    }
+
+    @Test
+    public void transactionStatusWithInvalidatedTransactionAndFailureCode() throws IOException {
+        // GIVEN a XpringClient which will return an invalidated transaction with a failed code.
+        io.xpring.proto.TransactionStatus transactionStatusResponse = io.xpring.proto.TransactionStatus.newBuilder().setValidated(false).setTransactionStatusCode(TRANSACTION_STATUS_FAILURE).build();
+        XpringClient client = getClient(
+                GRPCResult.ok(makeAccountInfo(DROPS_OF_XRP_IN_ACCOUNT)),
+                GRPCResult.ok(makeFee(DROPS_OF_XRP_FOR_FEE)),
+                GRPCResult.ok(makeSubmitSignedTransactionResponse(TRANSACTION_BLOB)),
+                GRPCResult.ok(makeLedgerSequence()),
+                GRPCResult.ok(transactionStatusResponse)
+        );
+
+        // WHEN the transaction status is retrieved.
+        io.xpring.xrpl.TransactionStatus transactionStatus = client.getTransactionStatus(TRANSACTION_HASH);
+
+        // THEN the status is PENDING.
+        assertThat(transactionStatus).isEqualTo(io.xpring.xrpl.TransactionStatus.PENDING);
+    }
+
+    @Test
+    public void transactionStatusWithInvalidatedTransactionAndSuccessCode() throws IOException {
+        // GIVEN a XpringClient which will return an invalidated transaction with a failed code.
+        io.xpring.proto.TransactionStatus transactionStatusResponse = io.xpring.proto.TransactionStatus.newBuilder().setValidated(false).setTransactionStatusCode(TRANSACTION_STATUS_SUCCESS).build();
+        XpringClient client = getClient(
+                GRPCResult.ok(makeAccountInfo(DROPS_OF_XRP_IN_ACCOUNT)),
+                GRPCResult.ok(makeFee(DROPS_OF_XRP_FOR_FEE)),
+                GRPCResult.ok(makeSubmitSignedTransactionResponse(TRANSACTION_BLOB)),
+                GRPCResult.ok(makeLedgerSequence()),
+                GRPCResult.ok(transactionStatusResponse)
+        );
+
+        // WHEN the transaction status is retrieved.
+        io.xpring.xrpl.TransactionStatus transactionStatus = client.getTransactionStatus(TRANSACTION_HASH);
+
+        // THEN the status is PENDING.
+        assertThat(transactionStatus).isEqualTo(io.xpring.xrpl.TransactionStatus.PENDING);
+    }
+
+    @Test
+    public void transactionStatusWithValidatedTransactionAndFailureCode() throws IOException {
+        // GIVEN a XpringClient which will return an invalidated transaction with a failed code.
+        io.xpring.proto.TransactionStatus transactionStatusResponse = io.xpring.proto.TransactionStatus.newBuilder().setValidated(true).setTransactionStatusCode(TRANSACTION_STATUS_FAILURE).build();
+        XpringClient client = getClient(
+                GRPCResult.ok(makeAccountInfo(DROPS_OF_XRP_IN_ACCOUNT)),
+                GRPCResult.ok(makeFee(DROPS_OF_XRP_FOR_FEE)),
+                GRPCResult.ok(makeSubmitSignedTransactionResponse(TRANSACTION_BLOB)),
+                GRPCResult.ok(makeLedgerSequence()),
+                GRPCResult.ok(transactionStatusResponse)
+        );
+
+        // WHEN the transaction status is retrieved.
+        io.xpring.xrpl.TransactionStatus transactionStatus = client.getTransactionStatus(TRANSACTION_HASH);
+
+        // THEN the status is FAILED.
+        assertThat(transactionStatus).isEqualTo(io.xpring.xrpl.TransactionStatus.FAILED);
+    }
+
+    @Test
+    public void transactionStatusWithValidatedTransactionAndSuccessCode() throws IOException {
+        // GIVEN a XpringClient which will return an invalidated transaction with a failed code.
+        io.xpring.proto.TransactionStatus transactionStatusResponse = io.xpring.proto.TransactionStatus.newBuilder().setValidated(true).setTransactionStatusCode(TRANSACTION_STATUS_SUCCESS).build();
+        XpringClient client = getClient(
+                GRPCResult.ok(makeAccountInfo(DROPS_OF_XRP_IN_ACCOUNT)),
+                GRPCResult.ok(makeFee(DROPS_OF_XRP_FOR_FEE)),
+                GRPCResult.ok(makeSubmitSignedTransactionResponse(TRANSACTION_BLOB)),
+                GRPCResult.ok(makeLedgerSequence()),
+                GRPCResult.ok(transactionStatusResponse)
+        );
+
+        // WHEN the transaction status is retrieved.
+        io.xpring.xrpl.TransactionStatus transactionStatus = client.getTransactionStatus(TRANSACTION_HASH);
+
+        // THEN the status is SUCCEEDED.
+        assertThat(transactionStatus).isEqualTo(io.xpring.xrpl.TransactionStatus.SUCCEEDED);
     }
 
     /**
@@ -219,15 +303,16 @@ public class XpringClientTest {
                 GRPCResult.ok(makeAccountInfo(DROPS_OF_XRP_IN_ACCOUNT)),
                 GRPCResult.ok(makeFee(DROPS_OF_XRP_FOR_FEE)),
                 GRPCResult.ok(makeSubmitSignedTransactionResponse(TRANSACTION_BLOB)),
-                GRPCResult.ok(makeLedgerSequence())
+                GRPCResult.ok(makeLedgerSequence()),
+                GRPCResult.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS))
         );
     }
 
     /**
      * Return a XpringClient which returns the given results for network calls.
      */
-    private XpringClient getClient(GRPCResult<AccountInfo> accountInfoResult, GRPCResult<Fee> feeResult, GRPCResult<SubmitSignedTransactionResponse> submitResult, GRPCResult<LedgerSequence> latestValidatedLedgerSequenceResult) throws IOException {
-        XRPLedgerAPIGrpc.XRPLedgerAPIImplBase serviceImpl = getService(accountInfoResult, feeResult, submitResult, latestValidatedLedgerSequenceResult);
+    private XpringClient getClient(GRPCResult<AccountInfo> accountInfoResult, GRPCResult<Fee> feeResult, GRPCResult<SubmitSignedTransactionResponse> submitResult, GRPCResult<LedgerSequence> latestValidatedLedgerSequenceResult, GRPCResult<io.xpring.proto.TransactionStatus> transactionStatusResult) throws IOException {
+        XRPLedgerAPIGrpc.XRPLedgerAPIImplBase serviceImpl = getService(accountInfoResult, feeResult, submitResult, latestValidatedLedgerSequenceResult, transactionStatusResult);
 
         // Generate a unique in-process server name.
         String serverName = InProcessServerBuilder.generateName();
@@ -247,7 +332,7 @@ public class XpringClientTest {
     /**
      * Return a XRPLedgerService implementation which returns the given results for network calls.
      */
-    private XRPLedgerAPIGrpc.XRPLedgerAPIImplBase getService(GRPCResult<AccountInfo> accountInfoResult, GRPCResult<Fee> feeResult, GRPCResult<SubmitSignedTransactionResponse> submitResult, GRPCResult<LedgerSequence> latestValidatedLedgerSequenceResult) {
+    private XRPLedgerAPIGrpc.XRPLedgerAPIImplBase getService(GRPCResult<AccountInfo> accountInfoResult, GRPCResult<Fee> feeResult, GRPCResult<SubmitSignedTransactionResponse> submitResult, GRPCResult<LedgerSequence> latestValidatedLedgerSequenceResult, GRPCResult<io.xpring.proto.TransactionStatus> transactionStatusResult) {
         return mock(XRPLedgerAPIGrpc.XRPLedgerAPIImplBase.class, delegatesTo(
                 new XRPLedgerAPIGrpc.XRPLedgerAPIImplBase() {
                     @Override
@@ -293,6 +378,17 @@ public class XpringClientTest {
                             responseObserver.onCompleted();
                         }
                     }
+
+                    @Override
+                    public void getTransactionStatus(io.xpring.proto.GetTransactionStatusRequest request,
+                                                     io.grpc.stub.StreamObserver<io.xpring.proto.TransactionStatus> responseObserver) {
+                        if (transactionStatusResult.isError()) {
+                            responseObserver.onError(new Throwable(transactionStatusResult.getError()));
+                        } else {
+                            responseObserver.onNext(transactionStatusResult.getValue());
+                            responseObserver.onCompleted();
+                        }
+                    }
                 }
                 )
         );
@@ -327,5 +423,12 @@ public class XpringClientTest {
      */
     private LedgerSequence makeLedgerSequence() {
         return LedgerSequence.newBuilder().setIndex(12).build();
+    }
+
+    /**
+     * Make a Transaction Status.
+     */
+    private io.xpring.proto.TransactionStatus makeTransactionStatus(Boolean validated, String transactionStatusCode) {
+        return io.xpring.proto.TransactionStatus.newBuilder().setValidated(validated).setTransactionStatusCode(transactionStatusCode).build();
     }
 }

--- a/src/test/java/io/xpring/xrpl/XpringClientTest.java
+++ b/src/test/java/io/xpring/xrpl/XpringClientTest.java
@@ -220,7 +220,7 @@ public class XpringClientTest {
     }
 
     @Test
-    public void transactionStatusWithInvalidatedTransactionAndFailureCode() throws IOException {
+    public void transactionStatusWithUnvalidatedTransactionAndFailureCode() throws IOException {
         // GIVEN a XpringClient which will return an invalidated transaction with a failed code.
         io.xpring.proto.TransactionStatus transactionStatusResponse = io.xpring.proto.TransactionStatus.newBuilder().setValidated(false).setTransactionStatusCode(TRANSACTION_STATUS_FAILURE).build();
         XpringClient client = getClient(
@@ -239,8 +239,8 @@ public class XpringClientTest {
     }
 
     @Test
-    public void transactionStatusWithInvalidatedTransactionAndSuccessCode() throws IOException {
-        // GIVEN a XpringClient which will return an invalidated transaction with a failed code.
+    public void transactionStatusWithUnvalidatedTransactionAndSuccessCode() throws IOException {
+        // GIVEN a XpringClient which will return an unvalidated transaction with a success code.
         io.xpring.proto.TransactionStatus transactionStatusResponse = io.xpring.proto.TransactionStatus.newBuilder().setValidated(false).setTransactionStatusCode(TRANSACTION_STATUS_SUCCESS).build();
         XpringClient client = getClient(
                 GRPCResult.ok(makeAccountInfo(DROPS_OF_XRP_IN_ACCOUNT)),
@@ -259,7 +259,7 @@ public class XpringClientTest {
 
     @Test
     public void transactionStatusWithValidatedTransactionAndFailureCode() throws IOException {
-        // GIVEN a XpringClient which will return an invalidated transaction with a failed code.
+        // GIVEN a XpringClient which will return an validated transaction with a failed code.
         io.xpring.proto.TransactionStatus transactionStatusResponse = io.xpring.proto.TransactionStatus.newBuilder().setValidated(true).setTransactionStatusCode(TRANSACTION_STATUS_FAILURE).build();
         XpringClient client = getClient(
                 GRPCResult.ok(makeAccountInfo(DROPS_OF_XRP_IN_ACCOUNT)),
@@ -278,7 +278,7 @@ public class XpringClientTest {
 
     @Test
     public void transactionStatusWithValidatedTransactionAndSuccessCode() throws IOException {
-        // GIVEN a XpringClient which will return an invalidated transaction with a failed code.
+        // GIVEN a XpringClient which will return an validated transaction with a success code.
         io.xpring.proto.TransactionStatus transactionStatusResponse = io.xpring.proto.TransactionStatus.newBuilder().setValidated(true).setTransactionStatusCode(TRANSACTION_STATUS_SUCCESS).build();
         XpringClient client = getClient(
                 GRPCResult.ok(makeAccountInfo(DROPS_OF_XRP_IN_ACCOUNT)),
@@ -293,6 +293,23 @@ public class XpringClientTest {
 
         // THEN the status is SUCCEEDED.
         assertThat(transactionStatus).isEqualTo(io.xpring.xrpl.TransactionStatus.SUCCEEDED);
+    }
+
+    @Test
+    public void transactionStatusWithNodeError() throws IOException {
+        // GIVEN a XpringClient which will error when a transaction status is requested..
+        io.xpring.proto.TransactionStatus transactionStatusResponse = io.xpring.proto.TransactionStatus.newBuilder().setValidated(true).setTransactionStatusCode(TRANSACTION_STATUS_SUCCESS).build();
+        XpringClient client = getClient(
+                GRPCResult.ok(makeAccountInfo(DROPS_OF_XRP_IN_ACCOUNT)),
+                GRPCResult.ok(makeFee(DROPS_OF_XRP_FOR_FEE)),
+                GRPCResult.ok(makeSubmitSignedTransactionResponse(TRANSACTION_BLOB)),
+                GRPCResult.ok(makeLedgerSequence()),
+                GRPCResult.error(GENERIC_ERROR)
+        );
+
+        // WHEN the transaction status is retrieved THEN an error is thrown..
+        expectedException.expect(Exception.class);
+        client.getTransactionStatus(TRANSACTION_HASH);
     }
 
     /**


### PR DESCRIPTION
Code Changes:
- Wire RPC for getTransactionStatus
- Add enum for Transaction Status
- Wire RPC and enum to a new `getTransactionStatus` API

Tested:
- Add unit tests 
- Add integration Tests

This is part of a group of PRs:
- Xpring-JS / JavaScript: https://github.com/xpring-eng/Xpring-JS/pull/77
- Xpring4J / Java: https://github.com/xpring-eng/xpring4j/pull/44
- XpringKit / Swift: https://github.com/xpring-eng/XpringKit/pull/40

Note: Integration tests failing until the Appian node wrapper is updated. PR is here: https://github.com/xpring-eng/AppianJS/pull/29