### PR TITLE
[RFC] Add test for Transaction Status with Non Payment Transaction

### DIFF
--- a/src/main/java/io/xpring/xrpl/RawTransactionStatus.java
+++ b/src/main/java/io/xpring/xrpl/RawTransactionStatus.java
@@ -1,6 +1,7 @@
 package io.xpring.xrpl;
 
 import io.xpring.proto.TransactionStatus;
+import rpc.v1.TransactionOuterClass.Transaction;
 import rpc.v1.Tx.GetTxResponse;
 
 /** Encapsulates fields of a raw transaction status which is returned by the XRP Ledger. */
@@ -8,6 +9,7 @@ public class RawTransactionStatus {
     private boolean validated;
     private String transactionStatusCode;
     private int lastLedgerSequence;
+    private boolean isPaymentTransaction;
 
     /**
      * Create a new RawTransactionStatus from a {@link TransactionStatus} protocol buffer.
@@ -18,6 +20,10 @@ public class RawTransactionStatus {
         this.validated = transactionStatus.getValidated();
         this.transactionStatusCode = transactionStatus.getTransactionStatusCode();
         this.lastLedgerSequence = transactionStatus.getLastLedgerSequence();
+
+        // Assume all old protocol buffers are payment transactions since we don't have this data in our limited API.
+        // TODO(keefertaylor): Plumb this data through.
+        this.isPaymentTransaction = true;
     }
 
     /**
@@ -28,7 +34,11 @@ public class RawTransactionStatus {
     public RawTransactionStatus(GetTxResponse getTxResponse) {
         this.validated = getTxResponse.getValidated();
         this.transactionStatusCode = getTxResponse.getMeta().getTransactionResult().getResult();
-        this.lastLedgerSequence = getTxResponse.getTransaction().getLastLedgerSequence();
+
+        Transaction transaction = getTxResponse.getTransaction();
+
+        this.lastLedgerSequence = transaction.getLastLedgerSequence();
+        this.isPaymentTransaction = transaction.hasPayment();
     }
 
     /**


### PR DESCRIPTION
## High Level Overview of Change

We should test the case where a non-payment transaction's status is queried. This is somewhat complicated to do because we don't have the information we need in the old set of protocol buffers.

Here's a draft of what this would look like. 

### Context of Change

Follow on to #78.

### Type of Change

- [x] New Test Case

## Before / After

New test
## Test Plan

N/A
