### PR TITLE
Pass through `test` parameter when creating Wallets

### DIFF
--- a/src/main/java/io/xpring/xrpl/Wallet.java
+++ b/src/main/java/io/xpring/xrpl/Wallet.java
@@ -21,7 +21,18 @@ public class Wallet {
      * @throws XpringKitException If the seed is malformed.
      */
     public Wallet(String seed) throws XpringKitException {
-        this.javaScriptWallet = JavaScriptWalletFactory.get().walletFromSeed(seed);
+        this(seed, false);
+    }
+
+    /**
+     * Initialize a new wallet from a seed.
+     *
+     * @param seed A base58check encoded seed for the wallet.
+     * @param isTest Whether the address is for use on a test network.
+     * @throws XpringKitException If the seed is malformed.
+     */
+    public Wallet(String seed, boolean isTest) throws XpringKitException {
+        this.javaScriptWallet = JavaScriptWalletFactory.get().walletFromSeed(seed, isTest);
     }
 
     /**
@@ -32,8 +43,20 @@ public class Wallet {
      * @throws XpringKitException If the mnemonic or derivation path are malformed.
      */
     public Wallet(String mnemonic, String derivationPath) throws XpringKitException {
+        this(mnemonic, derivationPath, false);
+    }
+
+    /**
+     * Create a new HD Wallet.
+     *
+     * @param mnemonic       A space separated mnemonic.
+     * @param derivationPath A derivation. If null, the default derivation path will be used.
+     * @param isTest Whether the address is for use on a test network.
+     * @throws XpringKitException If the mnemonic or derivation path are malformed.
+     */
+    public Wallet(String mnemonic, String derivationPath, boolean isTest) throws XpringKitException {
         this.javaScriptWallet = JavaScriptWalletFactory.get().walletFromMnemonicAndDerivationPath(mnemonic,
-            derivationPath);
+            derivationPath, isTest);
     }
 
     /**
@@ -43,8 +66,19 @@ public class Wallet {
      * @throws XpringKitException If wallet generation fails.
      */
     public static WalletGenerationResult generateRandomWallet() throws XpringKitException {
-        JavaScriptWalletGenerationResult javaScriptWalletGenerationResult = JavaScriptWalletFactory.get()
-            .generateRandomWallet();
+        return generateRandomWallet(false);
+    }
+
+    /**
+     * Generate a random Wallet.
+     *
+     * @param isTest Whether the address is for use on a test network.
+     * @return A {WalletGenerationResult} containing the artifacts of the generation process.
+     * @throws XpringKitException If wallet generation fails.
+     */
+    public static WalletGenerationResult generateRandomWallet(boolean isTest) throws XpringKitException {
+            JavaScriptWalletGenerationResult javaScriptWalletGenerationResult = JavaScriptWalletFactory.get()
+            .generateRandomWallet(isTest);
 
         // TODO(keefertaylor): This should be a direct conversion, rather than recreating a new wallet.
         Wallet newWallet = new Wallet(javaScriptWalletGenerationResult.getMnemonic(),

--- a/src/main/java/io/xpring/xrpl/javascript/JavaScriptWalletFactory.java
+++ b/src/main/java/io/xpring/xrpl/javascript/JavaScriptWalletFactory.java
@@ -44,7 +44,6 @@ public class JavaScriptWalletFactory {
      *
      * @param isTest Whether the address is for use on a test network.
      * @return A {WalletGenerationResult} containing the artifacts of the generation process.
-     * @throws XpringKitException If wallet generation fails.
      */
     public JavaScriptWalletGenerationResult generateRandomWallet(boolean isTest) {
         byte[] randomBytes = randomBytes(16);
@@ -64,7 +63,7 @@ public class JavaScriptWalletFactory {
      * @param seed A base58check encoded seed for the wallet.
      * @param isTest Whether the address is for use on a test network.
      * @throws XpringKitException If the seed is malformed.
-     * @returns A new {@link JavaScriptWallet}.
+     * @return A new {@link JavaScriptWallet}.
      */
     public JavaScriptWallet walletFromSeed(String seed, boolean isTest) throws XpringKitException {
         Value wallet = this.wallet.invokeMember("generateWalletFromSeed", seed, isTest);
@@ -81,7 +80,7 @@ public class JavaScriptWalletFactory {
      * @param derivationPath A derivation. If null, the default derivation path will be used.
      * @param isTest Whether the address is for use on a test network.
      * @throws XpringKitException If the mnemonic or derivation path are malformed.
-     * @returns A new {@link JavaScriptWallet}.
+     * @return A new {@link JavaScriptWallet}.
      */
     public JavaScriptWallet walletFromMnemonicAndDerivationPath(String mnemonic, String derivationPath, boolean isTest) throws XpringKitException {
         try {

--- a/src/test/java/io/xpring/xrpl/WalletTest.java
+++ b/src/test/java/io/xpring/xrpl/WalletTest.java
@@ -11,9 +11,15 @@ public class WalletTest {
     public ExpectedException expectedException = ExpectedException.none();
 
     @Test
-    public void testGenerateWalletFromSeed() throws XpringKitException {
+    public void testGenerateMainNetWalletFromSeed() throws XpringKitException {
         Wallet wallet = new Wallet("snYP7oArxKepd3GPDcrjMsJYiJeJB");
         assertEquals(wallet.getAddress(), "XVnJMYQFqA8EAijpKh5EdjEY5JqyxykMKKSbrUX8uchF6U8");
+    }
+
+    @Test
+    public void testGenerateTestNetWalletFromSeed() throws XpringKitException {
+        Wallet wallet = new Wallet("snYP7oArxKepd3GPDcrjMsJYiJeJB", true);
+        assertEquals(wallet.getAddress(), "T7zFmeZo6uLHP4Vd21TpXjrTBk487ZQPGVQsJ1mKWGCD5rq");
     }
 
     @Test
@@ -38,7 +44,7 @@ public class WalletTest {
     }
 
     @Test
-    public void  testGenerateWalletFromMnemonicNoDerivationPath() throws XpringKitException {
+    public void testGenerateWalletFromMnemonicNoDerivationPath() throws XpringKitException {
         String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
         Wallet wallet = new Wallet(mnemonic, null);
 
@@ -48,7 +54,7 @@ public class WalletTest {
     }
 
     @Test
-    public void  testGenerateWalletFromMnemonicDerivationPath0() throws XpringKitException {
+    public void testGenerateMainNetWalletFromMnemonicDerivationPath0() throws XpringKitException {
         String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
         String derivationPath = "m/44'/144'/0'/0/0";
         Wallet wallet = new Wallet(mnemonic, derivationPath);
@@ -56,6 +62,17 @@ public class WalletTest {
         assertEquals(wallet.getPublicKey(), "031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE");
         assertEquals(wallet.getPrivateKey(), "0090802A50AA84EFB6CDB225F17C27616EA94048C179142FECF03F4712A07EA7A4");
         assertEquals(wallet.getAddress(), "XVMFQQBMhdouRqhPMuawgBMN1AVFTofPAdRsXG5RkPtUPNQ");
+    }
+
+    @Test
+    public void testGenerateTestNetWalletFromMnemonicDerivationPath0() throws XpringKitException {
+        String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        String derivationPath = "m/44'/144'/0'/0/0";
+        Wallet wallet = new Wallet(mnemonic, derivationPath, true);
+
+        assertEquals(wallet.getPublicKey(), "031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE");
+        assertEquals(wallet.getPrivateKey(), "0090802A50AA84EFB6CDB225F17C27616EA94048C179142FECF03F4712A07EA7A4");
+        assertEquals(wallet.getAddress(), "TVHLFWLKvbMv1LFzd6FA2Bf9MPpcy4mRto4VFAAxLuNpvdW");
     }
 
     @Test


### PR DESCRIPTION
X-Addresses support a special format for TestNet. Xpring-Common-JS currently ignores this parameter and defaults everything to MainNet.

Add support for this parameter in all initializers and factory methods of the `Wallet` class. Pass through this parameter to the address derivation code. 

Make the parameter optional and default to MainNet. This is because I think:
- Most folks will just want mainnet addresses by default
- The behavior of existing code won't change, so we can release this as a point fix

Tested:
- Unit tests

Note that the unit test case is derived from manually checking values on http://xrpaddress.info.

----

Note this was originally implemented in: https://github.com/xpring-eng/xpring-common-js/pull/105