### PR TITLE
Abstraction around raw transaction status

### DIFF
--- a/src/main/java/io/xpring/xrpl/RawTransactionStatus.java
+++ b/src/main/java/io/xpring/xrpl/RawTransactionStatus.java
@@ -30,7 +30,7 @@ public class RawTransactionStatus {
      * Retrieve the transaction status code.
      */
     public String getTransactionStatusCode() {
-        return this.getTransactionStatusCode();
+        return this.transactionStatusCode;
     }
 
     /**

--- a/src/main/java/io/xpring/xrpl/RawTransactionStatus.java
+++ b/src/main/java/io/xpring/xrpl/RawTransactionStatus.java
@@ -1,0 +1,42 @@
+package io.xpring.xrpl;
+
+import io.xpring.proto.TransactionStatus;
+
+/** Encapsulates fields of a raw transaction status which is returned by the XRP Ledger. */
+public class RawTransactionStatus {
+    private boolean validated;
+    private String transactionStatusCode;
+    private int lastLedgerSequence;
+
+    /**
+     * Create a new RawTransactionStatus from a {@link TransactionStatus} protocol buffer.
+     *
+     * @param transactionStatus The transaction status to encapsulate.
+     */
+    public RawTransactionStatus(TransactionStatus transactionStatus) {
+        this.validated = transactionStatus.getValidated();
+        this.transactionStatusCode = transactionStatus.getTransactionStatusCode();
+        this.lastLedgerSequence = transactionStatus.getLastLedgerSequence();
+    }
+
+    /**
+     * Retrieve whether or not the transaction has been validated.
+     */
+    public boolean getValidated() {
+        return this.validated;
+    }
+
+    /**
+     * Retrieve the transaction status code.
+     */
+    public String getTransactionStatusCode() {
+        return this.getTransactionStatusCode();
+    }
+
+    /**
+     * Retrieve the last ledger sequence this transaction is valid for.
+     */
+    public int getLastLedgerSequence() {
+        return this.lastLedgerSequence;
+    }
+}

--- a/src/main/java/io/xpring/xrpl/ReliableSubmissionXpringClient.java
+++ b/src/main/java/io/xpring/xrpl/ReliableSubmissionXpringClient.java
@@ -30,7 +30,7 @@ public class ReliableSubmissionXpringClient implements XpringClientDecorator {
             Thread.sleep(ledgerCloseTime);
 
             // Get transaction status.
-            io.xpring.proto.TransactionStatus transactionStatus = this.getRawTransactionStatus(transactionHash);
+            RawTransactionStatus transactionStatus = this.getRawTransactionStatus(transactionHash);
             int lastLedgerSequence = transactionStatus.getLastLedgerSequence();
             if (lastLedgerSequence == 0) {
                 throw new XpringKitException("The transaction did not have a lastLedgerSequence field so transaction status cannot be reliably determined.");
@@ -59,7 +59,7 @@ public class ReliableSubmissionXpringClient implements XpringClientDecorator {
     }
 
     @Override
-    public io.xpring.proto.TransactionStatus getRawTransactionStatus(String transactionHash) {
+    public RawTransactionStatus getRawTransactionStatus(String transactionHash) {
         return this.decoratedClient.getRawTransactionStatus(transactionHash);
     }
 }

--- a/src/main/java/io/xpring/xrpl/XpringClientDecorator.java
+++ b/src/main/java/io/xpring/xrpl/XpringClientDecorator.java
@@ -55,5 +55,5 @@ public interface XpringClientDecorator {
      * @param transactionHash: The hash of the transaction.
      * @return an {@link io.xpring.proto.TransactionStatus} containing the raw transaction status.
      */
-    io.xpring.proto.TransactionStatus getRawTransactionStatus(String transactionHash);
+    RawTransactionStatus getRawTransactionStatus(String transactionHash);
 }

--- a/src/main/java/io/xpring/xrpl/legacy/LegacyDefaultXpringClient.java
+++ b/src/main/java/io/xpring/xrpl/legacy/LegacyDefaultXpringClient.java
@@ -4,12 +4,8 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.xpring.proto.*;
 import io.xpring.proto.XRPLedgerAPIGrpc.XRPLedgerAPIBlockingStub;
-import io.xpring.xrpl.XpringClientDecorator;
-import io.xpring.xrpl.XpringKitException;
-import io.xpring.xrpl.legacy.LegacySigner;
+import io.xpring.xrpl.*;
 import io.xpring.xrpl.TransactionStatus;
-import io.xpring.xrpl.Wallet;
-import io.xpring.xrpl.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,7 +85,7 @@ public class LegacyDefaultXpringClient implements XpringClientDecorator {
      * @return The status of the given transaction.
      */
     public TransactionStatus getTransactionStatus(String transactionHash) {
-        io.xpring.proto.TransactionStatus transactionStatus = getRawTransactionStatus(transactionHash);
+        RawTransactionStatus transactionStatus = getRawTransactionStatus(transactionHash);
 
         // Return PENDING if the transaction is not validated.
         if (!transactionStatus.getValidated()) {
@@ -180,10 +176,11 @@ public class LegacyDefaultXpringClient implements XpringClientDecorator {
      * @param transactionHash: The hash of the transaction.
      * @return an {@link io.xpring.proto.TransactionStatus} containing the raw transaction status.
      */
-    public io.xpring.proto.TransactionStatus getRawTransactionStatus(String transactionHash) {
+    public RawTransactionStatus getRawTransactionStatus(String transactionHash) {
         Objects.requireNonNull(transactionHash);
         GetTransactionStatusRequest transactionStatusRequest = GetTransactionStatusRequest.newBuilder().setTransactionHash(transactionHash).build();
 
-        return stub.getTransactionStatus(transactionStatusRequest);
+        io.xpring.proto.TransactionStatus transactionStatus = stub.getTransactionStatus(transactionStatusRequest);
+        return new RawTransactionStatus(transactionStatus);
     }
 }

--- a/src/main/java/io/xpring/xrpl/legacy/LegacyDefaultXpringClient.java
+++ b/src/main/java/io/xpring/xrpl/legacy/LegacyDefaultXpringClient.java
@@ -4,8 +4,12 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.xpring.proto.*;
 import io.xpring.proto.XRPLedgerAPIGrpc.XRPLedgerAPIBlockingStub;
-import io.xpring.xrpl.*;
+import io.xpring.xrpl.RawTransactionStatus;
 import io.xpring.xrpl.TransactionStatus;
+import io.xpring.xrpl.Utils;
+import io.xpring.xrpl.Wallet;
+import io.xpring.xrpl.XpringClientDecorator;
+import io.xpring.xrpl.XpringKitException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/test/java/io/xpring/xrpl/FakeXpringClient.java
+++ b/src/test/java/io/xpring/xrpl/FakeXpringClient.java
@@ -14,14 +14,14 @@ public class FakeXpringClient implements  XpringClientDecorator {
     public TransactionStatus transactionStatusValue;
     public String sendValue;
     public int latestValidatedLedgerValue;
-    public io.xpring.proto.TransactionStatus rawTransactionStatusValue;
+    public RawTransactionStatus rawTransactionStatusValue;
 
     public FakeXpringClient(
             BigInteger getBalanceValue,
             TransactionStatus transactionStatusValue,
             String sendValue,
             int latestValidatedLedgerValue,
-            io.xpring.proto.TransactionStatus rawTransactionStatusValue
+            RawTransactionStatus rawTransactionStatusValue
     ) {
         this.getBalanceValue = getBalanceValue;
         this.transactionStatusValue = transactionStatusValue;
@@ -51,7 +51,7 @@ public class FakeXpringClient implements  XpringClientDecorator {
     }
 
     @Override
-    public io.xpring.proto.TransactionStatus getRawTransactionStatus(String transactionHash) {
+    public RawTransactionStatus getRawTransactionStatus(String transactionHash) {
         return this.rawTransactionStatusValue;
     }
 }

--- a/src/test/java/io/xpring/xrpl/ReliableSubmissionXpringClientTest.java
+++ b/src/test/java/io/xpring/xrpl/ReliableSubmissionXpringClientTest.java
@@ -28,12 +28,14 @@ public class ReliableSubmissionXpringClientTest {
     private static final TransactionStatus DEFAULT_TRANSACTION_STATUS_VALUE = TransactionStatus.SUCCEEDED;
     private static final String DEFAULT_SEND_VALUE = "DEADBEEF";
     private static final int DEFAULT_LATEST_LEDGER_VALUE = 10;
-    private static final io.xpring.proto.TransactionStatus DEFAULT_RAW_TRANSACTION_STATUS_VALUE = io.xpring.proto.TransactionStatus.
-            newBuilder().
-            setValidated(true).
-            setTransactionStatusCode(TRANSACTION_STATUS_CODE).
-            setLastLedgerSequence(LAST_LEDGER_SEQUENCE).
-            build();
+    private static final RawTransactionStatus DEFAULT_RAW_TRANSACTION_STATUS_VALUE =new RawTransactionStatus(
+            io.xpring.proto.TransactionStatus.
+                    newBuilder().
+                    setValidated(true).
+                    setTransactionStatusCode(TRANSACTION_STATUS_CODE).
+                    setLastLedgerSequence(LAST_LEDGER_SEQUENCE).
+                    build()
+    );
 
     FakeXpringClient fakeXpringClient;
     ReliableSubmissionXpringClient reliableSubmissionXpringClient;
@@ -84,7 +86,7 @@ public class ReliableSubmissionXpringClientTest {
     @Test
     public void testGetRawTransactionStatus() throws XpringKitException {
         // GIVEN a `ReliableSubmissionClient` decorating a FakeXpringClient WHEN a raw transaction status is retrieved
-        io.xpring.proto.TransactionStatus transactionStatus = reliableSubmissionXpringClient.getRawTransactionStatus(TRANSACTION_HASH);
+        RawTransactionStatus transactionStatus = reliableSubmissionXpringClient.getRawTransactionStatus(TRANSACTION_HASH);
 
         // THEN the result is returned unaltered.
         assertThat(transactionStatus).isEqualTo(DEFAULT_RAW_TRANSACTION_STATUS_VALUE);
@@ -93,11 +95,13 @@ public class ReliableSubmissionXpringClientTest {
     @Test(timeout=10000)
     public void testSendWithExpiredLedgerSequenceAndUnvalidatedTransaction() throws XpringKitException {
         // GIVEN A faked latestLedgerSequence number that will increment past the lastLedgerSequence for a transaction
-        this.fakeXpringClient.rawTransactionStatusValue = io.xpring.proto.TransactionStatus.newBuilder()
-                .setValidated(false)
-                .setLastLedgerSequence(LAST_LEDGER_SEQUENCE)
-                .setTransactionStatusCode(TRANSACTION_STATUS_CODE)
-                .build();
+        this.fakeXpringClient.rawTransactionStatusValue = new RawTransactionStatus(
+                io.xpring.proto.TransactionStatus.newBuilder()
+                    .setValidated(false)
+                    .setLastLedgerSequence(LAST_LEDGER_SEQUENCE)
+                    .setTransactionStatusCode(TRANSACTION_STATUS_CODE)
+                    .build()
+        );
 
         runAfterOneSecond(() -> {
             this.fakeXpringClient.latestValidatedLedgerValue = LAST_LEDGER_SEQUENCE + 1;
@@ -111,18 +115,22 @@ public class ReliableSubmissionXpringClientTest {
     public void testSendWithUnxpiredLedgerSequenceAndValidatedTransaction() throws XpringKitException {
         // GIVEN A transaction that will validate in one second
         final String transactionStatusCode = "tesSuccess";
-        this.fakeXpringClient.rawTransactionStatusValue = io.xpring.proto.TransactionStatus.newBuilder()
-                .setValidated(false)
+        this.fakeXpringClient.rawTransactionStatusValue = new RawTransactionStatus(
+                io.xpring.proto.TransactionStatus.newBuilder()
+                        .setValidated(false)
                 .setLastLedgerSequence(LAST_LEDGER_SEQUENCE)
                 .setTransactionStatusCode(transactionStatusCode)
-                .build();
+                .build()
+        );
 
         runAfterOneSecond(() -> {
-            this.fakeXpringClient.rawTransactionStatusValue = io.xpring.proto.TransactionStatus.newBuilder()
-                    .setValidated(true)
-                    .setLastLedgerSequence(LAST_LEDGER_SEQUENCE)
-                    .setTransactionStatusCode(TRANSACTION_STATUS_CODE)
-                    .build();
+            this.fakeXpringClient.rawTransactionStatusValue = new RawTransactionStatus(
+                    io.xpring.proto.TransactionStatus.newBuilder()
+                        .setValidated(true)
+                        .setLastLedgerSequence(LAST_LEDGER_SEQUENCE)
+                        .setTransactionStatusCode(TRANSACTION_STATUS_CODE)
+                        .build()
+            );
         });
 
         // WHEN a reliable send is submitted THEN the send reaches a consistent state and returns.
@@ -132,10 +140,12 @@ public class ReliableSubmissionXpringClientTest {
     @Test
     public void testSendWithNoLastLedgerSequence() throws XpringKitException {
         // GIVEN a `ReliableSubmissionXpringClient` decorating a `FakeXpringClient` which will return a transaction that did not have a last ledger sequence attached.
-        this.fakeXpringClient.rawTransactionStatusValue = io.xpring.proto.TransactionStatus.newBuilder()
-                .setValidated(false)
-                .setTransactionStatusCode(TRANSACTION_STATUS_CODE)
-                .build();
+        this.fakeXpringClient.rawTransactionStatusValue = new RawTransactionStatus(
+                io.xpring.proto.TransactionStatus.newBuilder()
+                    .setValidated(false)
+                    .setTransactionStatusCode(TRANSACTION_STATUS_CODE)
+                    .build()
+        );
 
         // WHEN a reliable send is submitted THEN an error is thrown.
         expectedException.expect(Exception.class);

--- a/src/test/java/io/xpring/xrpl/ReliableSubmissionXpringClientTest.java
+++ b/src/test/java/io/xpring/xrpl/ReliableSubmissionXpringClientTest.java
@@ -28,7 +28,7 @@ public class ReliableSubmissionXpringClientTest {
     private static final TransactionStatus DEFAULT_TRANSACTION_STATUS_VALUE = TransactionStatus.SUCCEEDED;
     private static final String DEFAULT_SEND_VALUE = "DEADBEEF";
     private static final int DEFAULT_LATEST_LEDGER_VALUE = 10;
-    private static final RawTransactionStatus DEFAULT_RAW_TRANSACTION_STATUS_VALUE =new RawTransactionStatus(
+    private static final RawTransactionStatus DEFAULT_RAW_TRANSACTION_STATUS_VALUE = new RawTransactionStatus(
             io.xpring.proto.TransactionStatus.
                     newBuilder().
                     setValidated(true).


### PR DESCRIPTION
`XpringClientDecorator` will share a definition across the legacy protocol buffers (from `xpring-common-protocol-buffers`) and the rippled protocol buffers. 

This PR creates an abstraction that wraps the return type from this method in an interface. This will allow us to create a bridge layer between the old and new protocol buffers during the migration.

Analog in:
JS: https://github.com/xpring-eng/Xpring-JS/pull/115
Swift: https://github.com/xpring-eng/XpringKit/pull/88

# Background

rippled is going to implement protocol buffer support natively, which is going to use a set of well reviewed protocol buffers. The implementation in rippled is being done here: https://github.com/ripple/rippled/pull/3159.

In order to do the upgrade in place, we will swap out the base decorator with two implementations: 
- `LegacyDefaultXpringClient`: Uses the old protocol buffers
- `DefaultXpringClient`: Uses the new protocol buffers

Once we have a working implementation, the constructor on `XpringClient` will be changed to take a new boolean parameter, `useLegacy`, which will control with base implementation is used. 

# Status

- [x] [Generate new versions of the protocol buffers](https://github.com/xpring-eng/xpring4j/pull/69)
- [x] [Migrate existing code to a `legacy` subdirectory and namespace](https://github.com/xpring-eng/xpring4j/pull/67)
- [ ] Create code that works with the new protocol buffers from the rippled team
   - [x] [Create a new `DefaultXpringClient` with tests](https://github.com/xpring-eng/xpring4j/pull/76)
   - [ ] Read only calls for new `DefaultXpringClient` (WIP in this PR)
   - [ ] Write calls fro `DeafultXpringClient`
- [ ] Add a boolean parameter to switch between implementations