### PR TITLE
Generate protocol buffers from rippled

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,7 @@
 [submodule "xpring-common-js"]
 	path = xpring-common-js
 	url = git@github.com:xpring-eng/xpring-common-js.git
+[submodule "rippled"]
+	path = rippled
+	url = http://github.com/cjcobb23/rippled
+	branch = grpcSupport

--- a/pom.xml
+++ b/pom.xml
@@ -294,8 +294,6 @@
                     </pluginArtifact>
                 </configuration>
                 <executions>
-
-
                     <execution>
                         <id>Compile xpring-common-protocol-buffers protocol buffers</id>
                         <configuration>
@@ -321,7 +319,6 @@
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -294,6 +294,8 @@
                     </pluginArtifact>
                 </configuration>
                 <executions>
+
+
                     <execution>
                         <id>Compile xpring-common-protocol-buffers protocol buffers</id>
                         <configuration>
@@ -308,6 +310,7 @@
                     <execution>
                         <id>Compile rippled protocol buffers</id>
                         <configuration>
+                          <clearOutputDirectory>false</clearOutputDirectory>
                           <protoSourceRoot>${project.basedir}/rippled/src/ripple/proto</protoSourceRoot>
                         </configuration>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,6 @@
                 <version>0.6.1</version>
                 <configuration>
                     <protocExecutable>/usr/local/bin/protoc</protocExecutable>
-                    <protoSourceRoot>${project.basedir}/xpring-common-protocol-buffers/proto</protoSourceRoot>
                     <protocArtifact>
                         com.google.protobuf:protoc:3.10.0:exe:${os.detected.classifier}
                     </protocArtifact>
@@ -296,6 +295,21 @@
                 </configuration>
                 <executions>
                     <execution>
+                        <id>Compile xpring-common-protocol-buffers protocol buffers</id>
+                        <configuration>
+                          <protoSourceRoot>${project.basedir}/xpring-common-protocol-buffers/proto</protoSourceRoot>
+                        </configuration>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>compile-custom</goal>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>Compile rippled protocol buffers</id>
+                        <configuration>
+                          <protoSourceRoot>${project.basedir}/rippled/src/ripple/proto</protoSourceRoot>
+                        </configuration>
                         <goals>
                             <goal>compile</goal>
                             <goal>compile-custom</goal>
@@ -304,6 +318,7 @@
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION
Long term, [xpring-common-protocol-buffers](https://github.com/xpring-eng/xpring-common-protocol-buffers) is going to disappear and be replaced with an official and well reviewed implementation by the rippled team. 

The implementation in rippled is being done here: https://github.com/ripple/rippled/pull/3159.

To access the new rippled protocol buffers, a new submodule is added. Note that the submodule is `cjcobb23/rippled` (rather than `ripple/rippled`) since I can't figure out how to get a submodule to track an open PR. I filed an Asana task to track this update here: https://app.asana.com/0/1143722888069470/1155647690941937.

This change segregates the protocol buffers so that we can do the transition in several phases. As of now:
- /generated/*.proto : 'new' protocol buffers from rippled. Unused, as of now.
- /generated/legacy/*.proto : The same protocol buffers from xpring-common-protocol-buffers which we have been using. 

When we have fully migrated the library to rippled's protocol buffers we can simply delete the `legacy` folder to delete the migration. 

Analog to: https://github.com/xpring-eng/Xpring-JS/pull/108