### PR TITLE
Add tests for multiple failure codes

### DIFF
--- a/src/test/java/io/xpring/xrpl/DefaultXpringClientTest.java
+++ b/src/test/java/io/xpring/xrpl/DefaultXpringClientTest.java
@@ -155,7 +155,9 @@ public class DefaultXpringClientTest {
             // GIVEN a XpringClient which will return an unvalidated transaction with a failed code.
             DefaultXpringClient client = getClient(
                     GRPCResult.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
-                    GRPCResult.ok(makeTransactionStatus(false, transactionFailureCode))
+                    GRPCResult.ok(makeTransactionStatus(false, transactionFailureCode)),
+                    GRPCResult.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
+                    GRPCResult.ok(makeSubmitTransactionResponse(TRANSACTION_HASH))
             );
 
             // WHEN the transaction status is retrieved.

--- a/src/test/java/io/xpring/xrpl/DefaultXpringClientTest.java
+++ b/src/test/java/io/xpring/xrpl/DefaultXpringClientTest.java
@@ -85,7 +85,13 @@ public class DefaultXpringClientTest {
     private static final String TRANSACTION_BLOB = "DEADBEEF";
     private static final String GENERIC_ERROR = "Mocked network error";
     private static final String TRANSACTION_STATUS_SUCCESS = "tesSUCCESS";
-    private static final String TRANSACTION_STATUS_FAILURE = "tecFAILURE";
+    private static final String [] TRANSACTION_FAILURE_STATUS_CODES = {
+            "tefFAILURE",
+            "tecCLAIM",
+            "telBAD_PUBLIC_KEY",
+            "temBAD_FEE",
+            "terRETRY"
+    };
     private static final String TRANSACTION_HASH = "DEADBEEF";
 
     /** The seed for a wallet with funds on the XRP Ledger test net. */
@@ -133,17 +139,20 @@ public class DefaultXpringClientTest {
 
     @Test
     public void transactionStatusWithUnvalidatedTransactionAndFailureCode() throws IOException, XpringKitException {
-        // GIVEN a XpringClient which will return an unvalidated transaction with a failed code.
-        DefaultXpringClient client = getClient(
-                GRPCResult.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
-                GRPCResult.ok(makeTransactionStatus(false, TRANSACTION_STATUS_FAILURE))
-        );
+        // Iterate over different types of transaction status codes which represent failures.
+        for (String transactionFailureCode : TRANSACTION_FAILURE_STATUS_CODES) {
+            // GIVEN a XpringClient which will return an unvalidated transaction with a failed code.
+            DefaultXpringClient client = getClient(
+                    GRPCResult.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
+                    GRPCResult.ok(makeTransactionStatus(false, transactionFailureCode))
+            );
 
-        // WHEN the transaction status is retrieved.
-        io.xpring.xrpl.TransactionStatus transactionStatus = client.getTransactionStatus(TRANSACTION_HASH);
+            // WHEN the transaction status is retrieved.
+            io.xpring.xrpl.TransactionStatus transactionStatus = client.getTransactionStatus(TRANSACTION_HASH);
 
-        // THEN the status is PENDING.
-        assertThat(transactionStatus).isEqualTo(io.xpring.xrpl.TransactionStatus.PENDING);
+            // THEN the status is PENDING.
+            assertThat(transactionStatus).isEqualTo(io.xpring.xrpl.TransactionStatus.PENDING);
+        }
     }
 
     @Test
@@ -163,17 +172,20 @@ public class DefaultXpringClientTest {
 
     @Test
     public void transactionStatusWithValidatedTransactionAndFailureCode() throws IOException, XpringKitException {
-        // GIVEN a XpringClient which will return an validated transaction with a failed code.
-        DefaultXpringClient client = getClient(
-                GRPCResult.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
-                GRPCResult.ok(makeTransactionStatus(true, TRANSACTION_STATUS_FAILURE))
-        );
+        // Iterate over different types of transaction status codes which represent failures.
+        for (String transactionFailureCode : TRANSACTION_FAILURE_STATUS_CODES) {
+            // GIVEN a XpringClient which will return an validated transaction with a failed code.
+            DefaultXpringClient client = getClient(
+                    GRPCResult.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
+                    GRPCResult.ok(makeTransactionStatus(true, transactionFailureCode))
+            );
 
-        // WHEN the transaction status is retrieved.
-        io.xpring.xrpl.TransactionStatus transactionStatus = client.getTransactionStatus(TRANSACTION_HASH);
+            // WHEN the transaction status is retrieved.
+            io.xpring.xrpl.TransactionStatus transactionStatus = client.getTransactionStatus(TRANSACTION_HASH);
 
-        // THEN the status is FAILED.
-        assertThat(transactionStatus).isEqualTo(io.xpring.xrpl.TransactionStatus.FAILED);
+            // THEN the status is FAILED.
+            assertThat(transactionStatus).isEqualTo(io.xpring.xrpl.TransactionStatus.FAILED);
+        }
     }
 
     @Test

--- a/src/test/java/io/xpring/xrpl/DefaultXpringClientTest.java
+++ b/src/test/java/io/xpring/xrpl/DefaultXpringClientTest.java
@@ -192,7 +192,9 @@ public class DefaultXpringClientTest {
             // GIVEN a XpringClient which will return an validated transaction with a failed code.
             DefaultXpringClient client = getClient(
                     GRPCResult.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
-                    GRPCResult.ok(makeTransactionStatus(true, transactionFailureCode))
+                    GRPCResult.ok(makeTransactionStatus(true, transactionFailureCode)),
+                    GRPCResult.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
+                    GRPCResult.ok(makeSubmitTransactionResponse(TRANSACTION_HASH))
             );
 
             // WHEN the transaction status is retrieved.

--- a/src/test/java/io/xpring/xrpl/legacy/LegacyDefaultXpringClientTest.java
+++ b/src/test/java/io/xpring/xrpl/legacy/LegacyDefaultXpringClientTest.java
@@ -76,8 +76,14 @@ public class LegacyDefaultXpringClientTest {
     private static final String TRANSACTION_BLOB = "DEADBEEF";
     private static final String GENERIC_ERROR = "Mocked network error";
     private static final String TRANSACTION_STATUS_SUCCESS = "tesSUCCESS";
-    private static final String TRANSACTION_STATUS_FAILURE = "tecFAILURE";
     private static final String TRANSACTION_HASH = "DEADBEEF";
+    private static final String [] TRANSACTION_FAILURE_STATUS_CODES = {
+            "tefFAILURE",
+            "tecCLAIM",
+            "telBAD_PUBLIC_KEY",
+            "temBAD_FEE",
+            "terRETRY"
+    };
 
     /** The seed for a wallet with funds on the XRP Ledger test net. */
     private static final String WALLET_SEED = "snYP7oArxKepd3GPDcrjMsJYiJeJB";
@@ -225,21 +231,24 @@ public class LegacyDefaultXpringClientTest {
 
     @Test
     public void transactionStatusWithUnvalidatedTransactionAndFailureCode() throws IOException {
-        // GIVEN a XpringClient which will return an invalidated transaction with a failed code.
-        io.xpring.proto.TransactionStatus transactionStatusResponse = io.xpring.proto.TransactionStatus.newBuilder().setValidated(false).setTransactionStatusCode(TRANSACTION_STATUS_FAILURE).build();
-        LegacyDefaultXpringClient client = getClient(
-                GRPCResult.ok(makeAccountInfo(DROPS_OF_XRP_IN_ACCOUNT)),
-                GRPCResult.ok(makeFee(DROPS_OF_XRP_FOR_FEE)),
-                GRPCResult.ok(makeSubmitSignedTransactionResponse(TRANSACTION_BLOB)),
-                GRPCResult.ok(makeLedgerSequence()),
-                GRPCResult.ok(transactionStatusResponse)
-        );
+        // Iterate over different types of transaction status codes which represent failures.
+        for (String transactionFailureCode : TRANSACTION_FAILURE_STATUS_CODES) {
+            // GIVEN a XpringClient which will return an invalidated transaction with a failed code.
+            io.xpring.proto.TransactionStatus transactionStatusResponse = io.xpring.proto.TransactionStatus.newBuilder().setValidated(false).setTransactionStatusCode(transactionFailureCode).build();
+            LegacyDefaultXpringClient client = getClient(
+                    GRPCResult.ok(makeAccountInfo(DROPS_OF_XRP_IN_ACCOUNT)),
+                    GRPCResult.ok(makeFee(DROPS_OF_XRP_FOR_FEE)),
+                    GRPCResult.ok(makeSubmitSignedTransactionResponse(TRANSACTION_BLOB)),
+                    GRPCResult.ok(makeLedgerSequence()),
+                    GRPCResult.ok(transactionStatusResponse)
+            );
 
-        // WHEN the transaction status is retrieved.
-        io.xpring.xrpl.TransactionStatus transactionStatus = client.getTransactionStatus(TRANSACTION_HASH);
+            // WHEN the transaction status is retrieved.
+            io.xpring.xrpl.TransactionStatus transactionStatus = client.getTransactionStatus(TRANSACTION_HASH);
 
-        // THEN the status is PENDING.
-        assertThat(transactionStatus).isEqualTo(io.xpring.xrpl.TransactionStatus.PENDING);
+            // THEN the status is PENDING.
+            assertThat(transactionStatus).isEqualTo(io.xpring.xrpl.TransactionStatus.PENDING);
+        }
     }
 
     @Test
@@ -263,21 +272,24 @@ public class LegacyDefaultXpringClientTest {
 
     @Test
     public void transactionStatusWithValidatedTransactionAndFailureCode() throws IOException {
-        // GIVEN a XpringClient which will return an validated transaction with a failed code.
-        io.xpring.proto.TransactionStatus transactionStatusResponse = io.xpring.proto.TransactionStatus.newBuilder().setValidated(true).setTransactionStatusCode(TRANSACTION_STATUS_FAILURE).build();
-        LegacyDefaultXpringClient client = getClient(
-                GRPCResult.ok(makeAccountInfo(DROPS_OF_XRP_IN_ACCOUNT)),
-                GRPCResult.ok(makeFee(DROPS_OF_XRP_FOR_FEE)),
-                GRPCResult.ok(makeSubmitSignedTransactionResponse(TRANSACTION_BLOB)),
-                GRPCResult.ok(makeLedgerSequence()),
-                GRPCResult.ok(transactionStatusResponse)
-        );
+        // Iterate over different types of transaction status codes which represent failures.
+        for (String transactionFailureCode : TRANSACTION_FAILURE_STATUS_CODES) {
+            // GIVEN a XpringClient which will return an validated transaction with a failed code.
+            io.xpring.proto.TransactionStatus transactionStatusResponse = io.xpring.proto.TransactionStatus.newBuilder().setValidated(true).setTransactionStatusCode(transactionFailureCode).build();
+            LegacyDefaultXpringClient client = getClient(
+                    GRPCResult.ok(makeAccountInfo(DROPS_OF_XRP_IN_ACCOUNT)),
+                    GRPCResult.ok(makeFee(DROPS_OF_XRP_FOR_FEE)),
+                    GRPCResult.ok(makeSubmitSignedTransactionResponse(TRANSACTION_BLOB)),
+                    GRPCResult.ok(makeLedgerSequence()),
+                    GRPCResult.ok(transactionStatusResponse)
+            );
 
-        // WHEN the transaction status is retrieved.
-        io.xpring.xrpl.TransactionStatus transactionStatus = client.getTransactionStatus(TRANSACTION_HASH);
+            // WHEN the transaction status is retrieved.
+            io.xpring.xrpl.TransactionStatus transactionStatus = client.getTransactionStatus(TRANSACTION_HASH);
 
-        // THEN the status is FAILED.
-        assertThat(transactionStatus).isEqualTo(io.xpring.xrpl.TransactionStatus.FAILED);
+            // THEN the status is FAILED.
+            assertThat(transactionStatus).isEqualTo(io.xpring.xrpl.TransactionStatus.FAILED);
+        }
     }
 
     @Test


### PR DESCRIPTION
## High Level Overview of Change

@stephengu asked for multiple test cases on failure codes in XpringKit. This PR propagates the same logic here. 

### Context of Change

The rippled server returns [many codes](https://xrpl.org/transaction-results.html) which mean 'failure'. These are all prefixed in different ways. This PR tests all failure prefixes. 

This change was asked for in: https://github.com/xpring-eng/XpringKit/pull/94#pullrequestreview-351145809

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)

## Before / After

No change

## Test Plan

N/A
