### PR TITLE
[PayID] Add `PayIDUtils`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,11 @@
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.interledger</groupId>
+            <artifactId>spsp-core</artifactId>
+            <version>1.1.1</version>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/src/main/java/io/xpring/payid/PayIDUtils.java
+++ b/src/main/java/io/xpring/payid/PayIDUtils.java
@@ -11,7 +11,7 @@ public class PayIDUtils {
      * Parse a PayID to a payment pointer object
      *
      * @param payID The input payID..
-     * @returns A PaymentPointer object if the input was valid, otherwise undefined.
+     * @return A PaymentPointer object if the input was valid, otherwise undefined.
      */
     public static PaymentPointer parsePayID(String payID) {
         try {

--- a/src/main/java/io/xpring/payid/PayIDUtils.java
+++ b/src/main/java/io/xpring/payid/PayIDUtils.java
@@ -1,0 +1,28 @@
+package io.xpring.payid;
+
+import org.interledger.spsp.PaymentPointer;
+
+/**
+ * Provides utilities for PayID.
+ */
+public class PayIDUtils {
+
+    /**
+     * Parse a PayID to a payment pointer object
+     *
+     * @param payID The input payID..
+     * @returns A PaymentPointer object if the input was valid, otherwise undefined.
+     */
+    public static PaymentPointer parsePayID(String payID) {
+        try {
+            return PaymentPointer.of(payID);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Please do not instantiate this static utility class.
+     */
+    private PayIDUtils() {}
+}

--- a/src/test/java/io/xpring/payid/PayIDUtilsTest.java
+++ b/src/test/java/io/xpring/payid/PayIDUtilsTest.java
@@ -1,0 +1,85 @@
+package io.xpring.payid;
+
+import org.interledger.spsp.PaymentPointer;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class PayIDUtilsTest {
+    @Test
+    public void testParsePaymentPointerHostAndPath() {
+        // GIVEN a payment pointer with a host and a path.
+        String rawPaymentPointer = "$example.com/foo";
+
+        // WHEN it is parsed to a PaymentPointer object
+        PaymentPointer paymentPointer = PayIDUtils.parsePayID(rawPaymentPointer);
+
+        // THEN the host and path are set correctly.
+        assertEquals(paymentPointer.host(), "example.com");
+        assertEquals(paymentPointer.path(), "/foo");
+    }
+
+    @Test
+    public void testParsePaymentPointerWithWellKnownPath() {
+        // GIVEN a payment pointer with a well known path.
+        String rawPaymentPointer = "$example.com";
+
+        // WHEN it is parsed to a PaymentPointer object
+        PaymentPointer paymentPointer = PayIDUtils.parsePayID(rawPaymentPointer);
+
+        // THEN the host and path are set correctly.
+        assertEquals(paymentPointer.host(), "example.com");
+        // TODO(keefertaylor): Use constant for path when exposed, see: https://github.com/hyperledger/quilt/pull/437
+        assertEquals(paymentPointer.path(), "/.well-known/pay");
+    }
+
+    @Test
+    public void testParsePaymentPointerWithWellKnownPathAndTrailingSlash() {
+        // GIVEN a payment pointer with a well known path and a trailing slash.
+        String rawPaymentPointer = "$example.com";
+
+        // WHEN it is parsed to a PaymentPointer object
+        PaymentPointer paymentPointer = PayIDUtils.parsePayID(rawPaymentPointer);
+
+        // THEN the host and path are set correctly.
+        assertEquals(paymentPointer.host(), "example.com");
+        // TODO(keefertaylor): Use constant for path when exposed, see: https://github.com/hyperledger/quilt/pull/437
+        assertEquals(paymentPointer.path(), "/.well-known/pay");
+    }
+
+    @Test
+    public void testParsePaymentPointerIncorrectPrefix() {
+        // GIVEN a payment pointer without a '$' prefix
+        String rawPaymentPointer = "example.com/";
+
+        // WHEN it is parsed to a PaymentPointer object
+        PaymentPointer paymentPointer = PayIDUtils.parsePayID(rawPaymentPointer);
+
+        // THEN the result is null
+        assertNull(paymentPointer);
+    }
+
+    @Test
+    public void testParsePaymentPointerEmptyHost() {
+        // GIVEN a payment pointer without a host.
+        String rawPaymentPointer = "$";
+
+        // WHEN it is parsed to a PaymentPointer object
+        PaymentPointer paymentPointer = PayIDUtils.parsePayID(rawPaymentPointer);
+
+        // THEN the result is null
+        assertNull(paymentPointer);
+    }
+
+    @Test
+    public void testParsePaymentPointerNonAscii() {
+        // GIVEN a payment pointer with non-ascii characters.
+        String rawPaymentPointer = "$ZA̡͊͠͝LGΌ IS̯͈͕̹̘̱ͮ TO͇̹̺ͅƝ̴ȳ̳ TH̘Ë͖́̉ ͠P̯͍̭O̚N̐Y̡";
+
+        // WHEN it is parsed to a PaymentPointer object
+        PaymentPointer paymentPointer = PayIDUtils.parsePayID(rawPaymentPointer);
+
+        // THEN the result is null
+        assertNull(paymentPointer);
+    }
+}


### PR DESCRIPTION
## High Level Overview of Change

Add analog APIs for `PayIDUtils` in Xpring4J. 

Analogs in:
Swift: https://github.com/xpring-eng/XpringKit/pull/132
JavaScript: https://github.com/xpring-eng/xpring-common-js/pull/201

### Context of Change

I realize that this API seems a bit silly since it's a simple pass through of `org.interledger.spsp.core`, but I'd like to keep consistent APIs across SDKs and this class exists in JS / Swift. Users who want more control can always depend on the interledger code directly. 

Tests contain the same cases as the [JS test suite](https://github.com/xpring-eng/xpring-common-js/blob/master/test/PayID/pay-id-utils-test.ts).

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Before / After

New PayID utils class.

## Test Plan

New tests provided for CI.
