### PR TITLE
Refactors GRPCResult to take actual Throwable upon construction

### DIFF
--- a/src/test/java/io/xpring/xrpl/DefaultXpringClientTest.java
+++ b/src/test/java/io/xpring/xrpl/DefaultXpringClientTest.java
@@ -369,7 +369,7 @@ public class DefaultXpringClientTest {
                     @Override
                     public void getAccountInfo(AccountInfo.GetAccountInfoRequest request, StreamObserver<GetAccountInfoResponse> responseObserver) {
                         if (getAccountInfoResult.isError()) {
-                            responseObserver.onError(new Throwable(getAccountInfoResult.getError()));
+                            responseObserver.onError(getAccountInfoResult.getError());
                         } else {
                             responseObserver.onNext(getAccountInfoResult.getValue());
                             responseObserver.onCompleted();
@@ -379,7 +379,7 @@ public class DefaultXpringClientTest {
                     @Override
                     public void getTx(Tx.GetTxRequest request, StreamObserver<Tx.GetTxResponse> responseObserver) {
                         if (getTxResponseResult.isError()) {
-                            responseObserver.onError(new Throwable(getTxResponseResult.getError()));
+                            responseObserver.onError(getTxResponseResult.getError());
                         } else {
                             responseObserver.onNext(getTxResponseResult.getValue());
                             responseObserver.onCompleted();
@@ -390,7 +390,7 @@ public class DefaultXpringClientTest {
                     public void getFee(GetFeeRequest request,
                                        StreamObserver<GetFeeResponse> responseObserver) {
                         if (getFeeResult.isError()) {
-                            responseObserver.onError(new Throwable(getFeeResult.getError()));
+                            responseObserver.onError(getFeeResult.getError());
                         } else {
                             responseObserver.onNext(getFeeResult.getValue());
                             responseObserver.onCompleted();
@@ -401,7 +401,7 @@ public class DefaultXpringClientTest {
                     public void submitTransaction(SubmitTransactionRequest request,
                                                   StreamObserver<SubmitTransactionResponse> responseObserver) {
                         if (submitTransactionResult.isError()) {
-                            responseObserver.onError(new Throwable(submitTransactionResult.getError()));
+                            responseObserver.onError(submitTransactionResult.getError());
                         } else {
                             responseObserver.onNext(submitTransactionResult.getValue());
                             responseObserver.onCompleted();

--- a/src/test/java/io/xpring/xrpl/DefaultXpringClientTest.java
+++ b/src/test/java/io/xpring/xrpl/DefaultXpringClientTest.java
@@ -85,7 +85,7 @@ public class DefaultXpringClientTest {
     /** Mocked values in responses from the gRPC server. */
     private static final long DROPS_OF_XRP_IN_ACCOUNT = 10;
     private static final String TRANSACTION_BLOB = "DEADBEEF";
-    private static final String GENERIC_ERROR = "Mocked network error";
+    private static final Throwable GENERIC_ERROR = new Throwable("Mocked network error");
     private static final String TRANSACTION_STATUS_SUCCESS = "tesSUCCESS";
     private static final String [] TRANSACTION_FAILURE_STATUS_CODES = {
             "tefFAILURE",

--- a/src/test/java/io/xpring/xrpl/DefaultXpringClientTest.java
+++ b/src/test/java/io/xpring/xrpl/DefaultXpringClientTest.java
@@ -38,9 +38,9 @@ import java.util.Optional;
  */
 class GRPCResult<T> {
     private Optional<T> value;
-    private Optional<String> error;
+    private Optional<Throwable> error;
 
-    private GRPCResult(T value, String error) {
+    private GRPCResult(T value, Throwable error) {
         this.value = Optional.ofNullable(value);
         this.error = Optional.ofNullable(error);
     }
@@ -49,7 +49,7 @@ class GRPCResult<T> {
         return new GRPCResult<>(value, null);
     }
 
-    public static <U> GRPCResult<U> error(String error) {
+    public static <U> GRPCResult<U> error(Throwable error) {
         return new GRPCResult<>(null, error);
     }
 
@@ -61,7 +61,7 @@ class GRPCResult<T> {
         return value.get();
     }
 
-    public String getError() {
+    public Throwable getError() {
         return error.get();
     }
 }

--- a/src/test/java/io/xpring/xrpl/legacy/LegacyDefaultXpringClientTest.java
+++ b/src/test/java/io/xpring/xrpl/legacy/LegacyDefaultXpringClientTest.java
@@ -26,9 +26,9 @@ import java.util.Optional;
  */
 class GRPCResult<T> {
     private Optional<T> value;
-    private Optional<String> error;
+    private Optional<Throwable> error;
 
-    private GRPCResult(T value, String error) {
+    private GRPCResult(T value, Throwable error) {
         this.value = Optional.ofNullable(value);
         this.error = Optional.ofNullable(error);
     }
@@ -37,7 +37,7 @@ class GRPCResult<T> {
         return new GRPCResult<>(value, null);
     }
 
-    public static <U> GRPCResult<U> error(String error) {
+    public static <U> GRPCResult<U> error(Throwable error) {
         return new GRPCResult<>(null, error);
     }
 
@@ -49,7 +49,7 @@ class GRPCResult<T> {
         return value.get();
     }
 
-    public String getError() {
+    public Throwable getError() {
         return error.get();
     }
 }
@@ -74,7 +74,7 @@ public class LegacyDefaultXpringClientTest {
     private static final String DROPS_OF_XRP_IN_ACCOUNT = "10";
     private static final String DROPS_OF_XRP_FOR_FEE = "20";
     private static final String TRANSACTION_BLOB = "DEADBEEF";
-    private static final String GENERIC_ERROR = "Mocked network error";
+    private static final Throwable GENERIC_ERROR = new Throwable("Mocked network error");
     private static final String TRANSACTION_STATUS_SUCCESS = "tesSUCCESS";
     private static final String TRANSACTION_HASH = "DEADBEEF";
     private static final String [] TRANSACTION_FAILURE_STATUS_CODES = {
@@ -328,6 +328,7 @@ public class LegacyDefaultXpringClientTest {
         client.getTransactionStatus(TRANSACTION_HASH);
     }
 
+
     /**
      * Convenience method to get a XpringClient which has successful network calls.
      */
@@ -373,7 +374,7 @@ public class LegacyDefaultXpringClientTest {
                     public void getAccountInfo(io.xpring.proto.GetAccountInfoRequest request,
                                                io.grpc.stub.StreamObserver<io.xpring.proto.AccountInfo> responseObserver) {
                         if (accountInfoResult.isError()) {
-                            responseObserver.onError(new Throwable(accountInfoResult.getError()));
+                            responseObserver.onError(accountInfoResult.getError());
                         } else {
                             responseObserver.onNext(accountInfoResult.getValue());
                             responseObserver.onCompleted();
@@ -384,7 +385,7 @@ public class LegacyDefaultXpringClientTest {
                     public void getFee(io.xpring.proto.GetFeeRequest request,
                                        io.grpc.stub.StreamObserver<io.xpring.proto.Fee> responseObserver) {
                         if (feeResult.isError()) {
-                            responseObserver.onError(new Throwable(feeResult.getError()));
+                            responseObserver.onError(feeResult.getError());
                         } else {
                             responseObserver.onNext(feeResult.getValue());
                             responseObserver.onCompleted();
@@ -395,7 +396,7 @@ public class LegacyDefaultXpringClientTest {
                     public void submitSignedTransaction(io.xpring.proto.SubmitSignedTransactionRequest request,
                                                         io.grpc.stub.StreamObserver<io.xpring.proto.SubmitSignedTransactionResponse> responseObserver) {
                         if (submitResult.isError()) {
-                            responseObserver.onError(new Throwable(submitResult.getError()));
+                            responseObserver.onError(submitResult.getError());
                         } else {
                             responseObserver.onNext(submitResult.getValue());
                             responseObserver.onCompleted();
@@ -406,7 +407,7 @@ public class LegacyDefaultXpringClientTest {
                     public void getLatestValidatedLedgerSequence(io.xpring.proto.GetLatestValidatedLedgerSequenceRequest request,
                                                                  io.grpc.stub.StreamObserver<io.xpring.proto.LedgerSequence> responseObserver) {
                         if (latestValidatedLedgerSequenceResult.isError()) {
-                            responseObserver.onError(new Throwable(latestValidatedLedgerSequenceResult.getError()));
+                            responseObserver.onError(latestValidatedLedgerSequenceResult.getError());
                         } else {
                             responseObserver.onNext(latestValidatedLedgerSequenceResult.getValue());
                             responseObserver.onCompleted();
@@ -417,7 +418,7 @@ public class LegacyDefaultXpringClientTest {
                     public void getTransactionStatus(io.xpring.proto.GetTransactionStatusRequest request,
                                                      io.grpc.stub.StreamObserver<io.xpring.proto.TransactionStatus> responseObserver) {
                         if (transactionStatusResult.isError()) {
-                            responseObserver.onError(new Throwable(transactionStatusResult.getError()));
+                            responseObserver.onError(transactionStatusResult.getError());
                         } else {
                             responseObserver.onNext(transactionStatusResult.getValue());
                             responseObserver.onCompleted();


### PR DESCRIPTION
## High Level Overview of Change
The class GRPCResult is used to mock network responses for Xpring client unit tests.  This PR refactors GRPCResult to take an actual instance of a Throwable object upon construction, instead of a message string that is later wrapped in a Throwable.
<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
A new XpringClient method accountExists contains logic that depends on specific Error responses that may be returned from a gRPC call.  The unit test infrastructure needed to be updated to allow for mocking these specific types of responses.  This infrastructure will also be useful for thorough testing of improved error handling in the SDK.
 
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)

## Before / After
Before: GRPCResult constructed with a String error message
After: GRPCResult constructed with a pre-cooked Throwable that can be as specific as necessary.
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
Unit tests continue to pass.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
