### PR TITLE
Reliable Transaction Submission 

### DIFF
--- a/src/main/java/io/xpring/xrpl/DefaultXpringClient.java
+++ b/src/main/java/io/xpring/xrpl/DefaultXpringClient.java
@@ -17,7 +17,7 @@ import java.util.Objects;
  */
 public class DefaultXpringClient implements XpringClientDecorator {
     // TODO: Use TLS!
-    public static final String XPRING_TECH_GRPC_URL = "127.0.0.1:9090"; //"grpc.xpring.tech:80";
+    public static final String XPRING_TECH_GRPC_URL = "grpc.xpring.tech:80";
 
     // A margin to pad the current ledger sequence with when submitting transactions.
     private static final int LEDGER_SEQUENCE_MARGIN = 10;

--- a/src/main/java/io/xpring/xrpl/ReliableSubmissionXpringClient.java
+++ b/src/main/java/io/xpring/xrpl/ReliableSubmissionXpringClient.java
@@ -1,0 +1,65 @@
+package io.xpring.xrpl;
+
+import io.xpring.xrpl.XpringClientDecorator;
+
+import java.math.BigInteger;
+
+public class ReliableSubmissionXpringClient implements XpringClientDecorator {
+    XpringClientDecorator decoratedClient;
+
+    public ReliableSubmissionXpringClient(XpringClientDecorator decoratedClient) {
+        this.decoratedClient = decoratedClient;
+    }
+
+    @Override
+    public BigInteger getBalance(String xrplAccountAddress) throws XpringKitException {
+        return this.decoratedClient.getBalance(xrplAccountAddress);
+    }
+
+    @Override
+    public TransactionStatus getTransactionStatus(String transactionHash) {
+        return this.decoratedClient.getTransactionStatus(transactionHash);
+    }
+
+    public String send(BigInteger amount, String destinationAddress, Wallet sourceWallet) throws XpringKitException {
+        try {
+            long ledgerCloseTime = 4 * 1000;
+
+            // Submit a transaction hash and wait for a ledger to close.
+            String transactionHash = decoratedClient.send(amount, destinationAddress, sourceWallet);
+            Thread.sleep(ledgerCloseTime);
+
+            // Get transaction status.
+            io.xpring.proto.TransactionStatus transactionStatus = this.getRawTransactionStatus(transactionHash);
+            int lastLedgerSequence = transactionStatus.getLastLedgerSequence();
+            if (lastLedgerSequence == 0) {
+                throw new XpringKitException("The transaction did not have a lastLedgerSequence field so transaction status cannot be reliably determined.");
+            }
+
+            // Retrieve the latest ledger index.
+            int latestLedgerSequence = this.getLatestValidatedLedgerSequence();
+
+            // Poll until the transaction is validated, or until the lastLedgerSequence has been passed.
+            while (latestLedgerSequence <= lastLedgerSequence && !transactionStatus.getValidated()) {
+                Thread.sleep(ledgerCloseTime);
+
+                latestLedgerSequence = this.getLatestValidatedLedgerSequence();
+                transactionStatus = this.getRawTransactionStatus(transactionHash);
+            }
+
+            return transactionHash;
+        } catch (InterruptedException e) {
+            throw new XpringKitException("Reliable transaction submission project was interrupted.");
+        }
+    }
+
+    @Override
+    public int getLatestValidatedLedgerSequence() {
+        return this.decoratedClient.getLatestValidatedLedgerSequence();
+    }
+
+    @Override
+    public io.xpring.proto.TransactionStatus getRawTransactionStatus(String transactionHash) {
+        return this.decoratedClient.getRawTransactionStatus(transactionHash);
+    }
+}

--- a/src/main/java/io/xpring/xrpl/XpringClient.java
+++ b/src/main/java/io/xpring/xrpl/XpringClient.java
@@ -7,14 +7,15 @@ import java.math.BigInteger;
  *
  * @see "https://xrpl.org"
  */
-public class XpringClient implements XpringClientDecorator {
+public class XpringClient {
     private XpringClientDecorator decoratedClient;
 
     /**
      * Initialize a new client with the given options.
      */
     public XpringClient() {
-        this.decoratedClient = new DefaultXpringClient();
+        DefaultXpringClient defaultXpringClient = new DefaultXpringClient();
+        this.decoratedClient = new ReliableSubmissionXpringClient(defaultXpringClient);
     }
 
     /**

--- a/src/main/java/io/xpring/xrpl/XpringClientDecorator.java
+++ b/src/main/java/io/xpring/xrpl/XpringClientDecorator.java
@@ -1,5 +1,8 @@
 package io.xpring.xrpl;
 
+import io.xpring.proto.GetLatestValidatedLedgerSequenceRequest;
+import io.xpring.proto.LedgerSequence;
+
 import java.math.BigInteger;
 
 /**
@@ -13,7 +16,7 @@ public interface XpringClientDecorator {
      * @return A {@link BigInteger} with the number of drops in this account.
      * @throws XpringKitException If the given inputs were invalid.
      */
-    public BigInteger getBalance(final String xrplAccountAddress) throws XpringKitException;
+    BigInteger getBalance(final String xrplAccountAddress) throws XpringKitException;
 
 
     /**
@@ -22,7 +25,7 @@ public interface XpringClientDecorator {
      * @param transactionHash The hash of the transaction.
      * @return The status of the given transaction.
      */
-    public TransactionStatus getTransactionStatus(String transactionHash);
+    TransactionStatus getTransactionStatus(String transactionHash);
 
     /**
      * Transact XRP between two accounts on the ledger.
@@ -33,9 +36,24 @@ public interface XpringClientDecorator {
      * @return A transaction hash for the payment.
      * @throws XpringKitException If the given inputs were invalid.
      */
-    public String send(
+    String send(
             final BigInteger amount,
             final String destinationAddress,
             final Wallet sourceWallet
     ) throws XpringKitException;
+
+    /**
+     * Retrieve the latest validated ledger sequence on the XRP Ledger.
+     *
+     * @return A long representing the sequence of the most recently validated ledger.
+     */
+    int getLatestValidatedLedgerSequence();
+
+    /**
+     * Retrieve the raw transaction status for the given transaction hash.
+     *
+     * @param transactionHash: The hash of the transaction.
+     * @return an {@link io.xpring.proto.TransactionStatus} containing the raw transaction status.
+     */
+    io.xpring.proto.TransactionStatus getRawTransactionStatus(String transactionHash);
 }

--- a/src/test/java/io/xpring/xrpl/FakeXpringClient.java
+++ b/src/test/java/io/xpring/xrpl/FakeXpringClient.java
@@ -1,0 +1,57 @@
+package io.xpring.xrpl;
+
+
+import io.xpring.proto.Transaction;
+
+import java.math.BigInteger;
+
+/**
+ * A fake XpringClient which returns the given iVars as results from XpringClientDecorator calls.
+ * @Note: Since this class is passed by reference and the iVars are mutable, outputs of this class can be changed after it is injected.
+ */
+public class FakeXpringClient implements  XpringClientDecorator {
+    public BigInteger getBalanceValue;
+    public TransactionStatus transactionStatusValue;
+    public String sendValue;
+    public int latestValidatedLedgerValue;
+    public io.xpring.proto.TransactionStatus rawTransactionStatusValue;
+
+    public FakeXpringClient(
+            BigInteger getBalanceValue,
+            TransactionStatus transactionStatusValue,
+            String sendValue,
+            int latestValidatedLedgerValue,
+            io.xpring.proto.TransactionStatus rawTransactionStatusValue
+    ) {
+        this.getBalanceValue = getBalanceValue;
+        this.transactionStatusValue = transactionStatusValue;
+        this.sendValue = sendValue;
+        this.latestValidatedLedgerValue = latestValidatedLedgerValue;
+        this.rawTransactionStatusValue = rawTransactionStatusValue;
+    }
+
+    @Override
+    public BigInteger getBalance(String xrplAccountAddress) throws XpringKitException {
+        return this.getBalanceValue;
+    }
+
+    @Override
+    public TransactionStatus getTransactionStatus(String transactionHash) {
+        return this.transactionStatusValue;
+    }
+
+    @Override
+    public String send(BigInteger amount, String destinationAddress, Wallet sourceWallet) throws XpringKitException {
+        return this.sendValue;
+    }
+
+    @Override
+    public int getLatestValidatedLedgerSequence() {
+        return this.latestValidatedLedgerValue;
+    }
+
+    @Override
+    public io.xpring.proto.TransactionStatus getRawTransactionStatus(String transactionHash) {
+        return this.rawTransactionStatusValue;
+    }
+}

--- a/src/test/java/io/xpring/xrpl/ReliableSubmissionXpringClientTest.java
+++ b/src/test/java/io/xpring/xrpl/ReliableSubmissionXpringClientTest.java
@@ -6,12 +6,11 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.math.BigInteger;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-
-interface AsyncWork {
-    void run();
-}
 
 public class ReliableSubmissionXpringClientTest {
     @Rule
@@ -38,9 +37,11 @@ public class ReliableSubmissionXpringClientTest {
 
     FakeXpringClient fakeXpringClient;
     ReliableSubmissionXpringClient reliableSubmissionXpringClient;
+    private ScheduledExecutorService scheduledExecutor;
 
     @Before
     public void setUp() throws Exception {
+        this.scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
         this.fakeXpringClient = new FakeXpringClient(
                 DEFAULT_BALANCE_VALUE,
                 DEFAULT_TRANSACTION_STATUS_VALUE,
@@ -146,17 +147,7 @@ public class ReliableSubmissionXpringClientTest {
      *
      * @param work The work to run.
      */
-    private void runAfterOneSecond(AsyncWork work) {
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {
-                    assert(false);
-                }
-                work.run();
-            }
-        }).start();
+    private void runAfterOneSecond(Runnable work) {
+        scheduledExecutor.schedule(work, 1, TimeUnit.SECONDS);
     }
 }

--- a/src/test/java/io/xpring/xrpl/ReliableSubmissionXpringClientTest.java
+++ b/src/test/java/io/xpring/xrpl/ReliableSubmissionXpringClientTest.java
@@ -1,0 +1,162 @@
+package io.xpring.xrpl;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.math.BigInteger;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+interface AsyncWork {
+    void run();
+}
+
+public class ReliableSubmissionXpringClientTest {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private static final String XRPL_ADDRESS = "XVwDxLQ4SN9pEBQagTNHwqpFkPgGppXqrMoTmUcSKdCtcK5";
+    private static final String TRANSACTION_HASH = "DEADBEEF";
+    private static final String WALLET_SEED = "snYP7oArxKepd3GPDcrjMsJYiJeJB";
+    private static final BigInteger SEND_AMOUNT = new BigInteger("20");
+
+    private static final int LAST_LEDGER_SEQUENCE = 100;
+    private static final String TRANSACTION_STATUS_CODE = "tesSuccess";
+
+    private static final BigInteger DEFAULT_BALANCE_VALUE = new BigInteger("10");
+    private static final TransactionStatus DEFAULT_TRANSACTION_STATUS_VALUE = TransactionStatus.SUCCEEDED;
+    private static final String DEFAULT_SEND_VALUE = "DEADBEEF";
+    private static final int DEFAULT_LATEST_LEDGER_VALUE = 10;
+    private static final io.xpring.proto.TransactionStatus DEFAULT_RAW_TRANSACTION_STATUS_VALUE = io.xpring.proto.TransactionStatus.
+            newBuilder().
+            setValidated(true).
+            setTransactionStatusCode(TRANSACTION_STATUS_CODE).
+            setLastLedgerSequence(LAST_LEDGER_SEQUENCE).
+            build();
+
+    FakeXpringClient fakeXpringClient;
+    ReliableSubmissionXpringClient reliableSubmissionXpringClient;
+
+    @Before
+    public void setUp() throws Exception {
+        this.fakeXpringClient = new FakeXpringClient(
+                DEFAULT_BALANCE_VALUE,
+                DEFAULT_TRANSACTION_STATUS_VALUE,
+                DEFAULT_SEND_VALUE,
+                DEFAULT_LATEST_LEDGER_VALUE,
+                DEFAULT_RAW_TRANSACTION_STATUS_VALUE
+        );
+
+        this.reliableSubmissionXpringClient = new ReliableSubmissionXpringClient(fakeXpringClient);
+    }
+
+    @Test
+    public void testGetBalance() throws XpringKitException {
+        // GIVEN a `ReliableSubmissionClient` decorating a FakeXpringClient WHEN a balance is retrieved
+        BigInteger balance = reliableSubmissionXpringClient.getBalance(XRPL_ADDRESS);
+
+
+        // THEN the result is returned unaltered.
+        assertThat(balance).isEqualTo(DEFAULT_BALANCE_VALUE);
+    }
+
+    @Test
+    public void testGetTransactionStatus() throws XpringKitException {
+        // GIVEN a `ReliableSubmissionClient` decorating a FakeXpringClient WHEN a transaction status is retrieved
+        TransactionStatus transactionStatus = reliableSubmissionXpringClient.getTransactionStatus(TRANSACTION_HASH);
+
+        // THEN the result is returned unaltered.
+        assertThat(transactionStatus).isEqualTo(DEFAULT_TRANSACTION_STATUS_VALUE);
+    }
+
+    @Test
+    public void testGetLatestValidatedLedgerSequence() throws XpringKitException {
+        // GIVEN a `ReliableSubmissionClient` decorating a FakeXpringClient WHEN the latest ledger sequence is retrieved
+        int latestSequence = reliableSubmissionXpringClient.getLatestValidatedLedgerSequence();
+
+        // THEN the result is returned unaltered.
+        assertThat(latestSequence).isEqualTo(DEFAULT_LATEST_LEDGER_VALUE);
+    }
+
+    @Test
+    public void testGetRawTransactionStatus() throws XpringKitException {
+        // GIVEN a `ReliableSubmissionClient` decorating a FakeXpringClient WHEN a raw transaction status is retrieved
+        io.xpring.proto.TransactionStatus transactionStatus = reliableSubmissionXpringClient.getRawTransactionStatus(TRANSACTION_HASH);
+
+        // THEN the result is returned unaltered.
+        assertThat(transactionStatus).isEqualTo(DEFAULT_RAW_TRANSACTION_STATUS_VALUE);
+    }
+
+    @Test(timeout=10000)
+    public void testSendWithExpiredLedgerSequenceAndUnvalidatedTransaction() throws XpringKitException {
+        // GIVEN A faked latestLedgerSequence number that will increment past the lastLedgerSequence for a transaction
+        this.fakeXpringClient.rawTransactionStatusValue = io.xpring.proto.TransactionStatus.newBuilder()
+                .setValidated(false)
+                .setLastLedgerSequence(LAST_LEDGER_SEQUENCE)
+                .setTransactionStatusCode(TRANSACTION_STATUS_CODE)
+                .build();
+
+        runAfterOneSecond(() -> {
+            this.fakeXpringClient.latestValidatedLedgerValue = LAST_LEDGER_SEQUENCE + 1;
+        });
+
+        // WHEN a reliable send is submitted THEN the send reaches a consistent state and returns.
+        this.reliableSubmissionXpringClient.send(SEND_AMOUNT, XRPL_ADDRESS, new Wallet(WALLET_SEED));
+    }
+
+    @Test(timeout=10000)
+    public void testSendWithUnxpiredLedgerSequenceAndValidatedTransaction() throws XpringKitException {
+        // GIVEN A transaction that will validate in one second
+        final String transactionStatusCode = "tesSuccess";
+        this.fakeXpringClient.rawTransactionStatusValue = io.xpring.proto.TransactionStatus.newBuilder()
+                .setValidated(false)
+                .setLastLedgerSequence(LAST_LEDGER_SEQUENCE)
+                .setTransactionStatusCode(transactionStatusCode)
+                .build();
+
+        runAfterOneSecond(() -> {
+            this.fakeXpringClient.rawTransactionStatusValue = io.xpring.proto.TransactionStatus.newBuilder()
+                    .setValidated(true)
+                    .setLastLedgerSequence(LAST_LEDGER_SEQUENCE)
+                    .setTransactionStatusCode(TRANSACTION_STATUS_CODE)
+                    .build();
+        });
+
+        // WHEN a reliable send is submitted THEN the send reaches a consistent state and returns.
+        this.reliableSubmissionXpringClient.send(SEND_AMOUNT, XRPL_ADDRESS, new Wallet(WALLET_SEED));
+    }
+
+    @Test
+    public void testSendWithNoLastLedgerSequence() throws XpringKitException {
+        // GIVEN a `ReliableSubmissionXpringClient` decorating a `FakeXpringClient` which will return a transaction that did not have a last ledger sequence attached.
+        this.fakeXpringClient.rawTransactionStatusValue = io.xpring.proto.TransactionStatus.newBuilder()
+                .setValidated(false)
+                .setTransactionStatusCode(TRANSACTION_STATUS_CODE)
+                .build();
+
+        // WHEN a reliable send is submitted THEN an error is thrown.
+        expectedException.expect(Exception.class);
+        this.reliableSubmissionXpringClient.send(SEND_AMOUNT, XRPL_ADDRESS, new Wallet(WALLET_SEED));
+    }
+
+    /**
+     * Run the given work on an separate thread in after one second.
+     *
+     * @param work The work to run.
+     */
+    private void runAfterOneSecond(AsyncWork work) {
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    assert(false);
+                }
+                work.run();
+            }
+        }).start();
+    }
+}


### PR DESCRIPTION
Make calls to submit transactions block until the transaction status can be reliably determined. 

Note that as a product decision, this functionality is non-optional and thread blocking. 

New Classes:
- `ReliableSubmissionXpringClient`: Polls and blocks when submitting a transaction. Conforms to `XpringClientDecorator` and wraps `DefaultXpringClient`. 
- `ReliableSubmissionXpringClientTest`: Unit tests
- `FakeXpringClient`: A fake `XpringClientDecorator` used to unit test `ReliableXpringClient`

Future work may include:
- Making this functionality optional
- Using non-blocking calls
- Returning a transactionStatus along with a transaction hash

This is part of a trio of PRs across Xpring SDK:
- Xpring-JS / Javascript: https://github.com/xpring-eng/Xpring-JS/pull/88
- XpringKit/ Swift: https://github.com/xpring-eng/XpringKit/pull/41