### PR TITLE
Update documentation to point towards hosted nodes rather than shimming service 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,6 @@ Xpring4j provides the following features:
 
 ## Installation
 
-Xpring4j utilizes two components to access Xpring:
-
-1. The Xpring4j client-side library (This library)
-2. A server-side component that handles requests from this library and proxies them to an XRP node
-
 ### Client-Side Library
 
 Xpring4j is available as a Java library from Maven Central. Simply add the following to your `pom.xml`:
@@ -35,17 +30,19 @@ Xpring4j is available as a Java library from Maven Central. Simply add the follo
 </dependency>
 ```
 
-### Server-Side Component
+### rippled Node
 
-The server-side component sends client-side requests to an XRP Node.
+Xpring SDK needs to communicate with a rippled node which has gRPC enabled. Consult the [rippled documentation](https://github.com/ripple/rippled#build-from-source) for details on how to build your own node.
 
-To get developers started right away, Xpring provides the server-side component as a hosted service, which proxies requests from client-side libraries to a hosted XRP Node. Developers can reach the endpoint at:
+To get developers started right away, Xpring currently hosts nodes. These nodes are provided on a best effort basis, and may be subject to downtime. 
 
 ```
-grpc.xpring.tech:80
-```
+# TestNet
+alpha.test.xrp.xpring.io:50051
 
-Xpring is working on building a zero-config way for XRP node users to deploy and use the adapter as an open-source component of [rippled](https://github.com/ripple/rippled). Watch this space!
+# MainNet
+alpha.xrp.xpring.io:50051
+```
 
 ## Usage
 
@@ -149,8 +146,8 @@ wallet.verify(message, signature); // true
 ```java
 import io.xpring.xrpl.XpringClient;
 
-String grpcURL = "grpc.xpring.tech";
-XpringClient xpringClient = new XpringClient(grpcURL);
+String grpcURL = "alpha.test.xrp.xpring.io:50051"; // TestNet URL, use alpha.xrp.xpring.io:50051 for MainNet
+XpringClient xpringClient = new XpringClient(grpcURL, true);
 ```
 
 #### Retrieving a Balance
@@ -161,8 +158,8 @@ A `XpringClient` can check the balance of an account on the XRP Ledger.
 import io.xpring.xrpl.XpringClient;
 import java.math.BigInteger;
 
-String grpcURL = "grpc.xpring.tech";
-XpringClient xpringClient = new XpringClient(grpcURL);
+String grpcURL = "alpha.test.xrp.xpring.io:50051"; // TestNet URL, use alpha.xrp.xpring.io:50051 for MainNet
+XpringClient xpringClient = new XpringClient(grpcURL, true);
 
 String address = "X7u4MQVhU2YxS4P9fWzQjnNuDRUkP3GM6kiVjTjcQgUU3Jr";
 BigInteger balance = xpringClient.getBalance(address);
@@ -187,8 +184,8 @@ These states are determined by the `TransactionStatus` enum.
 import io.xpring.xrpl.XpringClient;
 import io.xpring.xrpl.TransactionStatus;
 
-String grpcURL = "grpc.xpring.tech";
-XpringClient xpringClient = new XpringClient(grpcURL);
+String grpcURL = "alpha.test.xrp.xpring.io:50051"; // TestNet URL, use alpha.xrp.xpring.io:50051 for MainNet
+XpringClient xpringClient = new XpringClient(grpcURL, true);
 
 String transactionHash = "9FC7D277C1C8ED9CE133CC17AEA9978E71FC644CE6F5F0C8E26F1C635D97AF4A";
 TransactionStatus transactionStatus = xpringClient.xpringClient.getTransactionStatus(transactionHash); // TransactionStatus.SUCCEEDED


### PR DESCRIPTION
## High Level Overview of Change

We're confident in the rippled node's ability to serve the demo SDK and want to point SLOHack users to these endpoints.