### PR TITLE
Implement skeleton for getTransactionHistory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <protobuf.version>3.11.4</protobuf.version>
         <slf4j.version>1.7.30</slf4j.version>
         <graalvm.version>20.0.0</graalvm.version>
-        <testcontainers.version>1.12.1</testcontainers.version>
+        <testcontainers.version>1.12.5</testcontainers.version>
         <!-- org.apache.maven.plugins:maven-checkstyle-plugin -->
         <checkstyle.config.location>checkstyle.xml</checkstyle.config.location>
         <checkstyle.violationSeverity>error</checkstyle.violationSeverity>

--- a/src/main/java/io/xpring/xrpl/DefaultXpringClient.java
+++ b/src/main/java/io/xpring/xrpl/DefaultXpringClient.java
@@ -233,13 +233,9 @@ public class DefaultXpringClient implements XpringClientDecorator {
 
         List<GetTransactionResponse> getTransactionResponseList = response.getTransactionsList();
 
-        List<ImmutableTransaction> transactionsList = getTransactionResponseList.stream()
+        return getTransactionResponseList.stream()
                 .map(DefaultXpringClient::getTransactionResponseToImmutableTransaction)
-                .collect(Collectors.toList());
-
-        ImmutableTransaction [] transactions = new ImmutableTransaction[transactionsList.size()];
-        transactions = transactionsList.toArray(transactions);
-        return transactions;
+                .toArray(size -> new ImmutableTransaction[size]);
     }
 
     private XRPDropsAmount getMinimumFee() {

--- a/src/main/java/io/xpring/xrpl/RawTransactionStatus.java
+++ b/src/main/java/io/xpring/xrpl/RawTransactionStatus.java
@@ -28,7 +28,7 @@ public class RawTransactionStatus {
      * @param getTransactionResponse The {@link GetTransactionResponse} to encapsulate.
      */
     public RawTransactionStatus(GetTransactionResponse getTransactionResponse) {
-        Transaction transaction = getTransactionResponse.getTransaction();
+        org.xrpl.rpc.v1.Transaction transaction = getTransactionResponse.getTransaction();
 
         this.validated = getTransactionResponse.getValidated();
         this.transactionStatusCode = getTransactionResponse.getMeta().getTransactionResult().getResult();

--- a/src/main/java/io/xpring/xrpl/ReliableSubmissionXpringClient.java
+++ b/src/main/java/io/xpring/xrpl/ReliableSubmissionXpringClient.java
@@ -60,4 +60,9 @@ public class ReliableSubmissionXpringClient implements XpringClientDecorator {
     public RawTransactionStatus getRawTransactionStatus(String transactionHash) throws XpringException {
         return this.decoratedClient.getRawTransactionStatus(transactionHash);
     }
+
+    @Override
+    public Transaction[] getTransactionHistory(String address) throws XpringException {
+        return this.decoratedClient.getTransactionHistory(address);
+    }
 }

--- a/src/main/java/io/xpring/xrpl/Transaction.java
+++ b/src/main/java/io/xpring/xrpl/Transaction.java
@@ -1,0 +1,11 @@
+package io.xpring.xrpl;
+
+import org.immutables.value.Value;
+
+/**
+ * Represents a transaction on the XRP Ledger.
+ */
+@Value.Immutable
+public interface Transaction {
+    // TODO(keefertaylor): Implement fields here.
+}

--- a/src/main/java/io/xpring/xrpl/XpringClientDecorator.java
+++ b/src/main/java/io/xpring/xrpl/XpringClientDecorator.java
@@ -53,4 +53,13 @@ public interface XpringClientDecorator {
      * @return an {@link io.xpring.proto.TransactionStatus} containing the raw transaction status.
      */
     RawTransactionStatus getRawTransactionStatus(String transactionHash) throws XpringException;
+
+    /**
+     * Retrieve the transaction history for an address.
+     *
+     * @param address: The address to retrieve transaction history for.
+     * @return: An array of {@link Transaction}s for the account.
+     * @throws XpringException If the given inputs were invalid.
+     */
+    Transaction [] getTransactionHistory(String address) throws XpringException;
 }

--- a/src/main/java/io/xpring/xrpl/legacy/LegacyDefaultXpringClient.java
+++ b/src/main/java/io/xpring/xrpl/legacy/LegacyDefaultXpringClient.java
@@ -5,6 +5,7 @@ import io.grpc.ManagedChannelBuilder;
 import io.xpring.proto.*;
 import io.xpring.proto.XRPLedgerAPIGrpc.XRPLedgerAPIBlockingStub;
 import io.xpring.xrpl.RawTransactionStatus;
+import io.xpring.xrpl.Transaction;
 import io.xpring.xrpl.TransactionStatus;
 import io.xpring.xrpl.Utils;
 import io.xpring.xrpl.Wallet;
@@ -132,7 +133,7 @@ public class LegacyDefaultXpringClient implements XpringClientDecorator {
         BigInteger currentFeeInDrops = this.getCurrentFeeInDrops();
         int lastValidatedLedgerSequence = this.getLatestValidatedLedgerSequence();
 
-        Transaction transaction = Transaction.newBuilder()
+        io.xpring.proto.Transaction transaction = io.xpring.proto.Transaction.newBuilder()
                 .setAccount(sourceWallet.getAddress())
                 .setFee(XRPAmount.newBuilder().setDrops(currentFeeInDrops.toString()).build())
                 .setSequence(accountInfo.getSequence())
@@ -197,5 +198,16 @@ public class LegacyDefaultXpringClient implements XpringClientDecorator {
 
         io.xpring.proto.TransactionStatus transactionStatus = stub.getTransactionStatus(transactionStatusRequest);
         return new RawTransactionStatus(transactionStatus);
+    }
+
+    /**
+     * Retrieve the transaction history for an address.
+     *
+     * @param address: The address to retrieve transaction history for.
+     * @return: An array of {@link io.xpring.xrpl.Transaction}s for the account.
+     * @throws XpringException If the given inputs were invalid.
+     */
+    public Transaction[] getTransactionHistory(String address) throws XpringException {
+        throw XpringException.unimplemented;
     }
 }

--- a/src/test/java/io/xpring/xrpl/FakeXpringClient.java
+++ b/src/test/java/io/xpring/xrpl/FakeXpringClient.java
@@ -13,19 +13,22 @@ public class FakeXpringClient implements  XpringClientDecorator {
     public String sendValue;
     public int latestValidatedLedgerValue;
     public RawTransactionStatus rawTransactionStatusValue;
+    public Transaction [] transactionHistory;
 
     public FakeXpringClient(
             BigInteger getBalanceValue,
             TransactionStatus transactionStatusValue,
             String sendValue,
             int latestValidatedLedgerValue,
-            RawTransactionStatus rawTransactionStatusValue
+            RawTransactionStatus rawTransactionStatusValue,
+            Transaction [] transactionHistory
     ) {
         this.getBalanceValue = getBalanceValue;
         this.transactionStatusValue = transactionStatusValue;
         this.sendValue = sendValue;
         this.latestValidatedLedgerValue = latestValidatedLedgerValue;
         this.rawTransactionStatusValue = rawTransactionStatusValue;
+        this.transactionHistory = transactionHistory;
     }
 
     @Override
@@ -51,5 +54,10 @@ public class FakeXpringClient implements  XpringClientDecorator {
     @Override
     public RawTransactionStatus getRawTransactionStatus(String transactionHash) {
         return this.rawTransactionStatusValue;
+    }
+
+    @Override
+    public Transaction [] getTransactionHistory(String address) {
+        return this.transactionHistory;
     }
 }

--- a/src/test/java/io/xpring/xrpl/RawTransactionStatusTest.java
+++ b/src/test/java/io/xpring/xrpl/RawTransactionStatusTest.java
@@ -3,6 +3,7 @@ package io.xpring.xrpl;
 import io.xpring.proto.TransactionStatus;
 import org.junit.Test;
 import org.xrpl.rpc.v1.*;
+import org.xrpl.rpc.v1.Transaction;
 import org.xrpl.rpc.v1.Common.*;
 
 import static org.junit.Assert.*;

--- a/src/test/java/io/xpring/xrpl/ReliableSubmissionXpringClientTest.java
+++ b/src/test/java/io/xpring/xrpl/ReliableSubmissionXpringClientTest.java
@@ -36,6 +36,9 @@ public class ReliableSubmissionXpringClientTest {
                     setLastLedgerSequence(LAST_LEDGER_SEQUENCE).
                     build()
     );
+    private static final Transaction [] DEFAULT_TRANSACTION_HISTORY_VALUE = {
+            ImmutableTransaction.builder().build()
+    };
 
     FakeXpringClient fakeXpringClient;
     ReliableSubmissionXpringClient reliableSubmissionXpringClient;
@@ -49,7 +52,8 @@ public class ReliableSubmissionXpringClientTest {
                 DEFAULT_TRANSACTION_STATUS_VALUE,
                 DEFAULT_SEND_VALUE,
                 DEFAULT_LATEST_LEDGER_VALUE,
-                DEFAULT_RAW_TRANSACTION_STATUS_VALUE
+                DEFAULT_RAW_TRANSACTION_STATUS_VALUE,
+                DEFAULT_TRANSACTION_HISTORY_VALUE
         );
 
         this.reliableSubmissionXpringClient = new ReliableSubmissionXpringClient(fakeXpringClient);
@@ -90,6 +94,15 @@ public class ReliableSubmissionXpringClientTest {
 
         // THEN the result is returned unaltered.
         assertThat(transactionStatus).isEqualTo(DEFAULT_RAW_TRANSACTION_STATUS_VALUE);
+    }
+
+    @Test
+    public void testGetRawTransactionHistory() throws XpringException {
+        // GIVEN a `ReliableSubmissionClient` decorating a FakeXpringClient WHEN transaction history is retrieved
+        Transaction [] transactionHistory = reliableSubmissionXpringClient.getTransactionHistory(XRPL_ADDRESS);
+
+        // THEN the result is returned unaltered.
+        assertThat(transactionHistory).isEqualTo(DEFAULT_TRANSACTION_HISTORY_VALUE);
     }
 
     @Test(timeout=10000)

--- a/src/test/java/io/xpring/xrpl/SignerTest.java
+++ b/src/test/java/io/xpring/xrpl/SignerTest.java
@@ -6,6 +6,7 @@ import java.math.BigInteger;
 import java.util.Arrays;
 
 import org.xrpl.rpc.v1.*;
+import org.xrpl.rpc.v1.Transaction;
 import org.xrpl.rpc.v1.Common.*;
 import org.xrpl.rpc.v1.Common.Account;
 import org.xrpl.rpc.v1.Common.Amount;


### PR DESCRIPTION
## High Level Overview of Change

Implement a skeleton of `getTransactionHistory` and tests inside of XpringClient.

Analogs:
JS: https://github.com/xpring-eng/Xpring-JS/pull/212
Java: https://github.com/xpring-eng/xpring4j/pull/116
Swift: https://github.com/xpring-eng/XpringKit/pull/124

### Context of Change

rippled recently implemented this RPC which we'd like to use.

Note that this functionality is not exposed in `XpringClient`, so this is still internal only. Currently `Transaction` objects are just empty containers. 

A future PR will:
- Update `Transaction` to have fields and to set them correctly from the protocol buffers
- Expose this as a public API

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Before / After

N/A - still internal only functionality. 

## Test Plan

New unit tests provided for CI.