### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "xpring-common-protocol-buffers"]
 	path = xpring-common-protocol-buffers
-	url = git@github.com:xpring-eng/xpring-common-protocol-buffers.git
+	url = https://github.com/xpring-eng/xpring-common-protocol-buffers.git
 [submodule "xpring-common-js"]
 	path = xpring-common-js
-	url = git@github.com:xpring-eng/xpring-common-js.git
+	url = https://github.com/xpring-eng/xpring-common-js.git


### PR DESCRIPTION
## High Level Overview of Change

`git@` format requires SSH keys to be properly set up. HTTPs does not. 

### Context of Change

Users sometimes have trouble cloning submodules, this makes their lives easy. 
### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Before / After
N/A

## Test Plan
CI