### PR TITLE
Protobuf wrapper objects (1/3)

### DIFF
--- a/src/main/java/io/xpring/ilp/DefaultIlpClient.java
+++ b/src/main/java/io/xpring/ilp/DefaultIlpClient.java
@@ -80,7 +80,7 @@ public class DefaultIlpClient implements IlpClientDecorator {
 
 
     @Override
-    public CreateAccountResponse createAccount(io.xpring.ilp.CreateAccountRequest createAccountRequest, Optional<String> bearerToken) throws XpringException {
+    public CreateAccountResponse createAccount(io.xpring.ilp.model.CreateAccountRequest createAccountRequest, Optional<String> bearerToken) throws XpringException {
         CreateAccountRequest createAccountRequestGrpc = CreateAccountRequest.newBuilder()
           .setAccountId(createAccountRequest.accountId())
           .setAssetCode(createAccountRequest.assetCode())

--- a/src/main/java/io/xpring/ilp/IlpClient.java
+++ b/src/main/java/io/xpring/ilp/IlpClient.java
@@ -6,9 +6,8 @@ import org.interledger.spsp.server.grpc.GetBalanceResponse;
 import org.interledger.spsp.server.grpc.SendPaymentResponse;
 
 import com.google.common.annotations.Beta;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.UnsignedLong;
-import io.grpc.ExperimentalApi;
+import io.xpring.ilp.model.CreateAccountRequest;
 import io.xpring.xrpl.XpringException;
 
 import java.math.BigInteger;

--- a/src/main/java/io/xpring/ilp/IlpClientDecorator.java
+++ b/src/main/java/io/xpring/ilp/IlpClientDecorator.java
@@ -6,6 +6,7 @@ import org.interledger.spsp.server.grpc.GetBalanceResponse;
 import org.interledger.spsp.server.grpc.SendPaymentResponse;
 
 import com.google.common.primitives.UnsignedLong;
+import io.xpring.ilp.model.CreateAccountRequest;
 import io.xpring.xrpl.XpringException;
 
 import java.math.BigInteger;

--- a/src/main/java/io/xpring/ilp/model/AccountBalance.java
+++ b/src/main/java/io/xpring/ilp/model/AccountBalance.java
@@ -1,0 +1,52 @@
+package io.xpring.ilp.model;
+
+import org.immutables.value.Value;
+import java.math.BigInteger;
+
+/**
+ * An immutable interface containing the different balances of an account on a connector.
+ */
+@Value.Immutable
+public interface AccountBalance {
+
+  static ImmutableAccountBalance.Builder builder() {
+    return ImmutableAccountBalance.builder();
+  }
+
+  /**
+   * @return The accountId for this account balance.
+   */
+  String accountId();
+
+  /**
+   * The amount of units representing the aggregate position this Connector operator holds with the account owner. A
+   * positive balance indicates the Connector operator has an outstanding liability (i.e., owes money) to the account
+   * holder. A negative balance represents an asset (i.e., the account holder owes money to the operator). This value is
+   * the sum of the clearing balance and the prepaid amount.
+   *
+   * @return An {@link BigInteger} representing the net clearingBalance of this account.
+   */
+  @Value.Derived
+  default BigInteger netBalance() {
+    return clearingBalance().add(prepaidAmount());
+  }
+
+  /**
+   * The amount of units representing the clearing position this Connector operator holds with the account owner. A
+   * positive clearing balance indicates the Connector operator has an outstanding liability (i.e., owes money) to the
+   * account holder. A negative clearing balance represents an asset (i.e., the account holder owes money to the
+   * operator).
+   *
+   * @return An {@link BigInteger} representing the net clearing balance of this account.
+   */
+  BigInteger clearingBalance();
+
+  /**
+   * The number of units that the account holder has prepaid. This value is factored into the value returned by {@link
+   * #netBalance()}, and is generally never negative.
+   *
+   * @return An {@link BigInteger} representing the number of units the counterparty (i.e., owner of this account) has
+   * prepaid with this Connector.
+   */
+  BigInteger prepaidAmount();
+}

--- a/src/main/java/io/xpring/ilp/model/AccountBalanceResponse.java
+++ b/src/main/java/io/xpring/ilp/model/AccountBalanceResponse.java
@@ -1,0 +1,36 @@
+package io.xpring.ilp.model;
+
+import org.immutables.value.Value;
+
+/**
+ * Response object for requests to get an account's balance
+ */
+@Value.Immutable
+public interface AccountBalanceResponse {
+
+  static ImmutableAccountBalanceResponse.Builder builder() {
+    return ImmutableAccountBalanceResponse.builder();
+  }
+
+  /**
+   * Currency code or other asset identifier that this account's balances will be denominated in
+   */
+  String assetCode();
+
+  /**
+   * Interledger amounts are integers, but most currencies are typically represented as # fractional units, e.g. cents.
+   * This property defines how many Interledger units make # up one regular unit. For dollars, this would usually be set
+   * to 9, so that Interledger # amounts are expressed in nano-dollars.
+   *
+   * @return an int representing this account's asset scale.
+   */
+  int assetScale();
+
+  /**
+   * Contains the balance of an account on a connector, denominated in the account's assetCode and assetScale
+   *
+   * @return an {@link AccountBalance} with net, clearing, and prepaid balance of an account.
+   */
+  AccountBalance accountBalance();
+
+}

--- a/src/main/java/io/xpring/ilp/model/CreateAccountRequest.java
+++ b/src/main/java/io/xpring/ilp/model/CreateAccountRequest.java
@@ -1,4 +1,4 @@
-package io.xpring.ilp;
+package io.xpring.ilp.model;
 
 import org.immutables.value.Value;
 

--- a/src/main/java/io/xpring/ilp/model/SendPaymentRequest.java
+++ b/src/main/java/io/xpring/ilp/model/SendPaymentRequest.java
@@ -14,6 +14,15 @@ public interface SendPaymentRequest {
   }
 
   /**
+   * The amount to send.  This amount is denominated in the asset code and asset scale of the sender's account
+   * on the connector.  For example, if the account has an asset code of "USD" and an asset scale of 9,
+   * a payment request of 100 units would send 100 nano-dollars.
+   *
+   * @return the amount to send to the recipient, denominated in the sender's account asset code and scale
+   */
+  UnsignedLong amount();
+
+  /**
    * A payment pointer is a standardized identifier for payment accounts.
    * This payment pointer will be the identifier for the account of the recipient of this payment on the ILP
    * network.
@@ -25,12 +34,8 @@ public interface SendPaymentRequest {
   String destinationPaymentPointer();
 
   /**
-   * The amount to send.  This amount is denominated in the asset code and asset scale of the sender's account
-   * on the connector.  For example, if the account has an asset code of "USD" and an asset scale of 9,
-   * a payment request of 100 units would send 100 nano-dollars.
-   *
-   * @return the amount to send to the recipient, denominated in the sender's account asset code and scale
+   * @return The accountID of the sender.
    */
-  UnsignedLong amount();
+  String senderAccountId();
 
 }

--- a/src/main/java/io/xpring/ilp/model/SendPaymentRequest.java
+++ b/src/main/java/io/xpring/ilp/model/SendPaymentRequest.java
@@ -1,0 +1,36 @@
+package io.xpring.ilp.model;
+
+import com.google.common.primitives.UnsignedLong;
+import org.immutables.value.Value;
+
+/**
+ * An immutable interface which can be used to send a payment request to a connector
+ */
+@Value.Immutable
+public interface SendPaymentRequest {
+
+  static ImmutableSendPaymentRequest.Builder builder() {
+    return ImmutableSendPaymentRequest.builder();
+  }
+
+  /**
+   * A payment pointer is a standardized identifier for payment accounts.
+   * This payment pointer will be the identifier for the account of the recipient of this payment on the ILP
+   * network.
+   *
+   * @see "https://github.com/interledger/rfcs/blob/master/0026-payment-pointers/0026-payment-pointers.md"
+   *
+   * @return A {@link String} conforming to the Payment Pointer RFC which identifies an account on the ILP network
+   */
+  String destinationPaymentPointer();
+
+  /**
+   * The amount to send.  This amount is denominated in the asset code and asset scale of the sender's account
+   * on the connector.  For example, if the account has an asset code of "USD" and an asset scale of 9,
+   * a payment request of 100 units would send 100 nano-dollars.
+   *
+   * @return the amount to send to the recipient, denominated in the sender's account asset code and scale
+   */
+  UnsignedLong amount();
+
+}

--- a/src/main/java/io/xpring/ilp/model/SendPaymentResponse.java
+++ b/src/main/java/io/xpring/ilp/model/SendPaymentResponse.java
@@ -1,0 +1,45 @@
+package io.xpring.ilp.model;
+
+import com.google.common.primitives.UnsignedLong;
+import org.immutables.value.Value;
+
+/**
+ * A response object containing details about a requested payment
+ */
+@Value.Immutable
+public interface SendPaymentResponse {
+
+  static ImmutableSendPaymentResponse.Builder builder() {
+    return ImmutableSendPaymentResponse.builder();
+  }
+
+  /**
+   * The original amount that was requested to be sent.
+   *
+   * @return An {@link UnsignedLong} representing the original amount to be sent in a given payment.
+   */
+  UnsignedLong originalAmount();
+
+  /**
+   * The actual amount, in the receivers units, that was delivered to the receiver. Any currency conversion and/or
+   * connector fees may cause this to be different than the amount sent.
+   *
+   * @return An {@link UnsignedLong} representing the amount delivered.
+   */
+  UnsignedLong amountDelivered();
+
+  /**
+   * The actual amount, in the senders units, that was sent to the receiver. In the case of a timeout or rejected
+   * packets this amount may be less than the requested amount to be sent.
+   *
+   * @return An {@link UnsignedLong} representing the amount sent.
+   */
+  UnsignedLong amountSent();
+
+  /**
+   * Indicates if the payment was completed successfully.
+   *
+   * @return true if payment was successful
+   */
+  boolean successfulPayment();
+}

--- a/src/test/java/io/xpring/ilp/DefaultIlpClientTest.java
+++ b/src/test/java/io/xpring/ilp/DefaultIlpClientTest.java
@@ -131,7 +131,7 @@ public class DefaultIlpClientTest {
     DefaultIlpClient client = getClient();
 
     // WHEN an account is created with ALL parameters set
-    io.xpring.ilp.CreateAccountRequest createAccountRequest = io.xpring.ilp.CreateAccountRequest.builder("USD", 6)
+    io.xpring.ilp.model.CreateAccountRequest createAccountRequest = io.xpring.ilp.model.CreateAccountRequest.builder("USD", 6)
       .accountId("foo")
       .description("test account")
       .build();
@@ -147,7 +147,7 @@ public class DefaultIlpClientTest {
     DefaultIlpClient client = getClient();
 
     // WHEN an account is created with a populated request but without an auth token
-    io.xpring.ilp.CreateAccountRequest createAccountRequest = io.xpring.ilp.CreateAccountRequest.builder("USD", 6)
+    io.xpring.ilp.model.CreateAccountRequest createAccountRequest = io.xpring.ilp.model.CreateAccountRequest.builder("USD", 6)
       .accountId("foo")
       .description("test account")
       .build();
@@ -163,7 +163,7 @@ public class DefaultIlpClientTest {
     DefaultIlpClient client = getClient();
 
     // WHEN an account is created with no auth token and no accountId
-    io.xpring.ilp.CreateAccountRequest createAccountRequest = io.xpring.ilp.CreateAccountRequest.builder("USD", 6)
+    io.xpring.ilp.model.CreateAccountRequest createAccountRequest = io.xpring.ilp.model.CreateAccountRequest.builder("USD", 6)
       .build();
     CreateAccountResponse response = client.createAccount(createAccountRequest, Optional.empty());
 

--- a/src/test/java/io/xpring/ilp/IlpIntegrationTests.java
+++ b/src/test/java/io/xpring/ilp/IlpIntegrationTests.java
@@ -9,6 +9,7 @@ import org.interledger.spsp.server.grpc.GetBalanceResponse;
 import org.interledger.spsp.server.grpc.SendPaymentResponse;
 
 import com.google.common.primitives.UnsignedLong;
+import io.xpring.ilp.model.CreateAccountRequest;
 import io.xpring.ilp.util.IlpAuthConstants;
 import io.xpring.xrpl.XpringException;
 import org.junit.AfterClass;


### PR DESCRIPTION
## High Level Overview of Change

Asana task: https://app.asana.com/0/1143722888069470/1165556580466065

- Added immutable data classes that will get converted to/from protobuf objects to avoid exposing protobufs in the public API
- Moved `CreateAccountRequest` from `io.xpring.ilp` to `io.xpring.ilp.model`
**NOTE: admin API endpoints such as createAccount and getAccount will not receive this treatment, since they will likely go away in the next Xpring4j release**
<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

Currently, the ILP API consumes and produces generated protobuf objects. This was a means of convenience and was done in the interest of time. However, generated protobuf objects can be ugly, so we shouldn't expose them in the public API.  This PR simply adds objects that protobufs can be converted from/into to expose better request/response objects in the API.
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] New feature (non-breaking change which adds functionality)

## Before / After

Before: `IlpClient` consumes and produces protobuf objects
After: `IlpClient` still consumes and produces protobuf, but in part 2 of this PR, it will consume and produce these new wrapper objects.
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
The existing test suite will suffice for this PR, but will need some refactoring (ie changing request/response types) once these objects are in use.

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->


## Future Tasks
- Write a conversion service that will convert to/from protobufs to/from these new objects
- Change `IlpClient` signatures to use new objects