### PR TITLE
Add `test` parameter when Encoding X-Addresses

### DIFF
--- a/src/main/java/io/xpring/xrpl/javascript/JavaScriptUtils.java
+++ b/src/main/java/io/xpring/xrpl/javascript/JavaScriptUtils.java
@@ -50,8 +50,8 @@ public class JavaScriptUtils {
 
         Value encodeXAddressFunction = javaScriptUtils.getMember("encodeXAddress");
         Value result = classicAddress.tag().isPresent() ?
-                encodeXAddressFunction.execute(classicAddress.address(), classicAddress.tag().get()) :
-                encodeXAddressFunction.execute(classicAddress.address());
+                encodeXAddressFunction.execute(classicAddress.address(), classicAddress.tag().get(), classicAddress.isTest()) :
+                encodeXAddressFunction.execute(classicAddress.address(), classicAddress.isTest());
         return result.asString();
     }
 

--- a/src/test/java/io/xpring/xrpl/UtilsTest.java
+++ b/src/test/java/io/xpring/xrpl/UtilsTest.java
@@ -44,8 +44,8 @@ public class UtilsTest {
     }
 
     @Test
-    public void testEncodeXAddressWithAddressAndTag() {
-        // GIVEN a valid classic address and a tag.
+    public void testEncodeMainNetXAddressWithAddressAndTag() {
+        // GIVEN a valid classic address and a tag on MainNet.
         String address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1";
         long tag = 12345;
         ClassicAddress classicAddress = ImmutableClassicAddress.builder().address(address).tag(tag).isTest(false).build();
@@ -55,6 +55,20 @@ public class UtilsTest {
 
         // THEN the result is as expected.
         assertEquals(xAddress, "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT");
+    }
+
+    @Test
+    public void testEncodeTestNetXAddressWithAddressAndTag() {
+        // GIVEN a valid classic address and a tag on TestNet.
+        String address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1";
+        long tag = 12345;
+        ClassicAddress classicAddress = ImmutableClassicAddress.builder().address(address).tag(tag).isTest(true).build();
+
+        // WHEN they are encoded to an X-Address.
+        String xAddress = Utils.encodeXAddress(classicAddress);
+
+        // THEN the result is as expected.
+        assertEquals(xAddress, "TVsBZmcewpEHgajPi1jApLeYnHPJw82v9JNYf7dkGmWphmh");
     }
 
     @Test


### PR DESCRIPTION
X-Addresses support a special format for TestNet. Xpring-Common-JS currently ignores this parameter and defaults everything to mainnet. 

Tested:
- Unit tests

Note that the unit test case is derived from manually checking values on http://xrpaddress.info.

---
Underlying core implementation done in: https://github.com/xpring-eng/xpring-common-js/pull/104