### PR TITLE
Dynamically create a transaction hash for integration tests

### DIFF
--- a/src/test/java/io/xpring/xrpl/XRPClientIntegrationTests.java
+++ b/src/test/java/io/xpring/xrpl/XRPClientIntegrationTests.java
@@ -30,9 +30,6 @@ public class XRPClientIntegrationTests {
     /** Drops of XRP to send. */
     private static final BigInteger AMOUNT = new BigInteger("1");
 
-    /** Hash of a successful transaction. */
-    private static final String TRANSACTION_HASH = "DAA9F31628C952A48DAE71829E91847BF4EF23C0FABDD7218E41836D1E68EEBD";
-
     @Before
     public void setUp() throws Exception {
         this.legacyXRPClient = new XRPClient(LEGACY_GRPC_URL, false);
@@ -47,7 +44,14 @@ public class XRPClientIntegrationTests {
 
     @Test
     public void getPaymentStatusTest_legacy() throws XpringException  {
-        TransactionStatus transactionStatus = legacyXRPClient.getPaymentStatus(TRANSACTION_HASH);
+        // GIVEN a hash of a payment transaction.
+        Wallet wallet = new Wallet(WALLET_SEED);
+        String transactionHash = legacyXRPClient.send(AMOUNT, XRPL_ADDRESS, wallet);
+
+        // WHEN the transaction status is retrieved.
+        TransactionStatus transactionStatus = legacyXRPClient.getPaymentStatus(transactionHash);
+
+        // THEN the status is 'succeeded'.
         assertThat(transactionStatus).isEqualTo(TransactionStatus.SUCCEEDED);
     }
 
@@ -67,7 +71,14 @@ public class XRPClientIntegrationTests {
 
     @Test
     public void getPaymentStatusTest() throws XpringException {
-        TransactionStatus transactionStatus = xrpClient.getPaymentStatus(TRANSACTION_HASH);
+        // GIVEN a hash of a payment transaction.
+        Wallet wallet = new Wallet(WALLET_SEED);
+        String transactionHash = xrpClient.send(AMOUNT, XRPL_ADDRESS, wallet);
+
+        // WHEN the transaction status is retrieved.
+        TransactionStatus transactionStatus = xrpClient.getPaymentStatus(transactionHash);
+
+        // THEN the status is 'succeeded'.
         assertThat(transactionStatus).isEqualTo(TransactionStatus.SUCCEEDED);
     }
 


### PR DESCRIPTION
## High Level Overview of Change

Create a transaction hash on the fly for integration checks rather than relying on a static hash.

### Context of Change

The Testnet nodes we use for integration tests have limited history and are reset from time to time. As a result, static hashes age out of the nodes history at least monthly, causing CI to fail.

Instead, send a payment with a known good hash and check that hash. This ensures that our hash will always be up to date. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

No more hash refreshing check ins.

## Test Plan

CI