### PR TITLE
Enable Linter and Fix Lint Errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,3 +53,9 @@ $ git submodule update --init --recursive
 # Run tests.
 $ mvn clean test
 ```
+
+Lint rules are enforced on all continuous integration builds via 
+[CheckStyle](https://maven.apache.org/plugins/maven-checkstyle-plugin/). It is recommended developers use the 
+[IntelliJ CheckStyle Plugin](https://plugins.jetbrains.com/plugin/1065-checkstyle-idea) to lint their code during
+development.
+

--- a/pom.xml
+++ b/pom.xml
@@ -331,13 +331,6 @@
                 </dependencies>
                 <executions>
                     <execution>
-                        <id>validate</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                    <execution>
                         <id>verify</id>
                         <phase>verify</phase>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -331,9 +331,23 @@
                 </dependencies>
                 <executions>
                     <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>
+                    </execution>
+                    <execution>
+                        <id>verify</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <failsOnError>true</failsOnError>
+                            <failOnViolation>true</failOnViolation>
+                            <violationSeverity>warning</violationSeverity>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/main/java/io/xpring/common/XRPLNetwork.java
+++ b/src/main/java/io/xpring/common/XRPLNetwork.java
@@ -3,18 +3,19 @@ package io.xpring.common;
 /**
  * Possible networks to resolve.
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public enum XRPLNetwork {
-    DEV("devnet"),
-    TEST("testnet"),
-    MAIN("mainnet");
+  DEV("devnet"),
+  TEST("testnet"),
+  MAIN("mainnet");
 
-    private String networkName;
+  private String networkName;
 
-    XRPLNetwork(String networkName) {
-        this.networkName = networkName;
-    }
+  XRPLNetwork(String networkName) {
+    this.networkName = networkName;
+  }
 
-    public String getNetworkName() {
-        return networkName;
-    }
+  public String getNetworkName() {
+    return networkName;
+  }
 }

--- a/src/main/java/io/xpring/ilp/DefaultIlpClient.java
+++ b/src/main/java/io/xpring/ilp/DefaultIlpClient.java
@@ -14,9 +14,6 @@ import io.xpring.ilp.grpc.IlpCredentials;
 import io.xpring.ilp.model.AccountBalance;
 import io.xpring.ilp.model.PaymentRequest;
 import io.xpring.ilp.model.PaymentResult;
-import io.xpring.ilp.model.AccountBalance;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.TimeUnit;
 
@@ -25,81 +22,77 @@ import java.util.concurrent.TimeUnit;
  */
 public class DefaultIlpClient implements IlpClientDecorator {
 
-    private static final Logger logger = LoggerFactory.getLogger(DefaultIlpClient.class);
+  private final BalanceServiceGrpc.BalanceServiceBlockingStub balanceServiceStub;
+  private final IlpOverHttpServiceGrpc.IlpOverHttpServiceBlockingStub ilpOverHttpServiceStub;
 
-    private final BalanceServiceGrpc.BalanceServiceBlockingStub balanceServiceStub;
-    private final IlpOverHttpServiceGrpc.IlpOverHttpServiceBlockingStub ilpOverHttpServiceStub;
+  /**
+   * Initialize a new client with a configured URL.
+   *
+   * @param grpcUrl The gRPC URL exposed by Hermes.
+   */
+  DefaultIlpClient(String grpcUrl) {
+    this(ManagedChannelBuilder
+        .forAddress(grpcUrl, 443)
+        .build()
+    );
+  }
 
-    /**
-     * Initialize a new client with a configured URL
-     * @param grpcUrl The gRPC URL exposed by Hermes
-     */
-    protected DefaultIlpClient(String grpcUrl) {
-        this(ManagedChannelBuilder
-          .forAddress(grpcUrl, 443)
-          .build()
-        );
-    }
+  /**
+   * Required-args Constructor, currently for testing.
+   *
+   * @param channel A {@link ManagedChannel}.
+   */
+  DefaultIlpClient(final ManagedChannel channel) {
+    this.balanceServiceStub = BalanceServiceGrpc.newBlockingStub(channel);
+    this.ilpOverHttpServiceStub = IlpOverHttpServiceGrpc.newBlockingStub(channel);
 
-    /**
-     * Required-args Constructor, currently for testing.
-     *
-     * @param channel A {@link ManagedChannel}.
-     */
-    public DefaultIlpClient(final ManagedChannel channel) {
-        this.balanceServiceStub = BalanceServiceGrpc.newBlockingStub(channel);
-        this.ilpOverHttpServiceStub = IlpOverHttpServiceGrpc.newBlockingStub(channel);
-
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            channel.shutdown();
-            try {
-                channel.awaitTermination(5, TimeUnit.SECONDS);
-            }
-            catch (Exception timedOutException) {
-                try {
-                    channel.shutdownNow();
-                }
-                catch (Exception e) {
-                    // nothing more can be done
-                }
-            }
-        }));
-    }
-
-    @Override
-    public AccountBalance getBalance(final String accountId, final String accessToken) throws IlpException {
-        GetBalanceRequest request = GetBalanceRequest.newBuilder()
-          .setAccountId(accountId)
-          .build();
-
+    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+      channel.shutdown();
+      try {
+        channel.awaitTermination(5, TimeUnit.SECONDS);
+      } catch (Exception timedOutException) {
         try {
-            GetBalanceResponse response = this.balanceServiceStub
-              .withCallCredentials(IlpCredentials.build(accessToken))
-              .getBalance(request);
-
-            // Convert protobuf response to AccountBalanceResponse
-            return AccountBalance.from(response);
-        } catch (StatusRuntimeException statusRuntimeException) {
-            throw IlpException.from(statusRuntimeException);
+          channel.shutdownNow();
+        } catch (Exception e) {
+          // nothing more can be done
         }
+      }
+    }));
+  }
+
+  @Override
+  public AccountBalance getBalance(final String accountId, final String accessToken) throws IlpException {
+    GetBalanceRequest request = GetBalanceRequest.newBuilder()
+        .setAccountId(accountId)
+        .build();
+
+    try {
+      GetBalanceResponse response = this.balanceServiceStub
+          .withCallCredentials(IlpCredentials.build(accessToken))
+          .getBalance(request);
+
+      // Convert protobuf response to AccountBalanceResponse
+      return AccountBalance.from(response);
+    } catch (StatusRuntimeException statusRuntimeException) {
+      throw IlpException.from(statusRuntimeException);
     }
+  }
 
-    @Override
-    public PaymentResult sendPayment(final PaymentRequest paymentRequest,
-                                     final String accessToken) throws IlpException {
-        try {
-            // Convert paymentRequest to a protobuf object
-            SendPaymentRequest request = paymentRequest.toProto();
+  @Override
+  public PaymentResult sendPayment(final PaymentRequest paymentRequest,
+                                   final String accessToken) throws IlpException {
+    try {
+      // Convert paymentRequest to a protobuf object
+      SendPaymentRequest request = paymentRequest.toProto();
 
-            SendPaymentResponse protoResponse =
-              ilpOverHttpServiceStub
-                .withCallCredentials(IlpCredentials.build(accessToken))
-                .sendMoney(request);
+      SendPaymentResponse protoResponse = ilpOverHttpServiceStub
+          .withCallCredentials(IlpCredentials.build(accessToken))
+          .sendMoney(request);
 
-            return PaymentResult.from(protoResponse);
+      return PaymentResult.from(protoResponse);
 
-        } catch (StatusRuntimeException statusRuntimeException) {
-            throw IlpException.from(statusRuntimeException);
-        }
+    } catch (StatusRuntimeException statusRuntimeException) {
+      throw IlpException.from(statusRuntimeException);
     }
+  }
 }

--- a/src/main/java/io/xpring/ilp/IlpClient.java
+++ b/src/main/java/io/xpring/ilp/IlpClient.java
@@ -11,41 +11,42 @@ import java.util.Objects;
  */
 public class IlpClient {
 
-    private IlpClientDecorator decoratedClient;
+  private IlpClientDecorator decoratedClient;
 
-    /**
-     * Initialize a new client with a configured URL
-     * @param grpcUrl The gRPC URL exposed by Hermes
-     */
-    public IlpClient(String grpcUrl) {
-        Objects.requireNonNull(grpcUrl, "grpcUrl must not be null");
-        this.decoratedClient = new DefaultIlpClient(grpcUrl);
-    }
+  /**
+   * Initialize a new client with a configured URL.
+   *
+   * @param grpcUrl The gRPC URL exposed by Hermes.
+   */
+  public IlpClient(String grpcUrl) {
+    Objects.requireNonNull(grpcUrl, "grpcUrl must not be null");
+    this.decoratedClient = new DefaultIlpClient(grpcUrl);
+  }
 
-    /**
-     * Get the balance of the specified account on the connector.
-     *
-     * @param accountId The accountId to get the balance for.
-     * @param accessToken Access token used for authentication.
-     * @return An {@link AccountBalance} with account balances and denomination.
-     * @throws IlpException If the given inputs were invalid, the account doesn't exist, or authentication failed.
-     */
-    public AccountBalance getBalance(final String accountId, final String accessToken) throws IlpException {
-        return decoratedClient.getBalance(accountId, accessToken);
-    }
+  /**
+   * Get the balance of the specified account on the connector.
+   *
+   * @param accountId   The accountId to get the balance for.
+   * @param accessToken Access token used for authentication.
+   * @return An {@link AccountBalance} with account balances and denomination.
+   * @throws IlpException If the given inputs were invalid, the account doesn't exist, or authentication failed.
+   */
+  public AccountBalance getBalance(final String accountId, final String accessToken) throws IlpException {
+    return decoratedClient.getBalance(accountId, accessToken);
+  }
 
-    /**
-     * Send a payment from the given accountId to the destinationPaymentPointer payment pointer
-     *
-     * @param paymentRequest a {@link PaymentRequest} with parameters used to send a payment
-     * @param accessToken Access token of the sender
-     * @return A {@link PaymentResult} with details about the payment. Note that this method will not
-     *          necessarily throw an exception if the payment failed. Payment status can be checked in
-     *          {@link PaymentResult#successfulPayment()}
-     * @throws IlpException If the given inputs were invalid.
-     */
-    public PaymentResult sendPayment(final PaymentRequest paymentRequest,
-                                     final String accessToken) throws IlpException {
-        return decoratedClient.sendPayment(paymentRequest, accessToken);
-    }
+  /**
+   * Send a payment from the given accountId to the destinationPaymentPointer payment pointer.
+   *
+   * @param paymentRequest a {@link PaymentRequest} with parameters used to send a payment
+   * @param accessToken    Access token of the sender
+   * @return A {@link PaymentResult} with details about the payment. Note that this method will not
+   *     necessarily throw an exception if the payment failed. Payment status can be checked in.
+   * {@link PaymentResult#successfulPayment()}
+   * @throws IlpException If the given inputs were invalid.
+   */
+  public PaymentResult sendPayment(final PaymentRequest paymentRequest,
+                                   final String accessToken) throws IlpException {
+    return decoratedClient.sendPayment(paymentRequest, accessToken);
+  }
 }

--- a/src/main/java/io/xpring/ilp/IlpClientDecorator.java
+++ b/src/main/java/io/xpring/ilp/IlpClientDecorator.java
@@ -9,26 +9,26 @@ import io.xpring.ilp.model.PaymentResult;
  */
 public interface IlpClientDecorator {
 
-    /**
-     * Get the balance of the specified account on the connector.
-     *
-     * @param accountId The accountId to get the balance for.
-     * @param accessToken Access token used for authentication.
-     * @return An {@link AccountBalance} with account balances and denomination.
-     * @throws IlpException If the given inputs were invalid, the account doesn't exist, or authentication failed.
-     */
-    AccountBalance getBalance(final String accountId, final String accessToken) throws IlpException;
+  /**
+   * Get the balance of the specified account on the connector.
+   *
+   * @param accountId   The accountId to get the balance for.
+   * @param accessToken Access token used for authentication.
+   * @return An {@link AccountBalance} with account balances and denomination.
+   * @throws IlpException If the given inputs were invalid, the account doesn't exist, or authentication failed.
+   */
+  AccountBalance getBalance(final String accountId, final String accessToken) throws IlpException;
 
-    /**
-     * Send a payment from the given accountId to the destinationPaymentPointer payment pointer
-     *
-     * @param paymentRequest a {@link PaymentRequest} with parameters used to send a payment
-     * @param accessToken Access token of the sender
-     * @return A {@link PaymentResult} with details about the payment. Note that this method will not
-     *          necessarily throw an exception if the payment failed. Payment status can be checked in
-     *          {@link PaymentResult#successfulPayment()}
-     * @throws IlpException If the given inputs were invalid.
-     */
-    PaymentResult sendPayment(final PaymentRequest paymentRequest,
-                              final String accessToken) throws IlpException;
+  /**
+   * Send a payment from the given accountId to the destinationPaymentPointer payment pointer.
+   *
+   * @param paymentRequest a {@link PaymentRequest} with parameters used to send a payment
+   * @param accessToken    Access token of the sender
+   * @return A {@link PaymentResult} with details about the payment. Note that this method will not
+   *     necessarily throw an exception if the payment failed. Payment status can be checked in
+   *     {@link PaymentResult#successfulPayment()}
+   * @throws IlpException If the given inputs were invalid.
+   */
+  PaymentResult sendPayment(final PaymentRequest paymentRequest,
+                            final String accessToken) throws IlpException;
 }

--- a/src/main/java/io/xpring/ilp/IlpException.java
+++ b/src/main/java/io/xpring/ilp/IlpException.java
@@ -11,25 +11,32 @@ public class IlpException extends Exception {
   /**
    * Default Errors.
    */
-  public static final IlpException INTERNAL = new IlpException(IlpExceptionType.INTERNAL, "Internal error occurred on ILP network.");
-  public static final IlpException INVALID_ACCESS_TOKEN = new IlpException(
-    IlpExceptionType.INVALID_ACCESS_TOKEN,
-    "Access token was invalid. Access token should not start with \"Bearer\""
+  public static final IlpException INTERNAL = new IlpException(
+      IlpExceptionType.INTERNAL,
+      "Internal error occurred on ILP network."
   );
-  public static final IlpException INVALID_ARGUMENT = new IlpException(IlpExceptionType.INVALID_ARGUMENT, "Invalid argument in request body.");
-  public static final IlpException NOT_FOUND = new IlpException(IlpExceptionType.ACCOUNT_NOT_FOUND, "Account not found.");
-  public static final IlpException UNAUTHENTICATED = new IlpException(IlpExceptionType.UNAUTHENTICATED, "Authentication failed.");
-  public static final IlpException UNKNOWN = new IlpException(IlpExceptionType.UNKNOWN, "Unknown error occurred.");
+  public static final IlpException INVALID_ACCESS_TOKEN = new IlpException(
+      IlpExceptionType.INVALID_ACCESS_TOKEN,
+      "Access token was invalid. Access token should not start with \"Bearer\""
+  );
+  public static final IlpException INVALID_ARGUMENT =
+      new IlpException(IlpExceptionType.INVALID_ARGUMENT, "Invalid argument in request body.");
+  public static final IlpException NOT_FOUND =
+      new IlpException(IlpExceptionType.ACCOUNT_NOT_FOUND, "Account not found.");
+  public static final IlpException UNAUTHENTICATED =
+      new IlpException(IlpExceptionType.UNAUTHENTICATED, "Authentication failed.");
+  public static final IlpException UNKNOWN =
+      new IlpException(IlpExceptionType.UNKNOWN, "Unknown error occurred.");
 
   /**
-   * The type of this error
+   * The type of this error.
    */
   private IlpExceptionType type;
 
   /**
    * Construct a new instance of {@link IlpException}.
    *
-   * @param type the {@link IlpExceptionType} of this {@link IlpException}.
+   * @param type The {@link IlpExceptionType} of this {@link IlpException}.
    * @param message A detail message of what went wrong.
    */
   public IlpException(IlpExceptionType type, String message) {
@@ -48,10 +55,10 @@ public class IlpException extends Exception {
 
   /**
    * Construct an {@link IlpException} from a {@link StatusRuntimeException}.
-   *
+   * <p>
    * gRPC network calls will throw a {@link StatusRuntimeException} if something goes wrong.
    * This method allows for easy translation of {@link StatusRuntimeException}s to {@link IlpException}s.
-   *
+   * </p>
    * @param grpcException The {@link StatusRuntimeException} that was thrown by a gRPC network call.
    * @return A {@link IlpException} that is analogous to the grpcException thrown.
    */

--- a/src/main/java/io/xpring/ilp/grpc/IlpCredentials.java
+++ b/src/main/java/io/xpring/ilp/grpc/IlpCredentials.java
@@ -11,12 +11,10 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.Executor;
 
 /**
- * An extension of {@link CallCredentials} which provides a convenient way to
- * add an Authorization metadata header, and ensures every bearer token
- * going over the wire is prefixed with 'Bearer '
+ * An extension of {@link CallCredentials} which provides a convenient way to add an Authorization metadata header, and
+ * ensures every bearer token going over the wire is prefixed with 'Bearer '.
  */
 public class IlpCredentials extends CallCredentials {
-
   public static final String BEARER_PREFIX = "Bearer ";
   private static Logger LOGGER = LoggerFactory.getLogger(IlpCredentials.class);
 
@@ -50,12 +48,13 @@ public class IlpCredentials extends CallCredentials {
   }
 
   @Override
-  public void thisUsesUnstableApi() {}
+  public void thisUsesUnstableApi() {
+  }
 
   /**
-   * Adds an Authorization header to the request Metadata, prepending 'Bearer ' to the access token
+   * Adds an Authorization header to the request Metadata, prepending 'Bearer ' to the access token.
    *
-   * @param applier A {@link io.grpc.CallCredentials.MetadataApplier}
+   * @param applier     A {@link io.grpc.CallCredentials.MetadataApplier}
    * @param accessToken An access token that does not start with 'Bearer '
    */
   protected void applyToken(MetadataApplier applier, String accessToken) {

--- a/src/main/java/io/xpring/ilp/model/AccountBalance.java
+++ b/src/main/java/io/xpring/ilp/model/AccountBalance.java
@@ -7,7 +7,7 @@ import org.immutables.value.Value;
 import java.math.BigInteger;
 
 /**
- * Response object for requests to get an account's balance
+ * Response object for requests to get an account's balance.
  */
 @Value.Immutable
 public interface AccountBalance {
@@ -17,12 +17,12 @@ public interface AccountBalance {
   }
 
   /**
-   * @return The accountId for this account balance.
+   * The accountId for this account balance.
    */
   String accountId();
 
   /**
-   * Currency code or other asset identifier that this account's balances will be denominated in
+   * Currency code or other asset identifier that this account's balances will be denominated in.
    */
   String assetCode();
 
@@ -63,15 +63,15 @@ public interface AccountBalance {
    * #netBalance()}, and is generally never negative.
    *
    * @return An {@link BigInteger} representing the number of units the counterparty (i.e., owner of this account) has
-   * prepaid with this Connector.
+   *     prepaid with this Connector.
    */
   BigInteger prepaidAmount();
 
   /**
-   * Constructs an {@link AccountBalance} from a {@link GetBalanceResponse}
+   * Constructs an {@link AccountBalance} from a {@link GetBalanceResponse}.
    *
    * @param getBalanceResponse a {@link GetBalanceResponse} (protobuf object) whose field values will be used
-   *                           to construct an {@link AccountBalance}
+   *                           to construct an {@link AccountBalance}.
    * @return an {@link AccountBalance} with its fields set via the analogous protobuf fields.
    */
   static AccountBalance from(GetBalanceResponse getBalanceResponse) {

--- a/src/main/java/io/xpring/ilp/model/PaymentRequest.java
+++ b/src/main/java/io/xpring/ilp/model/PaymentRequest.java
@@ -6,7 +6,7 @@ import com.google.common.primitives.UnsignedLong;
 import org.immutables.value.Value;
 
 /**
- * An immutable interface which can be used to send a payment request to a connector
+ * An immutable interface which can be used to send a payment request to a connector.
  */
 public interface PaymentRequest {
 
@@ -28,22 +28,20 @@ public interface PaymentRequest {
    * This payment pointer will be the identifier for the account of the recipient of this payment on the ILP
    * network.
    *
-   * @see "https://github.com/interledger/rfcs/blob/master/0026-payment-pointers/0026-payment-pointers.md"
-   *
    * @return A {@link String} conforming to the Payment Pointer RFC which identifies an account on the ILP network
+   * @see "https://github.com/interledger/rfcs/blob/master/0026-payment-pointers/0026-payment-pointers.md"
    */
   String destinationPaymentPointer();
 
   /**
-   * @return The accountID of the sender.
+   * The accountID of the sender.
    */
   String senderAccountId();
 
   /**
-   * Constructs a {@link PaymentRequest} (non-proto) from a {@link SendPaymentRequest}
+   * Constructs a {@link PaymentRequest} (non-proto) from a {@link SendPaymentRequest}.
    *
-   * @return A {@link SendPaymentRequest} populated with the analogous fields in
-   *          a {@link PaymentRequest}
+   * @return A {@link SendPaymentRequest} populated with the analogous fields in a {@link PaymentRequest}.
    */
   SendPaymentRequest toProto();
 
@@ -53,10 +51,10 @@ public interface PaymentRequest {
     @Override
     public SendPaymentRequest toProto() {
       return SendPaymentRequest.newBuilder()
-        .setAmount(this.amount().longValue())
-        .setDestinationPaymentPointer(this.destinationPaymentPointer())
-        .setAccountId(this.senderAccountId())
-        .build();
+          .setAmount(this.amount().longValue())
+          .setDestinationPaymentPointer(this.destinationPaymentPointer())
+          .setAccountId(this.senderAccountId())
+          .build();
     }
   }
 }

--- a/src/main/java/io/xpring/ilp/model/PaymentResult.java
+++ b/src/main/java/io/xpring/ilp/model/PaymentResult.java
@@ -6,7 +6,7 @@ import com.google.common.primitives.UnsignedLong;
 import org.immutables.value.Value;
 
 /**
- * A response object containing details about a requested payment
+ * A response object containing details about a requested payment.
  */
 @Value.Immutable
 public interface PaymentResult {
@@ -46,17 +46,17 @@ public interface PaymentResult {
   boolean successfulPayment();
 
   /**
-   * Constructs a {@link PaymentResult} from a protobuf {@link SendPaymentResponse}
+   * Constructs a {@link PaymentResult} from a protobuf {@link SendPaymentResponse}.
    *
    * @param protoResponse a {@link SendPaymentResponse} to be converted
    * @return a {@link PaymentResult} with fields populated using the analogous fields in the proto object
    */
   static PaymentResult from(SendPaymentResponse protoResponse) {
     return PaymentResult.builder()
-      .originalAmount(UnsignedLong.valueOf(protoResponse.getOriginalAmount()))
-      .amountDelivered(UnsignedLong.valueOf(protoResponse.getAmountDelivered()))
-      .amountSent(UnsignedLong.valueOf(protoResponse.getAmountSent()))
-      .successfulPayment(protoResponse.getSuccessfulPayment())
-      .build();
+        .originalAmount(UnsignedLong.valueOf(protoResponse.getOriginalAmount()))
+        .amountDelivered(UnsignedLong.valueOf(protoResponse.getAmountDelivered()))
+        .amountSent(UnsignedLong.valueOf(protoResponse.getAmountSent()))
+        .successfulPayment(protoResponse.getSuccessfulPayment())
+        .build();
   }
 }

--- a/src/main/java/io/xpring/payid/PayIDClient.java
+++ b/src/main/java/io/xpring/payid/PayIDClient.java
@@ -4,7 +4,6 @@ import org.interledger.spsp.PaymentPointer;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.reflect.TypeToken;
-
 import io.xpring.common.XRPLNetwork;
 import io.xpring.payid.generated.ApiClient;
 import io.xpring.payid.generated.ApiException;
@@ -22,99 +21,108 @@ import java.util.Map;
  * Implements interaction with a PayID service.
  * Warning:  This class is experimental and should not be used in production applications.
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class PayIDClient implements PayIDClientInterface {
-    /**
-     * The network this PayID client resolves on.
-     */
-    private XRPLNetwork network;
+  /**
+   * The network this PayID client resolves on.
+   */
+  private XRPLNetwork network;
 
-    /**
-     * Whether to enable SSL Verification.
-     */
-    private boolean enableSSLVerification;
+  /**
+   * Whether to enable SSL Verification.
+   */
+  private boolean enableSSLVerification;
 
-    /**
-     * Initialize a new PayIDClient.
-     *
-     * @param network The network that addresses will be resolved on.
-     */
-    public PayIDClient(XRPLNetwork network) {
-        this.network = network;
-        this.enableSSLVerification = true;
+  /**
+   * Initialize a new PayIDClient.
+   *
+   * @param network The network that addresses will be resolved on.
+   */
+  public PayIDClient(XRPLNetwork network) {
+    this.network = network;
+    this.enableSSLVerification = true;
+  }
+
+  /**
+   * Set whether to enable or disable SSL verification.
+   * <p>
+   * Exposed for testing purposes.
+   * </p>
+   */
+  @VisibleForTesting
+  public void setEnableSSLVerification(boolean enableSSLVerification) {
+    this.enableSSLVerification = enableSSLVerification;
+  }
+
+  /**
+   * Resolve the given PayID to an XRP Address.
+   * <p>
+   * Note: The returned value will always be in an X-Address format.
+   * </p>
+   *
+   * @param payID The payID to resolve for an address.
+   * @return An XRP address representing the given PayID.
+   */
+  public String xrpAddressForPayID(String payID) throws PayIDException {
+    PaymentPointer paymentPointer = PayIDUtils.parsePayID(payID);
+    if (paymentPointer == null) {
+      throw PayIDException.invalidPaymentPointerException;
     }
 
-    /**
-     * Set whether to enable or disable SSL verification.
-     *
-     * Exposed for testing purposes.
-     */
-    @VisibleForTesting
-    public void setEnableSSLVerification(boolean enableSSLVerification) {
-        this.enableSSLVerification = enableSSLVerification;
+    ApiClient apiClient = new ApiClient();
+    apiClient.setBasePath("https://" + paymentPointer.host());
+    apiClient.setVerifyingSsl(enableSSLVerification);
+
+    String path = paymentPointer.path().substring(1);
+    final String[] localVarAccepts = {
+        "application/xrpl-" + this.network.getNetworkName() + "+json"
+    };
+
+    // NOTE: Swagger produces a higher level client that does not require this level of configuration,
+    // however access to Accept headers is not available unless we access the underlying class.
+    // TODO(keefertaylor): Factor this out to a helper function to make it clear which inputs matter.
+
+    String localVarPath = "/" + apiClient.escapeString(path.toString());
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+    if (localVarAccept != null) {
+      localVarHeaderParams.put("Accept", localVarAccept);
     }
+    final String[] localVarContentTypes = {};
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+    localVarHeaderParams.put("Content-Type", localVarContentType);
+    String[] localVarAuthNames = new String[]{};
 
-    /**
-     * Resolve the given PayID to an XRP Address.
-     *
-     * Note: The returned value will always be in an X-Address format.
-     *
-     * @param payID The payID to resolve for an address.
-     * @return An XRP address representing the given PayID.
-     */
-    public String xrpAddressForPayID(String payID) throws PayIDException {
-        PaymentPointer paymentPointer = PayIDUtils.parsePayID(payID);
-        if (paymentPointer == null) {
-            throw PayIDException.invalidPaymentPointerException;
-        }
-
-        ApiClient apiClient = new ApiClient();
-        apiClient.setBasePath("https://" + paymentPointer.host());
-        apiClient.setVerifyingSsl(enableSSLVerification);
-
-        String path = paymentPointer.path().substring(1);
-        final String[] localVarAccepts = {
-                "application/xrpl-" + this.network.getNetworkName() + "+json"
-        };
-
-        // NOTE: Swagger produces a higher level client that does not require this level of configuration,
-        // however access to Accept headers is not available unless we access the underlying class.
-        // TODO(keefertaylor): Factor this out to a helper function to make it clear which inputs matter.
-
-        String localVarPath = "/" + apiClient.escapeString(path.toString());
-        List<Pair> localVarQueryParams = new ArrayList<Pair>();
-        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-        final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-        if (localVarAccept != null) localVarHeaderParams.put("Accept", localVarAccept);
-        final String[] localVarContentTypes = {};
-        final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-        localVarHeaderParams.put("Content-Type", localVarContentType);
-        String[] localVarAuthNames = new String[] {};
-
-        try {
-            com.squareup.okhttp.Call call = apiClient.buildCall(
-                    localVarPath,
-                    "GET",
-                    localVarQueryParams,
-                    localVarCollectionQueryParams,
-                    null,
-                    localVarHeaderParams,
-                    localVarFormParams,
-                    localVarAuthNames,
-                    null
-            );
-            Type localVarReturnType = new TypeToken<PaymentInformation>(){}.getType();
-            ApiResponse<PaymentInformation> response = apiClient.execute(call, localVarReturnType);
-            PaymentInformation result = response.getData();
-            return result.getAddressDetails().getAddress();
-        } catch (ApiException exception) {
-            int code = exception.getCode();
-            if (code == 404) {
-                throw new PayIDException(PayIDExceptionType.MAPPING_NOT_FOUND, "Could not resolve " + payID + " on network " + this.network.getNetworkName());
-            } else {
-                throw new PayIDException(PayIDExceptionType.UNEXPECTED_RESPONSE, code + ": " + exception.getMessage());
-            }
-        }
+    try {
+      com.squareup.okhttp.Call call = apiClient.buildCall(
+          localVarPath,
+          "GET",
+          localVarQueryParams,
+          localVarCollectionQueryParams,
+          null,
+          localVarHeaderParams,
+          localVarFormParams,
+          localVarAuthNames,
+          null
+      );
+      Type localVarReturnType = new TypeToken<PaymentInformation>() {
+      }.getType();
+      ApiResponse<PaymentInformation> response = apiClient.execute(call, localVarReturnType);
+      PaymentInformation result = response.getData();
+      return result.getAddressDetails().getAddress();
+    } catch (ApiException exception) {
+      int code = exception.getCode();
+      if (code == 404) {
+        throw new PayIDException(
+            PayIDExceptionType.MAPPING_NOT_FOUND,
+            "Could not resolve " + payID + " on network " + this.network.getNetworkName()
+        );
+      } else {
+        throw new PayIDException(PayIDExceptionType.UNEXPECTED_RESPONSE, code + ": " + exception.getMessage());
+      }
     }
+  }
 }

--- a/src/main/java/io/xpring/payid/PayIDClientInterface.java
+++ b/src/main/java/io/xpring/payid/PayIDClientInterface.java
@@ -3,13 +3,14 @@ package io.xpring.payid;
 /**
  * An interface for a PayID client.
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public interface PayIDClientInterface {
-    /**
-     * Resolve the given PayID to an XRP Address.
-     *
-     * @param payID The payID to resolve for an address.
-     * @return An XRP address representing the given PayID.
-     */
-    String xrpAddressForPayID(String payID) throws PayIDException;
+  /**
+   * Resolve the given PayID to an XRP Address.
+   *
+   * @param payID The payID to resolve for an address.
+   * @return An XRP address representing the given PayID.
+   */
+  String xrpAddressForPayID(String payID) throws PayIDException;
 }
 

--- a/src/main/java/io/xpring/payid/PayIDException.java
+++ b/src/main/java/io/xpring/payid/PayIDException.java
@@ -1,29 +1,34 @@
 package io.xpring.payid;
 
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class PayIDException extends Exception {
-    /** Static exception for when a classic address is passed to an X-Address API. */
-    public static PayIDException invalidPaymentPointerException =
-            new PayIDException(PayIDExceptionType.INVALID_PAYMENT_POINTER, "Invalid Payment Pointer");
+  /**
+   * Static exception for when a classic address is passed to an X-Address API.
+   */
+  public static PayIDException invalidPaymentPointerException =
+      new PayIDException(PayIDExceptionType.INVALID_PAYMENT_POINTER, "Invalid Payment Pointer");
 
-    /** The type of exception. */
-    private PayIDExceptionType type;
+  /**
+   * The type of exception.
+   */
+  private PayIDExceptionType type;
 
-    /**
-     * Create a new exception.
-     *
-     * @param type The type of exception.
-     * @param message The message to to include in the exception
-     */
-    public PayIDException(PayIDExceptionType type, String message) {
-        super(message);
+  /**
+   * Create a new exception.
+   *
+   * @param type    The type of exception.
+   * @param message The message to to include in the exception
+   */
+  public PayIDException(PayIDExceptionType type, String message) {
+    super(message);
 
-        this.type = type;
-    }
+    this.type = type;
+  }
 
-    /**
-     * @return The exception type.
-     */
-    public PayIDExceptionType getType() {
-        return this.type;
-    }
+  /**
+   * The exception type.
+   */
+  public PayIDExceptionType getType() {
+    return this.type;
+  }
 }

--- a/src/main/java/io/xpring/payid/PayIDExceptionType.java
+++ b/src/main/java/io/xpring/payid/PayIDExceptionType.java
@@ -1,5 +1,9 @@
 package io.xpring.payid;
 
+/**
+ * Types of {@link PayIDException}s.
+ */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public enum PayIDExceptionType {
     INVALID_PAYMENT_POINTER,
     MAPPING_NOT_FOUND,

--- a/src/main/java/io/xpring/payid/PayIDUtils.java
+++ b/src/main/java/io/xpring/payid/PayIDUtils.java
@@ -5,24 +5,26 @@ import org.interledger.spsp.PaymentPointer;
 /**
  * Provides utilities for PayID.
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class PayIDUtils {
 
-    /**
-     * Parse a PayID to a payment pointer object
-     *
-     * @param payID The input payID..
-     * @return A PaymentPointer object if the input was valid, otherwise undefined.
-     */
-    public static PaymentPointer parsePayID(String payID) {
-        try {
-            return PaymentPointer.of(payID);
-        } catch (Exception e) {
-            return null;
-        }
+  /**
+   * Parse a PayID to a payment pointer object.
+   *
+   * @param payID The input payID..
+   * @return A PaymentPointer object if the input was valid, otherwise undefined.
+   */
+  public static PaymentPointer parsePayID(String payID) {
+    try {
+      return PaymentPointer.of(payID);
+    } catch (Exception e) {
+      return null;
     }
+  }
 
-    /**
-     * Please do not instantiate this static utility class.
-     */
-    private PayIDUtils() {}
+  /**
+   * Please do not instantiate this static utility class.
+   */
+  private PayIDUtils() {
+  }
 }

--- a/src/main/java/io/xpring/xrpl/ClassicAddress.java
+++ b/src/main/java/io/xpring/xrpl/ClassicAddress.java
@@ -9,19 +9,19 @@ import java.util.Optional;
  */
 @Value.Immutable
 public interface ClassicAddress {
-    /**
-     * @return The address component of the classic address.
-     */
-    public String address();
+  /**
+   * The address component of the classic address.
+   */
+  public String address();
 
-    /**
-     * @return The tag component of the classic address.
-     */
-    public Optional<Integer> tag();
+  /**
+   * The tag component of the classic address.
+   */
+  public Optional<Integer> tag();
 
-    /**
-     * @return A boolean indicating whether this address is for use on a test network.
-     */
-    public boolean isTest();
+  /**
+   * A boolean indicating whether this address is for use on a test network.
+   */
+  public boolean isTest();
 
 }

--- a/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
+++ b/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
@@ -3,14 +3,33 @@ package io.xpring.xrpl;
 import com.google.protobuf.ByteString;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import io.xpring.xrpl.model.XRPTransaction;
 import io.grpc.StatusRuntimeException;
+import io.xpring.xrpl.model.XRPTransaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xrpl.rpc.v1.*;
-import org.xrpl.rpc.v1.Common.*;
+import org.xrpl.rpc.v1.AccountAddress;
+import org.xrpl.rpc.v1.AccountRoot;
 import org.xrpl.rpc.v1.Common.Account;
 import org.xrpl.rpc.v1.Common.Amount;
+import org.xrpl.rpc.v1.Common.Destination;
+import org.xrpl.rpc.v1.Common.DestinationTag;
+import org.xrpl.rpc.v1.Common.LastLedgerSequence;
+import org.xrpl.rpc.v1.Common.SigningPublicKey;
+import org.xrpl.rpc.v1.CurrencyAmount;
+import org.xrpl.rpc.v1.GetAccountInfoRequest;
+import org.xrpl.rpc.v1.GetAccountInfoResponse;
+import org.xrpl.rpc.v1.GetAccountTransactionHistoryRequest;
+import org.xrpl.rpc.v1.GetAccountTransactionHistoryResponse;
+import org.xrpl.rpc.v1.GetFeeRequest;
+import org.xrpl.rpc.v1.GetFeeResponse;
+import org.xrpl.rpc.v1.GetTransactionRequest;
+import org.xrpl.rpc.v1.GetTransactionResponse;
+import org.xrpl.rpc.v1.Payment;
+import org.xrpl.rpc.v1.SubmitTransactionRequest;
+import org.xrpl.rpc.v1.SubmitTransactionResponse;
+import org.xrpl.rpc.v1.Transaction;
+import org.xrpl.rpc.v1.XRPDropsAmount;
+import org.xrpl.rpc.v1.XRPLedgerAPIServiceGrpc;
 import org.xrpl.rpc.v1.XRPLedgerAPIServiceGrpc.XRPLedgerAPIServiceBlockingStub;
 
 import java.math.BigInteger;
@@ -24,281 +43,288 @@ import java.util.concurrent.TimeUnit;
  *
  * @see "https://xrpl.org"
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class DefaultXRPClient implements XRPClientDecorator {
-    // A margin to pad the current ledger sequence with when submitting transactions.
-    private static final int MAX_LEDGER_VERSION_OFFSET = 10;
+  // A margin to pad the current ledger sequence with when submitting transactions.
+  private static final int MAX_LEDGER_VERSION_OFFSET = 10;
 
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    // Channel is the abstraction to connect to a service endpoint
-    private final XRPLedgerAPIServiceBlockingStub stub;
+  // Channel is the abstraction to connect to a service endpoint
+  private final XRPLedgerAPIServiceBlockingStub stub;
 
-    /**
-     * No-args Constructor.
-     */
-    public DefaultXRPClient(String grpcURL) {
-        this(ManagedChannelBuilder
-                .forTarget(grpcURL)
-                .usePlaintext()
-                .build()
-        );
-    }
+  /**
+   * No-args Constructor.
+   */
+  DefaultXRPClient(String grpcURL) {
+    this(ManagedChannelBuilder
+        .forTarget(grpcURL)
+        .usePlaintext()
+        .build()
+    );
+  }
 
-    /**
-     * Required-args Constructor, currently for testing.
-     *
-     * @param channel A {@link ManagedChannel}.
-     */
-    DefaultXRPClient(final ManagedChannel channel) {
-        // It is up to the client to determine whether to block the call. Here we create a blocking stub, but an async
-        // stub, or an async stub with Future are always possible.
-        this.stub = XRPLedgerAPIServiceGrpc.newBlockingStub(channel);
+  /**
+   * Required-args Constructor, currently for testing.
+   *
+   * @param channel A {@link ManagedChannel}.
+   */
+  DefaultXRPClient(final ManagedChannel channel) {
+    // It is up to the client to determine whether to block the call. Here we create a blocking stub, but an async
+    // stub, or an async stub with Future are always possible.
+    this.stub = XRPLedgerAPIServiceGrpc.newBlockingStub(channel);
 
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            channel.shutdown();
-            try {
-                channel.awaitTermination(5, TimeUnit.SECONDS);
-            }
-            catch (Exception timedOutException) {
-                try {
-                    channel.shutdownNow();
-                }
-                catch (Exception e) {
-                    // nothing more can be done
-                }
-            }
-        }));
-    }
-
-    /**
-     * Get the balance of the specified account on the XRP Ledger.
-     *
-     * @param xrplAccountAddress The X-Address to retrieve the balance for.
-     * @return A {@link BigInteger} with the number of drops in this account.
-     * @throws XRPException If the given inputs were invalid.
-     */
-    public BigInteger getBalance(final String xrplAccountAddress) throws XRPException {
-        if (!Utils.isValidXAddress(xrplAccountAddress)) {
-            throw XRPException.xAddressRequiredException;
-        }
-        ClassicAddress classicAddress = Utils.decodeXAddress(xrplAccountAddress);
-
-        AccountRoot accountData = this.getAccountData(classicAddress.address());
-
-        return BigInteger.valueOf(accountData.getBalance().getValue().getXrpAmount().getDrops());
-    }
-
-    /**
-     * Retrieve the transaction status for a Payment given transaction hash.
-     *
-     * Note: This method will only work for Payment type transactions which do not have the tf_partial_payment attribute set.
-     * See: https://xrpl.org/payment.html#payment-flags
-     *
-     * @param transactionHash The hash of the transaction.
-     * @return The status of the given transaction.
-     */
-    public TransactionStatus getPaymentStatus(String transactionHash) throws XRPException {
-        Objects.requireNonNull(transactionHash);
-
-        RawTransactionStatus transactionStatus = getRawTransactionStatus(transactionHash);
-
-        // Return PENDING if the transaction is not validated.
-        if (!transactionStatus.getValidated()) {
-            return TransactionStatus.PENDING;
-        }
-
-        return transactionStatus.getTransactionStatusCode().startsWith("tes") ? TransactionStatus.SUCCEEDED : TransactionStatus.FAILED;
-    }
-
-    /**
-     * Transact XRP between two accounts on the ledger.
-     *
-     * @param drops The number of drops of XRP to send.
-     * @param destinationAddress The X-Address to send the XRP to.
-     * @param sourceWallet The {@link Wallet} which holds the XRP.
-     * @return A transaction hash for the payment.
-     * @throws XRPException If the given inputs were invalid.
-     */
-    public String send(
-            final BigInteger drops,
-            final String destinationAddress,
-            final Wallet sourceWallet
-    ) throws XRPException {
-        Objects.requireNonNull(drops);
-        Objects.requireNonNull(destinationAddress);
-        Objects.requireNonNull(sourceWallet);
-
-        if (!Utils.isValidXAddress(destinationAddress)) {
-            throw XRPException.xAddressRequiredException;
-        }
-
-        ClassicAddress destinationClassicAddress = Utils.decodeXAddress(destinationAddress);
-        ClassicAddress sourceClassicAddress = Utils.decodeXAddress(sourceWallet.getAddress());
-
-        AccountRoot accountData = this.getAccountData(sourceClassicAddress.address());
-        XRPDropsAmount fee = this.getMinimumFee();
-        int lastValidatedLedgerSequence = this.getLatestValidatedLedgerSequence();
-
-        AccountAddress destinationAccountAddress = AccountAddress.newBuilder()
-                .setAddress(destinationClassicAddress.address())
-                .build();
-        AccountAddress sourceAccountAddress = AccountAddress.newBuilder()
-                .setAddress(sourceClassicAddress.address())
-                .build();
-
-        XRPDropsAmount dropsAmount = XRPDropsAmount.newBuilder().setDrops(drops.longValue()).build();
-        CurrencyAmount currencyAmount = CurrencyAmount.newBuilder().setXrpAmount(dropsAmount).build();
-        Amount amount = Amount.newBuilder().setValue(currencyAmount).build();
-        Destination destination = Destination.newBuilder().setValue(destinationAccountAddress).build();
-
-        Payment.Builder paymentBuilder = Payment.newBuilder()
-                .setAmount(amount)
-                .setDestination(destination);
-        if (destinationClassicAddress.tag().isPresent()) {
-            DestinationTag destinationTag = DestinationTag.newBuilder()
-                    .setValue(destinationClassicAddress.tag().get())
-                    .build();
-            paymentBuilder.setDestinationTag(destinationTag);
-        }
-
-        Payment payment = paymentBuilder.build();
-
-        byte [] signingPublicKeyBytes = Utils.hexStringToByteArray(sourceWallet.getPublicKey());
-        int lastLedgerSequenceInt = lastValidatedLedgerSequence + MAX_LEDGER_VERSION_OFFSET;
-
-        Account sourceAccount = Account.newBuilder().setValue(sourceAccountAddress).build();
-        LastLedgerSequence lastLedgerSequence = LastLedgerSequence.newBuilder().setValue(lastLedgerSequenceInt).build();
-        SigningPublicKey signingPublicKey = SigningPublicKey.newBuilder()
-                .setValue(ByteString.copyFrom(signingPublicKeyBytes))
-                .build();
-
-        Transaction transaction = Transaction.newBuilder()
-                .setAccount(sourceAccount)
-                .setFee(fee)
-                .setSequence(accountData.getSequence())
-                .setPayment(payment)
-                .setLastLedgerSequence(lastLedgerSequence)
-                .setSigningPublicKey(signingPublicKey)
-                .build();
-
-        byte [] signedTransaction = Signer.signTransaction(transaction, sourceWallet);
-
-        SubmitTransactionRequest request = SubmitTransactionRequest.newBuilder()
-                .setSignedTransaction(ByteString.copyFrom(signedTransaction))
-                .build();
-
-        SubmitTransactionResponse response = this.stub.submitTransaction(request);
-
-        byte [] hashBytes = response.getHash().toByteArray();
-        return Utils.byteArrayToHex(hashBytes);
-    }
-
-    /**
-     * Return the history of payments for the given account.
-     *
-     * Note: This method only works for payment type transactions. See "https://xrpl.org/payment.html".
-     * Note: This method only returns the history that is contained on the remote node,
-     *       which may not contain a full history of the network.
-     *
-     * @param address: The address (account) for which to retrieve payment history.
-     * @throws XRPException If there was a problem communicating with the XRP Ledger.
-     * @return An array of transactions associated with the account.
-     */
-    public List<XRPTransaction> paymentHistory(String address) throws XRPException {
-        if (!Utils.isValidXAddress(address)) {
-            throw XRPException.xAddressRequiredException;
-        }
-        ClassicAddress classicAddress = Utils.decodeXAddress(address);
-
-        AccountAddress account = AccountAddress.newBuilder().setAddress(classicAddress.address()).build();
-
-        GetAccountTransactionHistoryRequest request = GetAccountTransactionHistoryRequest.newBuilder()
-                .setAccount(account)
-                .build();
-        GetAccountTransactionHistoryResponse transactionHistory = stub.getAccountTransactionHistory(request);
-
-        List<GetTransactionResponse> getTransactionResponses = transactionHistory.getTransactionsList();
-
-        // Filter transactions to payments only and convert them to XRPTransactions.
-        // If a payment transaction fails conversion, throw an error.
-        List<XRPTransaction> payments = new ArrayList<XRPTransaction>();
-        for (GetTransactionResponse transactionResponse : getTransactionResponses) {
-            Transaction transaction = transactionResponse.getTransaction();
-            switch (transaction.getTransactionDataCase()) {
-                case PAYMENT: {
-                    XRPTransaction xrpTransaction = XRPTransaction.from(transaction);
-                    if (xrpTransaction == null) {
-                        throw XRPException.paymentConversionFailure;
-                    } else {
-                        payments.add(xrpTransaction);
-                    }
-                    break;
-                }
-                default: {
-                    // Intentionally do nothing, non-payment type transactions are ignored.
-                }
-            }
-        }
-        return payments;
-    }
-
-    /**
-     * Check if an address exists on the XRP Ledger.
-     *
-     * @param address The address to check the existence of.
-     * @return A boolean if the account is on the XRPLedger.
-     */
-    @Override
-    public boolean accountExists(String address) throws XRPException {
-        if (!Utils.isValidXAddress(address)) {
-            throw XRPException.xAddressRequiredException;
-        }
+    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+      channel.shutdown();
+      try {
+        channel.awaitTermination(5, TimeUnit.SECONDS);
+      } catch (Exception timedOutException) {
         try {
-            this.getBalance(address);
-            return true;
-        } catch (StatusRuntimeException exception) {
-            if (exception.getStatus().getCode() == io.grpc.Status.NOT_FOUND.getCode()) {
-                return false;
-            }
-            throw exception; // re-throw if code other than NOT_FOUND
-        } catch (Exception exception) {
-            throw exception; // re-throw any other type of exception
+          channel.shutdownNow();
+        } catch (Exception e) {
+          // nothing more can be done
         }
+      }
+    }));
+  }
+
+  /**
+   * Get the balance of the specified account on the XRP Ledger.
+   *
+   * @param xrplAccountAddress The X-Address to retrieve the balance for.
+   * @return A {@link BigInteger} with the number of drops in this account.
+   * @throws XRPException If the given inputs were invalid.
+   */
+  public BigInteger getBalance(final String xrplAccountAddress) throws XRPException {
+    if (!Utils.isValidXAddress(xrplAccountAddress)) {
+      throw XRPException.xAddressRequiredException;
+    }
+    ClassicAddress classicAddress = Utils.decodeXAddress(xrplAccountAddress);
+
+    AccountRoot accountData = this.getAccountData(classicAddress.address());
+
+    return BigInteger.valueOf(accountData.getBalance().getValue().getXrpAmount().getDrops());
+  }
+
+  /**
+   * Retrieve the transaction status for a Payment given transaction hash.
+   *
+   * <p>
+   * Note: This method will only work for Payment type transactions which do not have the tf_partial_payment attribute
+   * set.
+   *
+   * See: https://xrpl.org/payment.html#payment-flags
+   * </p>
+   *
+   * @param transactionHash The hash of the transaction.
+   * @return The status of the given transaction.
+   */
+  public TransactionStatus getPaymentStatus(String transactionHash) throws XRPException {
+    Objects.requireNonNull(transactionHash);
+
+    RawTransactionStatus transactionStatus = getRawTransactionStatus(transactionHash);
+
+    // Return PENDING if the transaction is not validated.
+    if (!transactionStatus.getValidated()) {
+      return TransactionStatus.PENDING;
     }
 
-    @Override
-    public int getLatestValidatedLedgerSequence() throws XRPException {
-        return this.getFeeResponse().getLedgerCurrentIndex();
+    return transactionStatus.getTransactionStatusCode().startsWith("tes")
+        ? TransactionStatus.SUCCEEDED
+        : TransactionStatus.FAILED;
+  }
+
+  /**
+   * Transact XRP between two accounts on the ledger.
+   *
+   * @param drops              The number of drops of XRP to send.
+   * @param destinationAddress The X-Address to send the XRP to.
+   * @param sourceWallet       The {@link Wallet} which holds the XRP.
+   * @return A transaction hash for the payment.
+   * @throws XRPException If the given inputs were invalid.
+   */
+  public String send(
+      final BigInteger drops,
+      final String destinationAddress,
+      final Wallet sourceWallet
+  ) throws XRPException {
+    Objects.requireNonNull(drops);
+    Objects.requireNonNull(destinationAddress);
+    Objects.requireNonNull(sourceWallet);
+
+    if (!Utils.isValidXAddress(destinationAddress)) {
+      throw XRPException.xAddressRequiredException;
     }
 
-    @Override
-    public RawTransactionStatus getRawTransactionStatus(String transactionHash) throws XRPException {
-        Objects.requireNonNull(transactionHash);
+    ClassicAddress destinationClassicAddress = Utils.decodeXAddress(destinationAddress);
+    ClassicAddress sourceClassicAddress = Utils.decodeXAddress(sourceWallet.getAddress());
 
-        byte [] transactionHashBytes = Utils.hexStringToByteArray(transactionHash);
-        ByteString transactionHashByteString = ByteString.copyFrom(transactionHashBytes);
-        GetTransactionRequest request = GetTransactionRequest.newBuilder().setHash(transactionHashByteString).build();
+    AccountRoot accountData = this.getAccountData(sourceClassicAddress.address());
+    XRPDropsAmount fee = this.getMinimumFee();
+    int lastValidatedLedgerSequence = this.getLatestValidatedLedgerSequence();
 
-        GetTransactionResponse response = this.stub.getTransaction(request);
+    AccountAddress destinationAccountAddress = AccountAddress.newBuilder()
+        .setAddress(destinationClassicAddress.address())
+        .build();
+    AccountAddress sourceAccountAddress = AccountAddress.newBuilder()
+        .setAddress(sourceClassicAddress.address())
+        .build();
 
-        return new RawTransactionStatus(response);
+    XRPDropsAmount dropsAmount = XRPDropsAmount.newBuilder().setDrops(drops.longValue()).build();
+    CurrencyAmount currencyAmount = CurrencyAmount.newBuilder().setXrpAmount(dropsAmount).build();
+    Amount amount = Amount.newBuilder().setValue(currencyAmount).build();
+    Destination destination = Destination.newBuilder().setValue(destinationAccountAddress).build();
+
+    Payment.Builder paymentBuilder = Payment.newBuilder()
+        .setAmount(amount)
+        .setDestination(destination);
+    if (destinationClassicAddress.tag().isPresent()) {
+      DestinationTag destinationTag = DestinationTag.newBuilder()
+          .setValue(destinationClassicAddress.tag().get())
+          .build();
+      paymentBuilder.setDestinationTag(destinationTag);
     }
 
-    private XRPDropsAmount getMinimumFee() {
-        return this.getFeeResponse().getFee().getMinimumFee();
+    Payment payment = paymentBuilder.build();
+
+    byte[] signingPublicKeyBytes = Utils.hexStringToByteArray(sourceWallet.getPublicKey());
+    int lastLedgerSequenceInt = lastValidatedLedgerSequence + MAX_LEDGER_VERSION_OFFSET;
+
+    Account sourceAccount = Account.newBuilder().setValue(sourceAccountAddress).build();
+    LastLedgerSequence lastLedgerSequence = LastLedgerSequence.newBuilder().setValue(lastLedgerSequenceInt).build();
+    SigningPublicKey signingPublicKey = SigningPublicKey.newBuilder()
+        .setValue(ByteString.copyFrom(signingPublicKeyBytes))
+        .build();
+
+    Transaction transaction = Transaction.newBuilder()
+        .setAccount(sourceAccount)
+        .setFee(fee)
+        .setSequence(accountData.getSequence())
+        .setPayment(payment)
+        .setLastLedgerSequence(lastLedgerSequence)
+        .setSigningPublicKey(signingPublicKey)
+        .build();
+
+    byte[] signedTransaction = Signer.signTransaction(transaction, sourceWallet);
+
+    SubmitTransactionRequest request = SubmitTransactionRequest.newBuilder()
+        .setSignedTransaction(ByteString.copyFrom(signedTransaction))
+        .build();
+
+    SubmitTransactionResponse response = this.stub.submitTransaction(request);
+
+    byte[] hashBytes = response.getHash().toByteArray();
+    return Utils.byteArrayToHex(hashBytes);
+  }
+
+  /**
+   * Return the history of payments for the given account.
+   *
+   * <p>
+   * Note: This method only works for payment type transactions. See "https://xrpl.org/payment.html".
+   * Note: This method only returns the history that is contained on the remote node,
+   * which may not contain a full history of the network.
+   * </p>
+   *
+   * @param address The address (account) for which to retrieve payment history.
+   * @return An array of transactions associated with the account.
+   * @throws XRPException If there was a problem communicating with the XRP Ledger.
+   */
+  public List<XRPTransaction> paymentHistory(String address) throws XRPException {
+    if (!Utils.isValidXAddress(address)) {
+      throw XRPException.xAddressRequiredException;
     }
+    ClassicAddress classicAddress = Utils.decodeXAddress(address);
 
-    private GetFeeResponse getFeeResponse() {
-        GetFeeRequest request = GetFeeRequest.newBuilder().build();
-        return this.stub.getFee(request);
+    AccountAddress account = AccountAddress.newBuilder().setAddress(classicAddress.address()).build();
+
+    GetAccountTransactionHistoryRequest request = GetAccountTransactionHistoryRequest.newBuilder()
+        .setAccount(account)
+        .build();
+    GetAccountTransactionHistoryResponse transactionHistory = stub.getAccountTransactionHistory(request);
+
+    List<GetTransactionResponse> getTransactionResponses = transactionHistory.getTransactionsList();
+
+    // Filter transactions to payments only and convert them to XRPTransactions.
+    // If a payment transaction fails conversion, throw an error.
+    List<XRPTransaction> payments = new ArrayList<XRPTransaction>();
+    for (GetTransactionResponse transactionResponse : getTransactionResponses) {
+      Transaction transaction = transactionResponse.getTransaction();
+      switch (transaction.getTransactionDataCase()) {
+        case PAYMENT: {
+          XRPTransaction xrpTransaction = XRPTransaction.from(transaction);
+          if (xrpTransaction == null) {
+            throw XRPException.paymentConversionFailure;
+          } else {
+            payments.add(xrpTransaction);
+          }
+          break;
+        }
+        default: {
+          // Intentionally do nothing, non-payment type transactions are ignored.
+        }
+      }
     }
+    return payments;
+  }
 
-    private AccountRoot getAccountData(String xrplAccountAddress) {
-        AccountAddress account = AccountAddress.newBuilder().setAddress(xrplAccountAddress).build();
-        GetAccountInfoRequest request = GetAccountInfoRequest.newBuilder().setAccount(account).build();
-
-        GetAccountInfoResponse response = this.stub.getAccountInfo(request);
-
-        return response.getAccountData();
+  /**
+   * Check if an address exists on the XRP Ledger.
+   *
+   * @param address The address to check the existence of.
+   * @return A boolean if the account is on the XRPLedger.
+   */
+  @Override
+  public boolean accountExists(String address) throws XRPException {
+    if (!Utils.isValidXAddress(address)) {
+      throw XRPException.xAddressRequiredException;
     }
+    try {
+      this.getBalance(address);
+      return true;
+    } catch (StatusRuntimeException exception) {
+      if (exception.getStatus().getCode() == io.grpc.Status.NOT_FOUND.getCode()) {
+        return false;
+      }
+      throw exception; // re-throw if code other than NOT_FOUND
+    } catch (Exception exception) {
+      throw exception; // re-throw any other type of exception
+    }
+  }
+
+  @Override
+  public int getLatestValidatedLedgerSequence() throws XRPException {
+    return this.getFeeResponse().getLedgerCurrentIndex();
+  }
+
+  @Override
+  public RawTransactionStatus getRawTransactionStatus(String transactionHash) throws XRPException {
+    Objects.requireNonNull(transactionHash);
+
+    byte[] transactionHashBytes = Utils.hexStringToByteArray(transactionHash);
+    ByteString transactionHashByteString = ByteString.copyFrom(transactionHashBytes);
+    GetTransactionRequest request = GetTransactionRequest.newBuilder().setHash(transactionHashByteString).build();
+
+    GetTransactionResponse response = this.stub.getTransaction(request);
+
+    return new RawTransactionStatus(response);
+  }
+
+  private XRPDropsAmount getMinimumFee() {
+    return this.getFeeResponse().getFee().getMinimumFee();
+  }
+
+  private GetFeeResponse getFeeResponse() {
+    GetFeeRequest request = GetFeeRequest.newBuilder().build();
+    return this.stub.getFee(request);
+  }
+
+  private AccountRoot getAccountData(String xrplAccountAddress) {
+    AccountAddress account = AccountAddress.newBuilder().setAddress(xrplAccountAddress).build();
+    GetAccountInfoRequest request = GetAccountInfoRequest.newBuilder().setAccount(account).build();
+
+    GetAccountInfoResponse response = this.stub.getAccountInfo(request);
+
+    return response.getAccountData();
+  }
 }

--- a/src/main/java/io/xpring/xrpl/RawTransactionStatus.java
+++ b/src/main/java/io/xpring/xrpl/RawTransactionStatus.java
@@ -1,58 +1,63 @@
 package io.xpring.xrpl;
 
-import org.xrpl.rpc.v1.*;
+import org.xrpl.rpc.v1.GetTransactionResponse;
+import org.xrpl.rpc.v1.Transaction;
 
-/** Encapsulates fields of a raw transaction status which is returned by the XRP Ledger. */
+/**
+ * Encapsulates fields of a raw transaction status which is returned by the XRP Ledger.
+ */
 // TODO(keefertaylor): This class is now defunct. Refactor and remove.
 public class RawTransactionStatus {
-    private boolean validated;
-    private String transactionStatusCode;
-    private int lastLedgerSequence;
-    private boolean isFullPayment;
+  private boolean validated;
+  private String transactionStatusCode;
+  private int lastLedgerSequence;
+  private boolean isFullPayment;
 
-    /**
-     * Create a new RawTransactionStatus from a {@link GetTransactionResponse} protocol buffer.
-     *
-     * @param getTransactionResponse The {@link GetTransactionResponse} to encapsulate.
-     */
-    public RawTransactionStatus(GetTransactionResponse getTransactionResponse) {
-        Transaction transaction = getTransactionResponse.getTransaction();
+  /**
+   * Create a new RawTransactionStatus from a {@link GetTransactionResponse} protocol buffer.
+   *
+   * @param getTransactionResponse The {@link GetTransactionResponse} to encapsulate.
+   */
+  public RawTransactionStatus(GetTransactionResponse getTransactionResponse) {
+    Transaction transaction = getTransactionResponse.getTransaction();
 
-        this.validated = getTransactionResponse.getValidated();
-        this.transactionStatusCode = getTransactionResponse.getMeta().getTransactionResult().getResult();
-        this.lastLedgerSequence = transaction.getLastLedgerSequence().getValue();
+    this.validated = getTransactionResponse.getValidated();
+    this.transactionStatusCode = getTransactionResponse.getMeta().getTransactionResult().getResult();
+    this.lastLedgerSequence = transaction.getLastLedgerSequence().getValue();
 
-        boolean isPayment = transaction.hasPayment();
-        int flags = transaction.getFlags().getValue();
+    boolean isPayment = transaction.hasPayment();
+    int flags = transaction.getFlags().getValue();
 
-        boolean isPartialPayment = RippledFlags.check(RippledFlags.TF_PARTIAL_PAYMENT, flags);
+    boolean isPartialPayment = RippledFlags.check(RippledFlags.TF_PARTIAL_PAYMENT, flags);
 
-        this.isFullPayment = isPayment && !isPartialPayment;
-    }
+    this.isFullPayment = isPayment && !isPartialPayment;
+  }
 
-    /**
-     * Retrieve whether or not the transaction has been validated.
-     */
-    public boolean getValidated() {
-        return this.validated;
-    }
+  /**
+   * Retrieve whether or not the transaction has been validated.
+   */
+  public boolean getValidated() {
+    return this.validated;
+  }
 
-    /**
-     * Retrieve the transaction status code.
-     */
-    public String getTransactionStatusCode() {
-        return this.transactionStatusCode;
-    }
+  /**
+   * Retrieve the transaction status code.
+   */
+  public String getTransactionStatusCode() {
+    return this.transactionStatusCode;
+  }
 
-    /**
-     * Retrieve the last ledger sequence this transaction is valid for.
-     */
-    public int getLastLedgerSequence() {
-        return this.lastLedgerSequence;
-    }
+  /**
+   * Retrieve the last ledger sequence this transaction is valid for.
+   */
+  public int getLastLedgerSequence() {
+    return this.lastLedgerSequence;
+  }
 
-    /**
-     * Returns whether the transaction represnented by this status is a full payment.
-     */
-    public boolean isFullPayment() { return this.isFullPayment; }
+  /**
+   * Returns whether the transaction represnented by this status is a full payment.
+   */
+  public boolean isFullPayment() {
+    return this.isFullPayment;
+  }
 }

--- a/src/main/java/io/xpring/xrpl/ReliableSubmissionXRPClient.java
+++ b/src/main/java/io/xpring/xrpl/ReliableSubmissionXRPClient.java
@@ -5,78 +5,81 @@ import io.xpring.xrpl.model.XRPTransaction;
 import java.math.BigInteger;
 import java.util.List;
 
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class ReliableSubmissionXRPClient implements XRPClientDecorator {
-    XRPClientDecorator decoratedClient;
+  XRPClientDecorator decoratedClient;
 
-    public ReliableSubmissionXRPClient(XRPClientDecorator decoratedClient) {
-        this.decoratedClient = decoratedClient;
+  public ReliableSubmissionXRPClient(XRPClientDecorator decoratedClient) {
+    this.decoratedClient = decoratedClient;
+  }
+
+  @Override
+  public BigInteger getBalance(String xrplAccountAddress) throws XRPException {
+    return this.decoratedClient.getBalance(xrplAccountAddress);
+  }
+
+  @Override
+  public TransactionStatus getPaymentStatus(String transactionHash) throws XRPException {
+    return this.decoratedClient.getPaymentStatus(transactionHash);
+  }
+
+  @Override
+  public String send(BigInteger amount, String destinationAddress, Wallet sourceWallet) throws XRPException {
+    try {
+      long ledgerCloseTime = 4 * 1000;
+
+      // Submit a transaction hash and wait for a ledger to close.
+      String transactionHash = decoratedClient.send(amount, destinationAddress, sourceWallet);
+      Thread.sleep(ledgerCloseTime);
+
+      // Get transaction status.
+      RawTransactionStatus transactionStatus = this.getRawTransactionStatus(transactionHash);
+      int lastLedgerSequence = transactionStatus.getLastLedgerSequence();
+      if (lastLedgerSequence == 0) {
+        throw new XRPException(
+            XRPExceptionType.UNKNOWN,
+            "The transaction did not have a lastLedgerSequence field so transaction status cannot be reliably "
+            + "determined."
+        );
+      }
+
+      // Retrieve the latest ledger index.
+      int latestLedgerSequence = this.getLatestValidatedLedgerSequence();
+
+      // Poll until the transaction is validated, or until the lastLedgerSequence has been passed.
+      while (latestLedgerSequence <= lastLedgerSequence && !transactionStatus.getValidated()) {
+        Thread.sleep(ledgerCloseTime);
+
+        latestLedgerSequence = this.getLatestValidatedLedgerSequence();
+        transactionStatus = this.getRawTransactionStatus(transactionHash);
+      }
+
+      return transactionHash;
+    } catch (InterruptedException e) {
+      throw new XRPException(
+          XRPExceptionType.UNKNOWN,
+          "Reliable transaction submission project was interrupted."
+      );
     }
+  }
 
-    @Override
-    public BigInteger getBalance(String xrplAccountAddress) throws XRPException {
-        return this.decoratedClient.getBalance(xrplAccountAddress);
-    }
+  @Override
+  public int getLatestValidatedLedgerSequence() throws XRPException {
+    return this.decoratedClient.getLatestValidatedLedgerSequence();
+  }
 
-    @Override
-    public TransactionStatus getPaymentStatus(String transactionHash) throws XRPException {
-        return this.decoratedClient.getPaymentStatus(transactionHash);
-    }
+  @Override
+  public RawTransactionStatus getRawTransactionStatus(String transactionHash) throws XRPException {
+    return this.decoratedClient.getRawTransactionStatus(transactionHash);
+  }
 
-    public String send(BigInteger amount, String destinationAddress, Wallet sourceWallet) throws XRPException {
-        try {
-            long ledgerCloseTime = 4 * 1000;
+  @Override
+  public List<XRPTransaction> paymentHistory(String address) throws XRPException {
+    return this.decoratedClient.paymentHistory(address);
+  }
 
-            // Submit a transaction hash and wait for a ledger to close.
-            String transactionHash = decoratedClient.send(amount, destinationAddress, sourceWallet);
-            Thread.sleep(ledgerCloseTime);
-
-            // Get transaction status.
-            RawTransactionStatus transactionStatus = this.getRawTransactionStatus(transactionHash);
-            int lastLedgerSequence = transactionStatus.getLastLedgerSequence();
-            if (lastLedgerSequence == 0) {
-                throw new XRPException(
-                        XRPExceptionType.UNKNOWN,
-                        "The transaction did not have a lastLedgerSequence field so transaction status cannot be reliably determined."
-                );
-            }
-
-            // Retrieve the latest ledger index.
-            int latestLedgerSequence = this.getLatestValidatedLedgerSequence();
-
-            // Poll until the transaction is validated, or until the lastLedgerSequence has been passed.
-            while (latestLedgerSequence <= lastLedgerSequence && !transactionStatus.getValidated()) {
-                Thread.sleep(ledgerCloseTime);
-
-                latestLedgerSequence = this.getLatestValidatedLedgerSequence();
-                transactionStatus = this.getRawTransactionStatus(transactionHash);
-            }
-
-            return transactionHash;
-        } catch (InterruptedException e) {
-            throw new XRPException(
-                    XRPExceptionType.UNKNOWN,
-                    "Reliable transaction submission project was interrupted."
-            );
-        }
-    }
-
-    @Override
-    public int getLatestValidatedLedgerSequence() throws XRPException {
-        return this.decoratedClient.getLatestValidatedLedgerSequence();
-    }
-
-    @Override
-    public RawTransactionStatus getRawTransactionStatus(String transactionHash) throws XRPException {
-        return this.decoratedClient.getRawTransactionStatus(transactionHash);
-    }
-
-    @Override
-    public List<XRPTransaction> paymentHistory(String address) throws XRPException {
-        return this.decoratedClient.paymentHistory(address);
-    }
-
-    @Override
-    public boolean accountExists(String address) throws XRPException {
-        return this.decoratedClient.accountExists(address);
-    }
+  @Override
+  public boolean accountExists(String address) throws XRPException {
+    return this.decoratedClient.accountExists(address);
+  }
 }

--- a/src/main/java/io/xpring/xrpl/RippledFlags.java
+++ b/src/main/java/io/xpring/xrpl/RippledFlags.java
@@ -2,28 +2,31 @@ package io.xpring.xrpl;
 
 /**
  * Flags used in ripppled transactions.
- *
+ * <p>
  * Note: These are only flags which are utilized in Xpring SDK. For a complete list of flags, see:
  * https://xrpl.org/transaction-common-fields.html#flags-field.
+ * </p>
  */
 public enum RippledFlags {
-    TF_PARTIAL_PAYMENT(131072);
+  TF_PARTIAL_PAYMENT(131072);
 
-    /** The value of the flag. */
-    public final int value;
+  /**
+   * The value of the flag.
+   */
+  public final int value;
 
-    RippledFlags(int value) {
-        this.value = value;
-    }
+  RippledFlags(int value) {
+    this.value = value;
+  }
 
-    /**
-     * Check if the given flag is present in the given flags.
-     *
-     * @param flag The flag to check the presence of.
-     * @param flags The flags to check
-     * @return A boolean indicating if the flag was present.
-     */
-    public static boolean check(RippledFlags flag, int flags) {
-        return (flag.value & flags) == flag.value;
-    }
+  /**
+   * Check if the given flag is present in the given flags.
+   *
+   * @param flag  The flag to check the presence of.
+   * @param flags The flags to check
+   * @return A boolean indicating if the flag was present.
+   */
+  public static boolean check(RippledFlags flag, int flags) {
+    return (flag.value & flags) == flag.value;
+  }
 }

--- a/src/main/java/io/xpring/xrpl/Signer.java
+++ b/src/main/java/io/xpring/xrpl/Signer.java
@@ -1,35 +1,38 @@
 package io.xpring.xrpl;
 
-import io.xpring.xrpl.javascript.JavaScriptSigner;
 import io.xpring.xrpl.javascript.JavaScriptLoaderException;
+import io.xpring.xrpl.javascript.JavaScriptSigner;
 import org.xrpl.rpc.v1.Transaction;
 
-
 public class Signer {
-    private static final JavaScriptSigner javascriptSigner;
+  private static final JavaScriptSigner javascriptSigner;
 
-    static {
-        try {
-            javascriptSigner = new JavaScriptSigner();
-        } catch (JavaScriptLoaderException e) {
-            throw new RuntimeException(e);
-        }
+  static {
+    try {
+      javascriptSigner = new JavaScriptSigner();
+    } catch (JavaScriptLoaderException e) {
+      throw new RuntimeException(e);
     }
+  }
 
-    /** Please do not instantiate this static utility class. */
-    private Signer() {}
+  /**
+   * Please do not instantiate this static utility class.
+   */
+  private Signer() {
+  }
 
-    /**
-     * Sign the given transaction with the given wallet.
-     * @param transaction The transaction to sign.
-     * @param wallet The wallet that will sign the transaction.
-     * @return A `SignedTransaction`.
-     */
-    public static byte[] signTransaction(Transaction transaction, Wallet wallet) {
-        try {
-            return javascriptSigner.signTransaction(transaction, wallet);
-        } catch (Exception exception) {
-            throw new RuntimeException(exception);
-        }
+  /**
+   * Sign the given transaction with the given wallet.
+   *
+   * @param transaction The transaction to sign.
+   * @param wallet The wallet that will sign the transaction.
+   * @return A `SignedTransaction`.
+   */
+  public static byte[] signTransaction(Transaction transaction, Wallet wallet) {
+    try {
+      return javascriptSigner.signTransaction(transaction, wallet);
+    } catch (Exception exception) {
+      throw new RuntimeException(exception);
     }
+  }
 }

--- a/src/main/java/io/xpring/xrpl/TransactionType.java
+++ b/src/main/java/io/xpring/xrpl/TransactionType.java
@@ -2,11 +2,11 @@ package io.xpring.xrpl;
 
 /**
  * Types of transactions on the XRP Ledger.
- *
+ * <p>
  * This is a partial list. Please file an issue if you have a use case that requires additional types.
- *
+ * </p>
  * See: https://xrpl.org/transaction-formats.html
  */
 public enum TransactionType {
-    PAYMENT
+  PAYMENT
 }

--- a/src/main/java/io/xpring/xrpl/Utils.java
+++ b/src/main/java/io/xpring/xrpl/Utils.java
@@ -8,111 +8,112 @@ import io.xpring.xrpl.javascript.JavaScriptUtils;
  */
 public class Utils {
 
-    private static final JavaScriptUtils javaScriptUtils;
+  private static final JavaScriptUtils javaScriptUtils;
 
-    static {
-        try {
-            javaScriptUtils = new JavaScriptUtils();
-        } catch (JavaScriptLoaderException e) {
-            throw new RuntimeException(e);
-        }
+  static {
+    try {
+      javaScriptUtils = new JavaScriptUtils();
+    } catch (JavaScriptLoaderException e) {
+      throw new RuntimeException(e);
     }
+  }
 
-    /**
-     * Please do not instantiate this static utility class.
-     */
-    private Utils() {
-    }
+  /**
+   * Please do not instantiate this static utility class.
+   */
+  private Utils() {
+  }
 
-    /**
-     * Check if the given string is a valid address on the XRP Ledger.
-     *
-     * @param address A string to validate
-     *
-     * @return A boolean indicating whether this was a valid address.
-     */
-    public static boolean isValidAddress(String address) {
-        return javaScriptUtils.isValidAddress(address);
-    }
+  /**
+   * Check if the given string is a valid address on the XRP Ledger.
+   *
+   * @param address A string to validate
+   * @return A boolean indicating whether this was a valid address.
+   */
+  public static boolean isValidAddress(String address) {
+    return javaScriptUtils.isValidAddress(address);
+  }
 
-    /**
-     * Convert bytes to a hex string.
-     *
-     * @param bytes The bytes to convert.
-     * @return Hex from bytes.
-     */
-    public static String byteArrayToHex(byte [] bytes) {
-        StringBuilder sb = new StringBuilder(bytes.length * 2);
-        for(byte b: bytes)
-            sb.append(String.format("%02x", b));
-        return sb.toString();
+  /**
+   * Convert bytes to a hex string.
+   *
+   * @param bytes The bytes to convert.
+   * @return Hex from bytes.
+   */
+  public static String byteArrayToHex(byte[] bytes) {
+    StringBuilder sb = new StringBuilder(bytes.length * 2);
+    for (byte b : bytes) {
+      sb.append(String.format("%02x", b));
     }
+    return sb.toString();
+  }
 
-    /**
-     * Convert a hex string to bytes.
-     *
-     * @param hex The hex to convert to bytes.
-     * @return Bytes from hex.
-     */
-    public static byte[] hexStringToByteArray(String hex) {
-        int len = hex.length();
-        byte[] data = new byte[len / 2];
-        for (int i = 0; i < len; i += 2) {
-            data[i / 2] = (byte) ((Character.digit(hex.charAt(i), 16) << 4)
-                    + Character.digit(hex.charAt(i+1), 16));
-        }
-        return data;
+  /**
+   * Convert a hex string to bytes.
+   *
+   * @param hex The hex to convert to bytes.
+   * @return Bytes from hex.
+   */
+  public static byte[] hexStringToByteArray(String hex) {
+    int len = hex.length();
+    byte[] data = new byte[len / 2];
+    for (int i = 0; i < len; i += 2) {
+      data[i / 2] = (byte) ((Character.digit(hex.charAt(i), 16) << 4)
+          + Character.digit(hex.charAt(i + 1), 16));
     }
+    return data;
+  }
 
-    /**
-     * Encode the given {@link ClassicAddress} and tag into an X-Address.
-     *
-     * @param classicAddress A {@link ClassicAddress} to encode
-     * @return A new X-Address if inputs were valid, otherwise undefined.
-     * @see <a href="https://xrpaddress.info/">https://xrpaddress.info/</a>
-     */
-    public static String encodeXAddress(ClassicAddress classicAddress) {
-        return javaScriptUtils.encodeXAddress(classicAddress);
-    }
+  /**
+   * Encode the given {@link ClassicAddress} and tag into an X-Address.
+   *
+   * @param classicAddress A {@link ClassicAddress} to encode
+   * @return A new X-Address if inputs were valid, otherwise undefined.
+   * @see <a href="https://xrpaddress.info/">https://xrpaddress.info/</a>
+   */
+  public static String encodeXAddress(ClassicAddress classicAddress) {
+    return javaScriptUtils.encodeXAddress(classicAddress);
+  }
 
-    /**
-     * Decode a {@link ClassicAddress} from a given X-Address.
-     *
-     * @param xAddress The xAddress to decode.
-     * @return A {@link ClassicAddress} if the inputs were valid, otherwise null.
-     * @see <a href="https://xrpaddress.info/">https://xrpaddress.info/</a>
-     */
-    public static ClassicAddress decodeXAddress(String xAddress) {
-        return javaScriptUtils.decodeXAddress(xAddress);
-    }
+  /**
+   * Decode a {@link ClassicAddress} from a given X-Address.
+   *
+   * @param xAddress The xAddress to decode.
+   * @return A {@link ClassicAddress} if the inputs were valid, otherwise null.
+   * @see <a href="https://xrpaddress.info/">https://xrpaddress.info/</a>
+   */
+  @SuppressWarnings("checkstyle:ParameterName")
+  public static ClassicAddress decodeXAddress(String xAddress) {
+    return javaScriptUtils.decodeXAddress(xAddress);
+  }
 
-    /**
-     * Check if the given string is a valid X-Address on the XRP Ledger.
-     *
-     * @param address A string to validate
-     * @return A boolean indicating whether this was a valid X-Address.
-     */
-    public static boolean isValidXAddress(String address) {
-        return javaScriptUtils.isValidXAddress(address);
-    }
+  /**
+   * Check if the given string is a valid X-Address on the XRP Ledger.
+   *
+   * @param address A string to validate
+   * @return A boolean indicating whether this was a valid X-Address.
+   */
+  public static boolean isValidXAddress(String address) {
+    return javaScriptUtils.isValidXAddress(address);
+  }
 
-    /**
-     * Check if the given string is a valid classic address on the XRP Ledger.
-     *
-     * @param address A string to validate
-     * @return A boolean indicating whether this was a valid clssic address.
-     */
-    public static boolean isValidClassicAddress(String address) {
-        return javaScriptUtils.isValidClassicAddress(address);
-    }
-          
-    /**
-     * Convert the given transaction blob to a transaction hash.
-     *
-     * @param transactionBlobHex  A hexadecimal encoded transaction blob.
-     * @return  A hex encoded hash if the input was valid, otherwise null.
-     */
-    public static String toTransactionHash(String transactionBlobHex) {
-        return javaScriptUtils.toTransactionHash(transactionBlobHex);
-    }
+  /**
+   * Check if the given string is a valid classic address on the XRP Ledger.
+   *
+   * @param address A string to validate
+   * @return A boolean indicating whether this was a valid clssic address.
+   */
+  public static boolean isValidClassicAddress(String address) {
+    return javaScriptUtils.isValidClassicAddress(address);
+  }
+
+  /**
+   * Convert the given transaction blob to a transaction hash.
+   *
+   * @param transactionBlobHex A hexadecimal encoded transaction blob.
+   * @return A hex encoded hash if the input was valid, otherwise null.
+   */
+  public static String toTransactionHash(String transactionBlobHex) {
+    return javaScriptUtils.toTransactionHash(transactionBlobHex);
+  }
 }

--- a/src/main/java/io/xpring/xrpl/Wallet.java
+++ b/src/main/java/io/xpring/xrpl/Wallet.java
@@ -10,152 +10,152 @@ import io.xpring.xrpl.javascript.JavaScriptWalletGenerationResult;
  */
 public class Wallet {
 
-    /**
-     * The underlying JavaScript wallet.
-     */
-    private JavaScriptWallet javaScriptWallet;
+  /**
+   * The underlying JavaScript wallet.
+   */
+  private JavaScriptWallet javaScriptWallet;
 
-    /**
-     * Initialize a new wallet from a seed.
-     *
-     * @param seed A base58check encoded seed for the wallet.
-     * @throws XRPException If the seed is malformed.
-     */
-    public Wallet(String seed) throws XRPException {
-        this(seed, false);
-    }
+  /**
+   * Initialize a new wallet from a seed.
+   *
+   * @param seed A base58check encoded seed for the wallet.
+   * @throws XRPException If the seed is malformed.
+   */
+  public Wallet(String seed) throws XRPException {
+    this(seed, false);
+  }
 
-    /**
-     * Initialize a new wallet from a seed.
-     *
-     * @param seed A base58check encoded seed for the wallet.
-     * @param isTest Whether the address is for use on a test network.
-     * @throws XRPException If the seed is malformed.
-     */
-    public Wallet(String seed, boolean isTest) throws XRPException {
-        this(JavaScriptWalletFactory.get().walletFromSeed(seed, isTest));
-    }
+  /**
+   * Initialize a new wallet from a seed.
+   *
+   * @param seed   A base58check encoded seed for the wallet.
+   * @param isTest Whether the address is for use on a test network.
+   * @throws XRPException If the seed is malformed.
+   */
+  public Wallet(String seed, boolean isTest) throws XRPException {
+    this(JavaScriptWalletFactory.get().walletFromSeed(seed, isTest));
+  }
 
-    /**
-     * Create a new HD Wallet.
-     *
-     * @param mnemonic       A space separated mnemonic.
-     * @param derivationPath A derivation. If null, the default derivation path will be used.
-     * @throws XRPException If the mnemonic or derivation path are malformed.
-     */
-    public Wallet(String mnemonic, String derivationPath) throws XRPException {
-        this(mnemonic, derivationPath, false);
-    }
+  /**
+   * Create a new HD Wallet.
+   *
+   * @param mnemonic       A space separated mnemonic.
+   * @param derivationPath A derivation. If null, the default derivation path will be used.
+   * @throws XRPException If the mnemonic or derivation path are malformed.
+   */
+  public Wallet(String mnemonic, String derivationPath) throws XRPException {
+    this(mnemonic, derivationPath, false);
+  }
 
-    /**
-     * Create a new HD Wallet.
-     *
-     * @param mnemonic       A space separated mnemonic.
-     * @param derivationPath A derivation. If null, the default derivation path will be used.
-     * @param isTest Whether the address is for use on a test network.
-     * @throws XRPException If the mnemonic or derivation path are malformed.
-     */
-    public Wallet(String mnemonic, String derivationPath, boolean isTest) throws XRPException {
-        this(JavaScriptWalletFactory.get().walletFromMnemonicAndDerivationPath(
-                mnemonic,
-                derivationPath,
-                isTest
-        ));
-    }
+  /**
+   * Create a new HD Wallet.
+   *
+   * @param mnemonic       A space separated mnemonic.
+   * @param derivationPath A derivation. If null, the default derivation path will be used.
+   * @param isTest         Whether the address is for use on a test network.
+   * @throws XRPException If the mnemonic or derivation path are malformed.
+   */
+  public Wallet(String mnemonic, String derivationPath, boolean isTest) throws XRPException {
+    this(JavaScriptWalletFactory.get().walletFromMnemonicAndDerivationPath(
+        mnemonic,
+        derivationPath,
+        isTest
+    ));
+  }
 
-    /**
-     * Create a new wallet from a set of keys.
-     *
-     * @param publicKey A hex encoded string representing the public key.
-     * @param privateKey A hex encoded string representing the private key.
-     * @param isTest Whether the address is for use on a test network.
-     * @throws XRPException If either input key is malformed.
-     * @return A new {@link JavaScriptWallet}.
-     */
-    public static Wallet walletFromKeys(String publicKey, String privateKey, boolean isTest) throws XRPException {
-        JavaScriptWallet javaScriptWallet = JavaScriptWalletFactory.get().walletFromKeys(publicKey, privateKey, isTest);
-        return new Wallet(javaScriptWallet);
-    }
+  /**
+   * Create a new wallet from a set of keys.
+   *
+   * @param publicKey  A hex encoded string representing the public key.
+   * @param privateKey A hex encoded string representing the private key.
+   * @param isTest     Whether the address is for use on a test network.
+   * @return A new {@link JavaScriptWallet}.
+   * @throws XRPException If either input key is malformed.
+   */
+  public static Wallet walletFromKeys(String publicKey, String privateKey, boolean isTest) throws XRPException {
+    JavaScriptWallet javaScriptWallet = JavaScriptWalletFactory.get().walletFromKeys(publicKey, privateKey, isTest);
+    return new Wallet(javaScriptWallet);
+  }
 
-    /**
-     * Create a new wallet from an {@link JavaScriptWallet}.
-     *
-     * @param javaScriptWallet The wallet to wrap.
-     */
-    @VisibleForTesting
-    public Wallet(JavaScriptWallet javaScriptWallet) {
-        this.javaScriptWallet = javaScriptWallet;
-    }
+  /**
+   * Create a new wallet from an {@link JavaScriptWallet}.
+   *
+   * @param javaScriptWallet The wallet to wrap.
+   */
+  @VisibleForTesting
+  public Wallet(JavaScriptWallet javaScriptWallet) {
+    this.javaScriptWallet = javaScriptWallet;
+  }
 
-    /**
-     * Generate a random Wallet.
-     *
-     * @return A {WalletGenerationResult} containing the artifacts of the generation process.
-     * @throws XRPException If wallet generation fails.
-     */
-    public static WalletGenerationResult generateRandomWallet() throws XRPException {
-        return generateRandomWallet(false);
-    }
+  /**
+   * Generate a random Wallet.
+   *
+   * @return A {WalletGenerationResult} containing the artifacts of the generation process.
+   * @throws XRPException If wallet generation fails.
+   */
+  public static WalletGenerationResult generateRandomWallet() throws XRPException {
+    return generateRandomWallet(false);
+  }
 
-    /**
-     * Generate a random Wallet.
-     *
-     * @param isTest Whether the address is for use on a test network.
-     * @return A {WalletGenerationResult} containing the artifacts of the generation process.
-     * @throws XRPException If wallet generation fails.
-     */
-    public static WalletGenerationResult generateRandomWallet(boolean isTest) throws XRPException {
-            JavaScriptWalletGenerationResult javaScriptWalletGenerationResult = JavaScriptWalletFactory.get()
-            .generateRandomWallet(isTest);
+  /**
+   * Generate a random Wallet.
+   *
+   * @param isTest Whether the address is for use on a test network.
+   * @return A {WalletGenerationResult} containing the artifacts of the generation process.
+   * @throws XRPException If wallet generation fails.
+   */
+  public static WalletGenerationResult generateRandomWallet(boolean isTest) throws XRPException {
+    JavaScriptWalletGenerationResult javaScriptWalletGenerationResult = JavaScriptWalletFactory.get()
+        .generateRandomWallet(isTest);
 
-        // TODO(keefertaylor): This should be a direct conversion, rather than recreating a new wallet.
-        Wallet newWallet = new Wallet(javaScriptWalletGenerationResult.getMnemonic(),
-            javaScriptWalletGenerationResult.getDerivationPath());
+    // TODO(keefertaylor): This should be a direct conversion, rather than recreating a new wallet.
+    Wallet newWallet = new Wallet(javaScriptWalletGenerationResult.getMnemonic(),
+        javaScriptWalletGenerationResult.getDerivationPath());
 
-        return new WalletGenerationResult(javaScriptWalletGenerationResult.getMnemonic(),
-            javaScriptWalletGenerationResult.getDerivationPath(), newWallet);
-    }
+    return new WalletGenerationResult(javaScriptWalletGenerationResult.getMnemonic(),
+        javaScriptWalletGenerationResult.getDerivationPath(), newWallet);
+  }
 
-    /**
-     * @return The address of this `Wallet`.
-     */
-    public String getAddress() {
-        return javaScriptWallet.getAddress();
-    }
+  /**
+   * The address of this `Wallet`.
+   */
+  public String getAddress() {
+    return javaScriptWallet.getAddress();
+  }
 
-    /**
-     * @return The public key of this `Wallet`.
-     */
-    public String getPublicKey() {
-        return javaScriptWallet.getPublicKey();
-    }
+  /**
+   * The public key of this `Wallet`.
+   */
+  public String getPublicKey() {
+    return javaScriptWallet.getPublicKey();
+  }
 
-    /**
-     * @return The private key of this `Wallet`.
-     */
-    public String getPrivateKey() {
-        return javaScriptWallet.getPrivateKey();
-    }
+  /**
+   * The private key of this `Wallet`.
+   */
+  public String getPrivateKey() {
+    return javaScriptWallet.getPrivateKey();
+  }
 
-    /**
-     * Sign the given input.
-     *
-     * @param input The input to sign as a hexadecimal string.
-     * @return A hexadecimal encoded signature.
-     * @throws XRPException If the input is malformed.
-     */
-    public String sign(String input) throws XRPException {
-        return javaScriptWallet.sign(input);
-    }
+  /**
+   * Sign the given input.
+   *
+   * @param input The input to sign as a hexadecimal string.
+   * @return A hexadecimal encoded signature.
+   * @throws XRPException If the input is malformed.
+   */
+  public String sign(String input) throws XRPException {
+    return javaScriptWallet.sign(input);
+  }
 
-    /**
-     * Verify that a given signature is valid for the given message.
-     *
-     * @param message   A message in hexadecimal encoding.
-     * @param signature A signature in hexademical encoding.
-     * @return A boolean indicating the validity of the signature.
-     */
-    public boolean verify(String message, String signature) {
-        return javaScriptWallet.verify(message, signature);
-    }
+  /**
+   * Verify that a given signature is valid for the given message.
+   *
+   * @param message   A message in hexadecimal encoding.
+   * @param signature A signature in hexademical encoding.
+   * @return A boolean indicating the validity of the signature.
+   */
+  public boolean verify(String message, String signature) {
+    return javaScriptWallet.verify(message, signature);
+  }
 }

--- a/src/main/java/io/xpring/xrpl/WalletGenerationResult.java
+++ b/src/main/java/io/xpring/xrpl/WalletGenerationResult.java
@@ -1,23 +1,46 @@
 package io.xpring.xrpl;
 
-/** Contains artifacts of generating a new Wallet. */
+/**
+ * Contains artifacts of generating a new Wallet.
+ */
 public class WalletGenerationResult {
-    /** The mnemonic of the newly generated Wallet. */
-    private String mnemonic;
-    public String getMnemonic() { return mnemonic; }
+  /**
+   * The mnemonic of the newly generated Wallet.
+   */
+  private String mnemonic;
 
-    /** The derivation path of the newly generated Wallet. */
-    private String derivationPath;
-    public String getDerivationPath() { return derivationPath; }
+  public String getMnemonic() {
+    return mnemonic;
+  }
 
-    /** The newly generated Wallet. */
-    private Wallet wallet;
-    public Wallet getWallet()  { return wallet; }
+  /**
+   * The derivation path of the newly generated Wallet.
+   */
+  private String derivationPath;
 
+  public String getDerivationPath() {
+    return derivationPath;
+  }
 
-    public WalletGenerationResult(String mnemonic, String derivationPath, Wallet wallet) {
-        this.mnemonic = mnemonic;
-        this.derivationPath = derivationPath;
-        this.wallet = wallet;
-    }
+  /**
+   * The newly generated Wallet.
+   */
+  private Wallet wallet;
+
+  public Wallet getWallet() {
+    return wallet;
+  }
+
+  /**
+   * Create a new JavaScriptWalletGenerationResult.
+   *
+   * @param mnemonic       The mnemonic that generated the wallet.
+   * @param derivationPath The derivation path that generated the wallet.
+   * @param wallet         The newly generated wallet.
+   */
+  public WalletGenerationResult(String mnemonic, String derivationPath, Wallet wallet) {
+    this.mnemonic = mnemonic;
+    this.derivationPath = derivationPath;
+    this.wallet = wallet;
+  }
 }

--- a/src/main/java/io/xpring/xrpl/XRPClient.java
+++ b/src/main/java/io/xpring/xrpl/XRPClient.java
@@ -11,95 +11,100 @@ import java.util.List;
  *
  * @see "https://xrpl.org"
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class XRPClient implements XRPClientInterface {
-    private XRPClientDecorator decoratedClient;
+  private XRPClientDecorator decoratedClient;
 
-    /** The XRPL Network of the node that this client is communicating with. */
-    private XRPLNetwork network;
+  /**
+   * The XRPL Network of the node that this client is communicating with.
+   */
+  private XRPLNetwork network;
 
-    /**
-     * Initialize a new client with the given options.
-     *
-     * @param grpcURL The remote URL to use for gRPC calls.
-     * @param network The network this XRPClient is connecting to.
-     */
-    public XRPClient(String grpcURL, XRPLNetwork network) {
-        XRPClientDecorator defaultXRPClient =  new DefaultXRPClient(grpcURL);
-        this.decoratedClient = new ReliableSubmissionXRPClient(defaultXRPClient);
+  /**
+   * Initialize a new client with the given options.
+   *
+   * @param grpcURL The remote URL to use for gRPC calls.
+   * @param network The network this XRPClient is connecting to.
+   */
+  public XRPClient(String grpcURL, XRPLNetwork network) {
+    XRPClientDecorator defaultXRPClient = new DefaultXRPClient(grpcURL);
+    this.decoratedClient = new ReliableSubmissionXRPClient(defaultXRPClient);
 
-        this.network = network;
-    }
+    this.network = network;
+  }
 
-    /**
-     * Retrieve the network that this XRPClient connects to.
-     */
-    public XRPLNetwork getNetwork() {
-        return this.network;
-    }
+  /**
+   * Retrieve the network that this XRPClient connects to.
+   */
+  public XRPLNetwork getNetwork() {
+    return this.network;
+  }
 
-    /**
-     * Get the balance of the specified account on the XRP Ledger.
-     **
-     * @param xrplAccountAddress The X-Address to retrieve the balance for.
-     * @return A {@link BigInteger} with the number of drops in this account.
-     * @throws XRPException If the given inputs were invalid.
-     */
-    public BigInteger getBalance(final String xrplAccountAddress) throws XRPException {
-        return decoratedClient.getBalance(xrplAccountAddress);
-    }
+  /**
+   * Get the balance of the specified account on the XRP Ledger.
+   * *
+   *
+   * @param xrplAccountAddress The X-Address to retrieve the balance for.
+   * @return A {@link BigInteger} with the number of drops in this account.
+   * @throws XRPException If the given inputs were invalid.
+   */
+  public BigInteger getBalance(final String xrplAccountAddress) throws XRPException {
+    return decoratedClient.getBalance(xrplAccountAddress);
+  }
 
-    /**
-     * Retrieve the transaction status for a Payment given transaction hash.
-     *
-     * Note: This method will only work for Payment type transactions which do not have the tf_partial_payment attribute set.
-     * See: https://xrpl.org/payment.html#payment-flags
-     *
-     * @param transactionHash The hash of the transaction.
-     * @return The status of the given transaction.
-     */
-    public TransactionStatus getPaymentStatus(String transactionHash) throws XRPException {
-        return decoratedClient.getPaymentStatus(transactionHash);
-    }
+  /**
+   * Retrieve the transaction status for a Payment given transaction hash.
+   * <p>
+   * Note: This method will only work for Payment type transactions which do not have the tf_partial_payment attribute
+   * set.
+   * See: https://xrpl.org/payment.html#payment-flags
+   * </p>
+   * @param transactionHash The hash of the transaction.
+   * @return The status of the given transaction.
+   */
+  public TransactionStatus getPaymentStatus(String transactionHash) throws XRPException {
+    return decoratedClient.getPaymentStatus(transactionHash);
+  }
 
-    /**
-     * Transact XRP between two accounts on the ledger.
-     *
-     * @param amount The number of drops of XRP to send.
-     * @param destinationAddress The X-Address to send the XRP to.
-     * @param sourceWallet The {@link Wallet} which holds the XRP.
-     * @return A transaction hash for the payment.
-     * @throws XRPException If the given inputs were invalid.
-     * */
-    public String send(
-            final BigInteger amount,
-            final String destinationAddress,
-            final Wallet sourceWallet
-    ) throws XRPException {
-        return decoratedClient.send(amount, destinationAddress, sourceWallet);
-    }
+  /**
+   * Transact XRP between two accounts on the ledger.
+   *
+   * @param amount             The number of drops of XRP to send.
+   * @param destinationAddress The X-Address to send the XRP to.
+   * @param sourceWallet       The {@link Wallet} which holds the XRP.
+   * @return A transaction hash for the payment.
+   * @throws XRPException If the given inputs were invalid.
+   */
+  public String send(
+      final BigInteger amount,
+      final String destinationAddress,
+      final Wallet sourceWallet
+  ) throws XRPException {
+    return decoratedClient.send(amount, destinationAddress, sourceWallet);
+  }
 
-    /**
-     * Check if an address exists on the XRP Ledger.
-     *
-     * @param xrplAccountAddress The address to check the existence of.
-     * @return A boolean if the account is on the XRP Ledger.
-     */
-    public boolean accountExists(final String xrplAccountAddress) throws XRPException {
-        return decoratedClient.accountExists(xrplAccountAddress);
-    }
+  /**
+   * Check if an address exists on the XRP Ledger.
+   *
+   * @param xrplAccountAddress The address to check the existence of.
+   * @return A boolean if the account is on the XRP Ledger.
+   */
+  public boolean accountExists(final String xrplAccountAddress) throws XRPException {
+    return decoratedClient.accountExists(xrplAccountAddress);
+  }
 
-    /**
-     * Return the history of payments for the given account.
-     *
-     * Note: This method only works for payment type transactions. See "https://xrpl.org/payment.html".
-     * Note: This method only returns the history that is contained on the remote node,
-     *       which may not contain a full history of the network.
-     *
-     * @param xrplAccountAddress: The address (account) for which to retrieve payment history.
-     * @throws XRPException If there was a problem communicating with the XRP Ledger.
-     * @return An array of transactions associated with the account.
-     */
-    public List<XRPTransaction> paymentHistory(String xrplAccountAddress) throws XRPException {
-        return decoratedClient.paymentHistory(xrplAccountAddress);
-    }
+  /**
+   * Return the history of payments for the given account.
+   * <p>
+   * Note: This method only works for payment type transactions. See "https://xrpl.org/payment.html".
+   * Note: This method only returns the history that is contained on the remote node,
+   * which may not contain a full history of the network.
+   * </p>
+   * @param xrplAccountAddress The address (account) for which to retrieve payment history.
+   * @return An array of transactions associated with the account.
+   * @throws XRPException If there was a problem communicating with the XRP Ledger.
+   */
+  public List<XRPTransaction> paymentHistory(String xrplAccountAddress) throws XRPException {
+    return decoratedClient.paymentHistory(xrplAccountAddress);
+  }
 }

--- a/src/main/java/io/xpring/xrpl/XRPClientDecorator.java
+++ b/src/main/java/io/xpring/xrpl/XRPClientDecorator.java
@@ -8,76 +8,78 @@ import java.util.List;
 /**
  * An common interface shared between XRPClient and the internal hierarchy of decorators.
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public interface XRPClientDecorator {
-    /**
-     * Get the balance of the specified account on the XRP Ledger.
-     *
-     * @param xrplAccountAddress The X-Address to retrieve the balance for.
-     * @return A {@link BigInteger} with the number of drops in this account.
-     * @throws XRPException If the given inputs were invalid.
-     */
-    BigInteger getBalance(final String xrplAccountAddress) throws XRPException;
+  /**
+   * Get the balance of the specified account on the XRP Ledger.
+   *
+   * @param xrplAccountAddress The X-Address to retrieve the balance for.
+   * @return A {@link BigInteger} with the number of drops in this account.
+   * @throws XRPException If the given inputs were invalid.
+   */
+  BigInteger getBalance(final String xrplAccountAddress) throws XRPException;
 
 
-    /**
-     * Retrieve the transaction status for a Payment given transaction hash.
-     *
-     * Note: This method will only work for Payment type transactions which do not have the tf_partial_payment attribute set.
-     * See: https://xrpl.org/payment.html#payment-flags
-     *
-     * @param transactionHash The hash of the transaction.
-     * @return The status of the given transaction.
-     */
-    public TransactionStatus getPaymentStatus(String transactionHash) throws XRPException;
+  /**
+   * Retrieve the transaction status for a Payment given transaction hash.
+   * <p>
+   * Note: This method will only work for Payment type transactions which do not have the tf_partial_payment attribute
+   * set.
+   * See: https://xrpl.org/payment.html#payment-flags
+   * </p>
+   * @param transactionHash The hash of the transaction.
+   * @return The status of the given transaction.
+   */
+  public TransactionStatus getPaymentStatus(String transactionHash) throws XRPException;
 
-    /**
-     * Transact XRP between two accounts on the ledger.
-     *
-     * @param amount The number of drops of XRP to send.
-     * @param destinationAddress The X-Address to send the XRP to.
-     * @param sourceWallet The {@link Wallet} which holds the XRP.
-     * @return A transaction hash for the payment.
-     * @throws XRPException If the given inputs were invalid.
-     */
-    String send(
-            final BigInteger amount,
-            final String destinationAddress,
-            final Wallet sourceWallet
-    ) throws XRPException;
+  /**
+   * Transact XRP between two accounts on the ledger.
+   *
+   * @param amount             The number of drops of XRP to send.
+   * @param destinationAddress The X-Address to send the XRP to.
+   * @param sourceWallet       The {@link Wallet} which holds the XRP.
+   * @return A transaction hash for the payment.
+   * @throws XRPException If the given inputs were invalid.
+   */
+  String send(
+      final BigInteger amount,
+      final String destinationAddress,
+      final Wallet sourceWallet
+  ) throws XRPException;
 
-    /**
-     * Retrieve the latest validated ledger sequence on the XRP Ledger.
-     *
-     * @return A long representing the sequence of the most recently validated ledger.
-     */
-    int getLatestValidatedLedgerSequence() throws XRPException;
+  /**
+   * Retrieve the latest validated ledger sequence on the XRP Ledger.
+   *
+   * @return A long representing the sequence of the most recently validated ledger.
+   */
+  int getLatestValidatedLedgerSequence() throws XRPException;
 
-    /**
-     * Retrieve the raw transaction status for the given transaction hash.
-     *
-     * @param transactionHash: The hash of the transaction.
-     * @return an {@link RawTransactionStatus} containing the raw transaction status.
-     */
-    RawTransactionStatus getRawTransactionStatus(String transactionHash) throws XRPException;
+  /**
+   * Retrieve the raw transaction status for the given transaction hash.
+   *
+   * @param transactionHash The hash of the transaction.
+   * @return an {@link RawTransactionStatus} containing the raw transaction status.
+   */
+  RawTransactionStatus getRawTransactionStatus(String transactionHash) throws XRPException;
 
-    /**
-     * Return the history of payments for the given account.
-     *
-     * Note: This method only works for payment type transactions. See "https://xrpl.org/payment.html"
-     * Note: This method only returns the history that is contained on the remote node,
-     *       which may not contain a full history of the network.
-     *
-     * @param address: The address (account) for which to retrieve payment history.
-     * @throws XRPException If there was a problem communicating with the XRP Ledger.
-     * @return An array of transactions associated with the account.
-     */
-    List<XRPTransaction> paymentHistory(String address) throws XRPException;
+  /**
+   * Return the history of payments for the given account.
+   * <p>
+   * Note: This method only works for payment type transactions. See "https://xrpl.org/payment.html"
+   * Note: This method only returns the history that is contained on the remote node,
+   * which may not contain a full history of the network.
+   * </p>
+   * @param address The address (account) for which to retrieve payment history.
+   * @return An array of transactions associated with the account.
+   * @throws XRPException If there was a problem communicating with the XRP Ledger.
+   */
+  List<XRPTransaction> paymentHistory(String address) throws XRPException;
 
-    /**
-     * Check if an address exists on the XRP Ledger.
-     *
-     * @param address The address to check the existence of.
-     * @return A boolean if the account is on the XRPLedger.
-     */
-    boolean accountExists(String address) throws XRPException;
+  /**
+   * Check if an address exists on the XRP Ledger.
+   *
+   * @param address The address to check the existence of.
+   * @return A boolean if the account is on the XRPLedger.
+   */
+  boolean accountExists(String address) throws XRPException;
 }

--- a/src/main/java/io/xpring/xrpl/XRPClientInterface.java
+++ b/src/main/java/io/xpring/xrpl/XRPClientInterface.java
@@ -6,53 +6,55 @@ import io.xpring.xrpl.model.XRPTransaction;
 import java.math.BigInteger;
 import java.util.List;
 
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public interface XRPClientInterface {
-    /**
-     * Retrieve the network that this XRPClient connects to.
-     */
-    public XRPLNetwork getNetwork();
+  /**
+   * Retrieve the network that this XRPClient connects to.
+   */
+  public XRPLNetwork getNetwork();
 
-    /**
-     * Get the balance of the specified account on the XRP Ledger.
-     *
-     * @param xrplAccountAddress The X-Address to retrieve the balance for.
-     * @return A {@link BigInteger} with the number of drops in this account.
-     * @throws XRPException If the given inputs were invalid.
-     */
-    BigInteger getBalance(final String xrplAccountAddress) throws XRPException;
+  /**
+   * Get the balance of the specified account on the XRP Ledger.
+   *
+   * @param xrplAccountAddress The X-Address to retrieve the balance for.
+   * @return A {@link BigInteger} with the number of drops in this account.
+   * @throws XRPException If the given inputs were invalid.
+   */
+  BigInteger getBalance(final String xrplAccountAddress) throws XRPException;
 
-    /**
-     * Retrieve the transaction status for a Payment given transaction hash.
-     *
-     * Note: This method will only work for Payment type transactions which do not have the tf_partial_payment attribute set.
-     * See: https://xrpl.org/payment.html#payment-flags
-     *
-     * @param transactionHash The hash of the transaction.
-     * @return The status of the given transaction.
-     */
-    TransactionStatus getPaymentStatus(String transactionHash) throws XRPException;
+  /**
+   * Retrieve the transaction status for a Payment given transaction hash.
+   * <p>
+   * Note: This method will only work for Payment type transactions which do not have the tf_partial_payment attribute
+   * set.
+   * See: https://xrpl.org/payment.html#payment-flags
+   * </p>
+   * @param transactionHash The hash of the transaction.
+   * @return The status of the given transaction.
+   */
+  TransactionStatus getPaymentStatus(String transactionHash) throws XRPException;
 
-    /**
-     * Transact XRP between two accounts on the ledger.
-     *
-     * @param amount The number of drops of XRP to send.
-     * @param destinationAddress The X-Address to send the XRP to.
-     * @param sourceWallet The {@link Wallet} which holds the XRP.
-     * @return A transaction hash for the payment.
-     * @throws XRPException If the given inputs were invalid.
-     */
-    public String send(BigInteger amount, String destinationAddress,  Wallet sourceWallet) throws XRPException;
+  /**
+   * Transact XRP between two accounts on the ledger.
+   *
+   * @param amount             The number of drops of XRP to send.
+   * @param destinationAddress The X-Address to send the XRP to.
+   * @param sourceWallet       The {@link Wallet} which holds the XRP.
+   * @return A transaction hash for the payment.
+   * @throws XRPException If the given inputs were invalid.
+   */
+  public String send(BigInteger amount, String destinationAddress, Wallet sourceWallet) throws XRPException;
 
-    /**
-     * Return the history of payments for the given account.
-     *
-     * Note: This method only works for payment type transactions. See "https://xrpl.org/payment.html".
-     * Note: This method only returns the history that is contained on the remote node,
-     *       which may not contain a full history of the network.
-     *
-     * @param address: The address (account) for which to retrieve payment history.
-     * @throws XRPException If there was a problem communicating with the XRP Ledger.
-     * @return An array of transactions associated with the account.
-     */
-    public List<XRPTransaction> paymentHistory(String address) throws XRPException;
+  /**
+   * Return the history of payments for the given account.
+   * <p>
+   * Note: This method only works for payment type transactions. See "https://xrpl.org/payment.html".
+   * Note: This method only returns the history that is contained on the remote node,
+   * which may not contain a full history of the network.
+   * </p>
+   * @param address The address (account) for which to retrieve payment history.
+   * @return An array of transactions associated with the account.
+   * @throws XRPException If there was a problem communicating with the XRP Ledger.
+   */
+  public List<XRPTransaction> paymentHistory(String address) throws XRPException;
 }

--- a/src/main/java/io/xpring/xrpl/XRPException.java
+++ b/src/main/java/io/xpring/xrpl/XRPException.java
@@ -1,41 +1,52 @@
 package io.xpring.xrpl;
 
-/** Exceptions which occur when working with xpring4j. */
+/**
+ * Exceptions which occur when working with xpring4j.
+ */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class XRPException extends Exception {
-    /** Static exception for when a classic address is passed to an X-Address API. */
-    public static XRPException xAddressRequiredException = new XRPException(
-            XRPExceptionType.X_ADDRESS_REQUIRED,
-            "Please use the X-Address format. See: https://xrpaddress.info/."
-    );
+  /**
+   * Static exception for when a classic address is passed to an X-Address API.
+   */
+  public static XRPException xAddressRequiredException = new XRPException(
+      XRPExceptionType.X_ADDRESS_REQUIRED,
+      "Please use the X-Address format. See: https://xrpaddress.info/."
+  );
 
-    /** Static exception for when a payment transaction can't be converted to an XRPTransaction. */
-    public static XRPException paymentConversionFailure = new XRPException(
-            XRPExceptionType.UNKNOWN,
-            "Could not convert payment transaction: (transaction). Please file a bug at https://github.com/xpring-eng/xpring4j/issues"
-    );
+  /**
+   * Static exception for when a payment transaction can't be converted to an XRPTransaction.
+   */
+  public static XRPException paymentConversionFailure = new XRPException(
+      XRPExceptionType.UNKNOWN,
+      "Could not convert payment transaction: (transaction). Please file a bug at https://github.com/xpring-eng/xpring4j/issues"
+  );
 
-    /** Static exception for when functionality is unimplemented. */
-    public static XRPException unimplemented = new XRPException(XRPExceptionType.UNIMPLEMENTED, "Unimplemented");
+  /**
+   * Static exception for when functionality is unimplemented.
+   */
+  public static XRPException unimplemented = new XRPException(XRPExceptionType.UNIMPLEMENTED, "Unimplemented");
 
-    /** The type of exception. */
-    private XRPExceptionType type;
+  /**
+   * The type of exception.
+   */
+  private XRPExceptionType type;
 
-    /**
-     * Create a new exception.
-     *
-     * @param type The type of exception.
-     * @param message The message to to include in the exception
-     */
-    public XRPException(XRPExceptionType type, String message) {
-        super(message);
+  /**
+   * Create a new exception.
+   *
+   * @param type    The type of exception.
+   * @param message The message to to include in the exception
+   */
+  public XRPException(XRPExceptionType type, String message) {
+    super(message);
 
-        this.type = type;
-    }
+    this.type = type;
+  }
 
-    /**
-     * @return The exception type.
-     */
-    public XRPExceptionType getType() {
-        return this.type;
-    }
+  /**
+   * The exception type.
+   */
+  public XRPExceptionType getType() {
+    return this.type;
+  }
 }

--- a/src/main/java/io/xpring/xrpl/XRPExceptionType.java
+++ b/src/main/java/io/xpring/xrpl/XRPExceptionType.java
@@ -1,5 +1,6 @@
 package io.xpring.xrpl;
 
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public enum XRPExceptionType {
     INVALID_INPUTS,
     SIGNING_ERROR,

--- a/src/main/java/io/xpring/xrpl/javascript/JavaScriptLoader.java
+++ b/src/main/java/io/xpring/xrpl/javascript/JavaScriptLoader.java
@@ -7,98 +7,97 @@ import org.graalvm.polyglot.Value;
 import java.io.InputStreamReader;
 
 /**
- * Provides helper functions for loading JavaScript
+ * Provides helper functions for loading JavaScript.
  */
 public class JavaScriptLoader {
 
-    /**
-     * Error messages for exceptions.
-     */
-    private static final String missingIndexJS = "Could not load JavaScript resources for the XRP Ledger. Check that `index.js` exists and is well formed.";
-    private static final String missingXpringCommonJS = "Could not find global XpringCommonJS in Context. Check that `XpringCommonJS.default` is defined as a global variable.";
-    private static final String missingResource = "Could not find the requested resource: ";
+  /**
+   * Error messages for exceptions.
+   */
+  private static final String missingIndexJS =
+      "Could not load JavaScript resources for the XRP Ledger. Check that `index.js` exists and is well formed.";
+  private static final String missingXpringCommonJS =
+      "Could not find global XpringCommonJS in Context. Check that `XpringCommonJS.default` is defined as a "
+          + "global variable.";
+  private static final String missingResource = "Could not find the requested resource: ";
 
-    /**
-     * The name of the JavaScript file to load from.
-     */
-    private static final String javaScriptResourceName = "/index.js";
+  /**
+   * The name of the JavaScript file to load from.
+   */
+  private static final String javaScriptResourceName = "/index.js";
 
-    /**
-     * The identifier for the JavaScript language in the graalvm polygot package.
-     */
-    private static final String javaScriptLanguageIdentifier = "js";
+  /**
+   * The identifier for the JavaScript language in the graalvm polygot package.
+   */
+  private static final String javaScriptLanguageIdentifier = "js";
 
-    private static final Context context;
+  private static final Context context;
 
-    static {
-        // Load the webpacked XpringCommonJS JavaScript file.
-        context = Context.create(javaScriptLanguageIdentifier);
-        Source source;
-        try (InputStreamReader reader =
-                 new InputStreamReader(JavaScriptLoader.class.getResourceAsStream(javaScriptResourceName))) {
-            source = Source.newBuilder(javaScriptLanguageIdentifier, reader, javaScriptResourceName).build();
-        } catch (Exception exception) {
-            throw new RuntimeException(missingIndexJS);
-        }
-
-        // Load the file into the context and find the root object.
-        context.eval(source);
+  static {
+    // Load the webpacked XpringCommonJS JavaScript file.
+    context = Context.create(javaScriptLanguageIdentifier);
+    Source source;
+    try (InputStreamReader reader =
+             new InputStreamReader(JavaScriptLoader.class.getResourceAsStream(javaScriptResourceName))) {
+      source = Source.newBuilder(javaScriptLanguageIdentifier, reader, javaScriptResourceName).build();
+    } catch (Exception exception) {
+      throw new RuntimeException(missingIndexJS);
     }
 
-    /**
-     * Please do not initialize this static utility class.
-     */
-    private JavaScriptLoader() {
+    // Load the file into the context and find the root object.
+    context.eval(source);
+  }
+
+  /**
+   * Please do not initialize this static utility class.
+   */
+  private JavaScriptLoader() {
+  }
+
+  /**
+   * Load a JavaScript Context that contains all the JavaScript code for the Xpring ecosystem.
+   *
+   * @return a new JavaScript context.
+   */
+  public static Context getContext() {
+    return context;
+  }
+
+  /**
+   * Load the value from the XpringCommonJS exports on the given JSContext.
+   * <p>
+   * This method loads value from `XpringCommonJS.$value`.
+   * </p>
+   * @param value The name of the value you are trying to load.
+   * @param context The context load from.
+   * @return A `Value` referring to the requested resource.
+   * @throws JavaScriptLoaderException An exception if the javascript could not be loaded.
+   */
+  public static Value loadResource(String value, Context context) throws JavaScriptLoaderException {
+    Value root = context.getBindings(javaScriptLanguageIdentifier).getMember("XpringCommonJS");
+
+    // If the root is not found throw an exception.
+    if (root.isNull()) {
+      throw new JavaScriptLoaderException(missingXpringCommonJS);
     }
 
-    /**
-     * Load a JavaScript Context that contains all the JavaScript code for the Xpring ecosystem.
-     *
-     * @return a new JavaScript context.
-     */
-    public static Context getContext() {
-        return context;
+    return loadResource(value, root);
+  }
+
+  /**
+   * Load a class or function as a keyed subscript from the given value.
+   *
+   * @param resourceName The name of the resource to load.
+   * @param value The value to load a resource from.
+   * @return A {@link Value} referring to the requested resource.
+   * @throws JavaScriptLoaderException An exception if the javascript could not be loaded.
+   */
+  public static Value loadResource(String resourceName, Value value) throws JavaScriptLoaderException {
+    Value resource = value.getMember(resourceName);
+    if (resource.isNull()) {
+      throw new JavaScriptLoaderException(missingResource + resourceName);
     }
 
-    /**
-     * Load the value from the XpringCommonJS exports on the given JSContext.
-     *
-     * This method loads value from `XpringCommonJS.$value`.
-     *
-     * @param value:   The name of the value you are trying to load.
-     * @param context: The context load from.
-     *
-     * @return A `Value` referring to the requested resource.
-     *
-     * @throws JavaScriptLoaderException An exception if the javascript could not be loaded.
-     */
-    public static Value loadResource(String value, Context context) throws JavaScriptLoaderException {
-        Value root = context.getBindings(javaScriptLanguageIdentifier).getMember("XpringCommonJS");
-
-        // If the root is not found throw an exception.
-        if (root.isNull()) {
-            throw new JavaScriptLoaderException(missingXpringCommonJS);
-        }
-
-        return loadResource(value, root);
-    }
-
-    /**
-     * Load a class or function as a keyed subscript from the given value.
-     *
-     * @param resourceName: The name of the resource to load.
-     * @param value:        The value to load a resource from.
-     *
-     * @return A {@link Value} referring to the requested resource.
-     *
-     * @throws JavaScriptLoaderException An exception if the javascript could not be loaded.
-     */
-    public static Value loadResource(String resourceName, Value value) throws JavaScriptLoaderException {
-        Value resource = value.getMember(resourceName);
-        if (resource.isNull()) {
-            throw new JavaScriptLoaderException(missingResource + resourceName);
-        }
-
-        return resource;
-    }
+    return resource;
+  }
 }

--- a/src/main/java/io/xpring/xrpl/javascript/JavaScriptLoaderException.java
+++ b/src/main/java/io/xpring/xrpl/javascript/JavaScriptLoaderException.java
@@ -1,8 +1,10 @@
 package io.xpring.xrpl.javascript;
 
-/** Exceptions which occur when working with JavaScript. */
+/**
+ * Exceptions which occur when working with JavaScript.
+ */
 public class JavaScriptLoaderException extends Exception {
-    public JavaScriptLoaderException(String errorMessage) {
-        super(errorMessage);
-    }
+  public JavaScriptLoaderException(String errorMessage) {
+    super(errorMessage);
+  }
 }

--- a/src/main/java/io/xpring/xrpl/javascript/JavaScriptSigner.java
+++ b/src/main/java/io/xpring/xrpl/javascript/JavaScriptSigner.java
@@ -1,87 +1,88 @@
 package io.xpring.xrpl.javascript;
 
-import com.google.protobuf.InvalidProtocolBufferException;
 import io.xpring.xrpl.Utils;
 import io.xpring.xrpl.Wallet;
-import io.xpring.xrpl.javascript.JavaScriptLoaderException;
-import io.xpring.xrpl.javascript.JavaScriptLoader;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Value;
 import org.xrpl.rpc.v1.Transaction;
 
-/** Provides JavaScript based Signing functionality. */
+/**
+ * Provides JavaScript based Signing functionality.
+ */
 public class JavaScriptSigner {
-    private Value signerClass;
-    private Value walletClass;
-    private Value transactionClass;
-    private Value utilsClass;
+  private Value signerClass;
+  private Value walletClass;
+  private Value transactionClass;
+  private Value utilsClass;
 
-    public JavaScriptSigner() throws JavaScriptLoaderException {
-        Context context = JavaScriptLoader.getContext();
-        this.transactionClass = JavaScriptLoader.loadResource("Transaction", context);
-        this.signerClass = JavaScriptLoader.loadResource("Signer", context);
-        this.walletClass = JavaScriptLoader.loadResource("Wallet", context);
-        this.utilsClass = JavaScriptLoader.loadResource("Utils", context);
-    }
+  /**
+   * Create a new JavaScriptSigner.
+   *
+   * @throws JavaScriptLoaderException if the bundled JavaScript is malformed.
+   */
+  public JavaScriptSigner() throws JavaScriptLoaderException {
+    Context context = JavaScriptLoader.getContext();
+    this.transactionClass = JavaScriptLoader.loadResource("Transaction", context);
+    this.signerClass = JavaScriptLoader.loadResource("Signer", context);
+    this.walletClass = JavaScriptLoader.loadResource("Wallet", context);
+    this.utilsClass = JavaScriptLoader.loadResource("Utils", context);
+  }
 
-    /**
-     * Sign the given transaction with the given wallet.
-     *
-     * @param transaction The {@link Transaction} to sign.
-     * @param wallet The {@link Wallet} that will sign the transaction.
-     *
-     * @return An array of bytes representing the signed transaction.
-     *
-     * @throws JavaScriptLoaderException An exception if the javascript could not be loaded.
-     */
-    public byte [] signTransaction(Transaction transaction, Wallet wallet) throws JavaScriptLoaderException {
-        // Convert Java objects into JavaScript objects.
-        Value javaScriptTransaction = transactionToJavaScriptValue(transaction);
-        Value javaScriptWallet = walletToJavaScriptValue(wallet);
+  /**
+   * Sign the given transaction with the given wallet.
+   *
+   * @param transaction The {@link Transaction} to sign.
+   * @param wallet The {@link Wallet} that will sign the transaction.
+   * @return An array of bytes representing the signed transaction.
+   * @throws JavaScriptLoaderException An exception if the javascript could not be loaded.
+   */
+  public byte[] signTransaction(Transaction transaction, Wallet wallet) throws JavaScriptLoaderException {
+    // Convert Java objects into JavaScript objects.
+    Value javaScriptTransaction = transactionToJavaScriptValue(transaction);
+    Value javaScriptWallet = walletToJavaScriptValue(wallet);
 
-        // Create a JavaScript SignedTransaction.
-        Value javascriptSignedTransaction = signerClass.invokeMember("signTransaction", javaScriptTransaction, javaScriptWallet);
+    // Create a JavaScript SignedTransaction.
+    Value javascriptSignedTransaction =
+        signerClass.invokeMember("signTransaction", javaScriptTransaction, javaScriptWallet);
 
-        // Convert JavaScript SignedTransaction into a Java SignedTransaction.
-        return valueToByteArray(javascriptSignedTransaction);
-    }
+    // Convert JavaScript SignedTransaction into a Java SignedTransaction.
+    return valueToByteArray(javascriptSignedTransaction);
+  }
 
-    /**
-     * Convert a {@link Value} into a byte array.
-     *
-     * @param javascriptByteArray The serialized bytes to convert.
-     * @return An array of bytes.
-     */
-    private byte [] valueToByteArray(Value javascriptByteArray) {
-        String signTransactionHex = utilsClass.invokeMember("toHex", javascriptByteArray).asString();
-        return Utils.hexStringToByteArray(signTransactionHex);
-    }
+  /**
+   * Convert a {@link Value} into a byte array.
+   *
+   * @param javascriptByteArray The serialized bytes to convert.
+   * @return An array of bytes.
+   */
+  private byte[] valueToByteArray(Value javascriptByteArray) {
+    String signTransactionHex = utilsClass.invokeMember("toHex", javascriptByteArray).asString();
+    return Utils.hexStringToByteArray(signTransactionHex);
+  }
 
-    /**
-     * Convert a Wallet to a JavaScript Value reference.
-     *
-     * @param wallet The {@link Wallet} to convert.
-     *
-     * @return A reference to the analagous wallet in JavaScript.
-     */
-    private Value walletToJavaScriptValue(Wallet wallet) {
-        String publicKeyHex = wallet.getPublicKey();
-        String privateKeyHex = wallet.getPrivateKey();
-        return walletClass.newInstance(publicKeyHex, privateKeyHex);
-    }
+  /**
+   * Convert a Wallet to a JavaScript Value reference.
+   *
+   * @param wallet The {@link Wallet} to convert.
+   * @return A reference to the analagous wallet in JavaScript.
+   */
+  private Value walletToJavaScriptValue(Wallet wallet) {
+    String publicKeyHex = wallet.getPublicKey();
+    String privateKeyHex = wallet.getPrivateKey();
+    return walletClass.newInstance(publicKeyHex, privateKeyHex);
+  }
 
-    /**
-     * Convert a Transaction to a JavaScript Value reference.
-     *
-     * @param transaction The {@link Transaction} to convert.
-     *
-     * @return A reference to the analagous transaction in JavaScript.
-     */
-    private Value transactionToJavaScriptValue(Transaction transaction) {
-        byte [] transactionBytes = transaction.toByteArray();
-        String transactionHex = Utils.byteArrayToHex(transactionBytes);
-        Value javaScriptBytes = utilsClass.invokeMember("toBytes", transactionHex);
+  /**
+   * Convert a Transaction to a JavaScript Value reference.
+   *
+   * @param transaction The {@link Transaction} to convert.
+   * @return A reference to the analagous transaction in JavaScript.
+   */
+  private Value transactionToJavaScriptValue(Transaction transaction) {
+    byte[] transactionBytes = transaction.toByteArray();
+    String transactionHex = Utils.byteArrayToHex(transactionBytes);
+    Value javaScriptBytes = utilsClass.invokeMember("toBytes", transactionHex);
 
-        return transactionClass.invokeMember("deserializeBinary", javaScriptBytes);
-    }
+    return transactionClass.invokeMember("deserializeBinary", javaScriptBytes);
+  }
 }

--- a/src/main/java/io/xpring/xrpl/javascript/JavaScriptUtils.java
+++ b/src/main/java/io/xpring/xrpl/javascript/JavaScriptUtils.java
@@ -1,121 +1,127 @@
 package io.xpring.xrpl.javascript;
 
+import io.xpring.xrpl.ClassicAddress;
+import io.xpring.xrpl.ImmutableClassicAddress;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
 
 import java.util.Objects;
 import java.util.Optional;
-import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Value;
-import io.xpring.xrpl.ClassicAddress;
-import io.xpring.xrpl.ImmutableClassicAddress;
 
-/** Provides JavaScript based Utils functionality. */
+
+/**
+ * Provides JavaScript based Utils functionality.
+ */
 public class JavaScriptUtils {
-    /**
-     * An reference to the underlying JavaScript Utils object.
-     */
-    private Value javaScriptUtils;
+  /**
+   * An reference to the underlying JavaScript Utils object.
+   */
+  private Value javaScriptUtils;
 
-    /**
-     * @throws JavaScriptLoaderException If the underlying JavaScript was missing or malformed.
-     */
-    public JavaScriptUtils() throws JavaScriptLoaderException {
-        Context context = JavaScriptLoader.getContext();
-        Value javaScriptUtils = JavaScriptLoader.loadResource("Utils", context);
+  /**
+   * Initialize a new JavaScriptUtils.
+   *
+   * @throws JavaScriptLoaderException If the underlying JavaScript was missing or malformed.
+   */
+  public JavaScriptUtils() throws JavaScriptLoaderException {
+    Context context = JavaScriptLoader.getContext();
+    Value javaScriptUtils = JavaScriptLoader.loadResource("Utils", context);
 
-        this.javaScriptUtils = javaScriptUtils;
+    this.javaScriptUtils = javaScriptUtils;
+  }
+
+  /**
+   * Check if the given string is a valid address on the XRP Ledger.
+   *
+   * @param address A string to validate.
+   * @return A boolean indicating whether this was a valid address.
+   */
+  public boolean isValidAddress(String address) {
+    Objects.requireNonNull(address);
+
+    Value isValidAddressFunction = javaScriptUtils.getMember("isValidAddress");
+    return isValidAddressFunction.execute(address).asBoolean();
+  }
+
+  /**
+   * Encode the given {@link ClassicAddress} and tag into an X-Address.
+   *
+   * @param classicAddress A {@link ClassicAddress} to encode
+   * @return A new X-Address if inputs were valid, otherwise null.
+   * @see <a href="https://xrpaddress.info/">https://xrpaddress.info/</a>
+   */
+  public String encodeXAddress(ClassicAddress classicAddress) {
+    Objects.requireNonNull(classicAddress);
+
+    Value encodeXAddressFunction = javaScriptUtils.getMember("encodeXAddress");
+    Value result = classicAddress.tag().isPresent()
+        ? encodeXAddressFunction.execute(classicAddress.address(), classicAddress.tag().get(), classicAddress.isTest())
+        : encodeXAddressFunction.execute(classicAddress.address(), classicAddress.isTest());
+    return result.asString();
+  }
+
+  /**
+   * Decode a {@link ClassicAddress} from a given X-Address.
+   *
+   * @param xAddress The xAddress to decode.
+   * @return A {@link ClassicAddress} if the inputs were valid, otherwise null.
+   * @see <a href="https://xrpaddress.info/">https://xrpaddress.info/</a>
+   */
+  @SuppressWarnings("checkstyle:ParameterName")
+  public ClassicAddress decodeXAddress(String xAddress) {
+    Objects.requireNonNull(xAddress);
+
+    Value decodeXAddressFunction = javaScriptUtils.getMember("decodeXAddress");
+    Value result = decodeXAddressFunction.execute(xAddress);
+
+    if (result.isNull()) {
+      return null;
     }
 
-    /**
-     * Check if the given string is a valid address on the XRP Ledger.
-     *
-     * @param address: A string to validate
-     * @return A boolean indicating whether this was a valid address.
-     */
-    public boolean isValidAddress(String address) {
-        Objects.requireNonNull(address);
+    String address = result.getMember("address").asString();
+    Integer tag = result.getMember("tag").isNull() ? null : result.getMember("tag").asInt();
+    boolean isTest = result.getMember("test").asBoolean();
 
-        Value isValidAddressFunction = javaScriptUtils.getMember("isValidAddress");
-        return isValidAddressFunction.execute(address).asBoolean();
-    }
+    return ImmutableClassicAddress.builder().address(address).tag(Optional.ofNullable(tag)).isTest(isTest).build();
+  }
 
-    /**
-     * Encode the given {@link ClassicAddress} and tag into an X-Address.
-     *
-     * @param classicAddress A {@link ClassicAddress} to encode
-     * @return A new X-Address if inputs were valid, otherwise null.
-     * @see <a href="https://xrpaddress.info/">https://xrpaddress.info/</a>
-     */
-    public String encodeXAddress(ClassicAddress classicAddress) {
-        Objects.requireNonNull(classicAddress);
+  /**
+   * Check if the given string is a valid X-Address on the XRP Ledger.
+   *
+   * @param address A string to validate.
+   * @return A boolean indicating whether this was a valid X-Address.
+   */
+  public boolean isValidXAddress(String address) {
+    Objects.requireNonNull(address);
 
-        Value encodeXAddressFunction = javaScriptUtils.getMember("encodeXAddress");
-        Value result = classicAddress.tag().isPresent() ?
-                encodeXAddressFunction.execute(classicAddress.address(), classicAddress.tag().get(), classicAddress.isTest()) :
-                encodeXAddressFunction.execute(classicAddress.address(), classicAddress.isTest());
-        return result.asString();
-    }
+    Value isValidXAddressFunction = javaScriptUtils.getMember("isValidXAddress");
+    return isValidXAddressFunction.execute(address).asBoolean();
+  }
 
-    /**
-     * Decode a {@link ClassicAddress} from a given X-Address.
-     *
-     * @param xAddress The xAddress to decode.
-     * @return A {@link ClassicAddress} if the inputs were valid, otherwise null.
-     * @see <a href="https://xrpaddress.info/">https://xrpaddress.info/</a>
-     */
-    public ClassicAddress decodeXAddress(String xAddress) {
-        Objects.requireNonNull(xAddress);
+  /**
+   * Check if the given string is a valid classic address on the XRP Ledger.
+   *
+   * @param address A string to validate.
+   * @return A boolean indicating whether this was a valid clssic address.
+   */
+  public boolean isValidClassicAddress(String address) {
+    Objects.requireNonNull(address);
 
-        Value decodeXAddressFunction = javaScriptUtils.getMember("decodeXAddress");
-        Value result = decodeXAddressFunction.execute(xAddress);
+    Value isValidClassicAddressFunction = javaScriptUtils.getMember("isValidClassicAddress");
+    return isValidClassicAddressFunction.execute(address).asBoolean();
+  }
 
-        if (result.isNull()) {
-            return null;
-        }
+  /**
+   * Convert the given transaction blob to a transaction hash.
+   *
+   * @param transactionBlobHex A hexadecimal encoded transaction blob.
+   * @return A hex encoded hash if the input was valid, otherwise null.
+   */
+  public String toTransactionHash(String transactionBlobHex) {
+    Objects.requireNonNull(transactionBlobHex);
 
-        String address = result.getMember("address").asString();
-        Integer tag = result.getMember("tag").isNull() ? null : result.getMember("tag").asInt();
-        boolean isTest = result.getMember("test").asBoolean();
-
-        return ImmutableClassicAddress.builder().address(address).tag(Optional.ofNullable(tag)).isTest(isTest).build();
-    }
-
-    /**
-     * Check if the given string is a valid X-Address on the XRP Ledger.
-     *
-     * @param address: A string to validate
-     * @return A boolean indicating whether this was a valid X-Address.
-     */
-    public boolean isValidXAddress(String address) {
-        Objects.requireNonNull(address);
-
-        Value isValidXAddressFunction = javaScriptUtils.getMember("isValidXAddress");
-        return isValidXAddressFunction.execute(address).asBoolean();
-    }
-
-    /**
-     * Check if the given string is a valid classic address on the XRP Ledger.
-     *
-     * @param address: A string to validate
-     * @return A boolean indicating whether this was a valid clssic address.
-     */
-    public boolean isValidClassicAddress(String address) {
-        Objects.requireNonNull(address);
-
-        Value isValidClassicAddressFunction = javaScriptUtils.getMember("isValidClassicAddress");
-        return isValidClassicAddressFunction.execute(address).asBoolean();
-    }
-
-    /**
-     * Convert the given transaction blob to a transaction hash.
-     *
-     * @param transactionBlobHex  A hexadecimal encoded transaction blob.
-     * @return  A hex encoded hash if the input was valid, otherwise null.
-     */
-    public String toTransactionHash(String transactionBlobHex) {
-        Objects.requireNonNull(transactionBlobHex);
-
-        Value transactionBlobToTransactionHashFunction = javaScriptUtils.getMember("transactionBlobToTransactionHash");
-        Value hash = transactionBlobToTransactionHashFunction.execute(transactionBlobHex);
-        return hash.isNull() ? null : hash.toString();
-    }
+    Value transactionBlobToTransactionHashFunction = javaScriptUtils.getMember("transactionBlobToTransactionHash");
+    Value hash = transactionBlobToTransactionHashFunction.execute(transactionBlobHex);
+    return hash.isNull() ? null : hash.toString();
+  }
 }

--- a/src/main/java/io/xpring/xrpl/javascript/JavaScriptWallet.java
+++ b/src/main/java/io/xpring/xrpl/javascript/JavaScriptWallet.java
@@ -9,73 +9,70 @@ import org.graalvm.polyglot.Value;
  */
 public class JavaScriptWallet {
 
-    /**
-     * An underlying reference to a JavaScript wallet.
-     */
-    private Value javaScriptWallet;
+  /**
+   * An underlying reference to a JavaScript wallet.
+   */
+  private Value javaScriptWallet;
 
-    /**
-     * Initialize a new JavaScriptWallet.
-     *
-     * @param javaScriptWallet A reference to a JavaScript based wallet.
-     */
-    public JavaScriptWallet(Value javaScriptWallet) {
-        this.javaScriptWallet = javaScriptWallet;
-    }
+  /**
+   * Initialize a new JavaScriptWallet.
+   *
+   * @param javaScriptWallet A reference to a JavaScript based wallet.
+   */
+  public JavaScriptWallet(Value javaScriptWallet) {
+    this.javaScriptWallet = javaScriptWallet;
+  }
 
-    /**
-     * Returns the address of this JavaScriptWallet.
-     *
-     * @return The address of the wallet.
-     */
-    public String getAddress() {
-        return javaScriptWallet.invokeMember("getAddress").asString();
-    }
+  /**
+   * Returns the address of this JavaScriptWallet.
+   *
+   * @return The address of the wallet.
+   */
+  public String getAddress() {
+    return javaScriptWallet.invokeMember("getAddress").asString();
+  }
 
-    /**
-     * Returns the public key of this JavaScriptWallet.
-     *
-     * @return A hexadecimal encoded representation of the wallet's public key.
-     */
-    public String getPublicKey() {
-        return javaScriptWallet.invokeMember("getPublicKey").asString();
-    }
+  /**
+   * Returns the public key of this JavaScriptWallet.
+   *
+   * @return A hexadecimal encoded representation of the wallet's public key.
+   */
+  public String getPublicKey() {
+    return javaScriptWallet.invokeMember("getPublicKey").asString();
+  }
 
-    /**
-     * Returns the private key of this JavaScriptWallet.
-     *
-     * @return A hexadecimal encoded representation of the wallet's private key.
-     */
-    public String getPrivateKey() {
-        return javaScriptWallet.invokeMember("getPrivateKey").asString();
-    }
+  /**
+   * Returns the private key of this JavaScriptWallet.
+   *
+   * @return A hexadecimal encoded representation of the wallet's private key.
+   */
+  public String getPrivateKey() {
+    return javaScriptWallet.invokeMember("getPrivateKey").asString();
+  }
 
-    /**
-     * Sign the given input.
-     *
-     * @param input The input to sign.
-     *
-     * @return A hexadecimal encoded signature.
-     *
-     * @throws XRPException An exception if the input could not be signed.
-     */
-    public String sign(String input) throws XRPException {
-        Value javaScriptSignature = javaScriptWallet.invokeMember("sign", input);
-        if (javaScriptSignature.isNull()) {
-            throw new XRPException(XRPExceptionType.SIGNING_ERROR, "Could not sign input");
-        }
-        return javaScriptSignature.asString();
+  /**
+   * Sign the given input.
+   *
+   * @param input The input to sign.
+   * @return A hexadecimal encoded signature.
+   * @throws XRPException An exception if the input could not be signed.
+   */
+  public String sign(String input) throws XRPException {
+    Value javaScriptSignature = javaScriptWallet.invokeMember("sign", input);
+    if (javaScriptSignature.isNull()) {
+      throw new XRPException(XRPExceptionType.SIGNING_ERROR, "Could not sign input");
     }
+    return javaScriptSignature.asString();
+  }
 
-    /**
-     * Verify that a given signature is valid for the given message.
-     *
-     * @param message   A message in hexadecimal encoding.
-     * @param signature A signature in hexademical encoding.
-     *
-     * @return A boolean indicating the validity of the signature.
-     */
-    public boolean verify(String message, String signature) {
-        return javaScriptWallet.invokeMember("verify", message, signature).asBoolean();
-    }
+  /**
+   * Verify that a given signature is valid for the given message.
+   *
+   * @param message   A message in hexadecimal encoding.
+   * @param signature A signature in hexademical encoding.
+   * @return A boolean indicating the validity of the signature.
+   */
+  public boolean verify(String message, String signature) {
+    return javaScriptWallet.invokeMember("verify", message, signature).asBoolean();
+  }
 }

--- a/src/main/java/io/xpring/xrpl/javascript/JavaScriptWalletFactory.java
+++ b/src/main/java/io/xpring/xrpl/javascript/JavaScriptWalletFactory.java
@@ -11,116 +11,120 @@ import java.security.SecureRandom;
 
 public class JavaScriptWalletFactory {
 
-    private static final JavaScriptWalletFactory sharedJavaScriptWalletFactory;
+  private static final JavaScriptWalletFactory sharedJavaScriptWalletFactory;
 
-    public static String invalidMnemonicOrDerivationPathMessage = "Invalid mnemonic or derivation path.";
+  public static String invalidMnemonicOrDerivationPathMessage = "Invalid mnemonic or derivation path.";
 
-    static {
-        try {
-            sharedJavaScriptWalletFactory = new JavaScriptWalletFactory();
-        } catch (JavaScriptLoaderException e) {
-            throw new RuntimeException(e);
-        }
+  static {
+    try {
+      sharedJavaScriptWalletFactory = new JavaScriptWalletFactory();
+    } catch (JavaScriptLoaderException e) {
+      throw new RuntimeException(e);
     }
+  }
 
-    private Value wallet;
+  private Value wallet;
 
-    private JavaScriptWalletFactory() throws JavaScriptLoaderException {
-        Context context = JavaScriptLoader.getContext();
-        this.wallet = JavaScriptLoader.loadResource("Wallet", context);
+  private JavaScriptWalletFactory() throws JavaScriptLoaderException {
+    Context context = JavaScriptLoader.getContext();
+    this.wallet = JavaScriptLoader.loadResource("Wallet", context);
+  }
+
+  public static JavaScriptWalletFactory get() {
+    return sharedJavaScriptWalletFactory;
+  }
+
+  public String getDefaultDerivationPath() throws JavaScriptLoaderException {
+    Value getDefaultDerivationPathFunction = JavaScriptLoader.loadResource("getDefaultDerivationPath", wallet);
+    return getDefaultDerivationPathFunction.execute().asString();
+  }
+
+  /**
+   * Generate a random Wallet.
+   *
+   * @param isTest Whether the address is for use on a test network.
+   * @return A {WalletGenerationResult} containing the artifacts of the generation process.
+   */
+  public JavaScriptWalletGenerationResult generateRandomWallet(boolean isTest) {
+    byte[] randomBytes = randomBytes(16);
+    String hexRandomBytes = Utils.byteArrayToHex(randomBytes);
+
+    Value walletGenerationResult = this.wallet.invokeMember("generateRandomWallet", hexRandomBytes, isTest);
+    return new JavaScriptWalletGenerationResult(
+        walletGenerationResult.getMember("mnemonic").asString(),
+        walletGenerationResult.getMember("derivationPath").asString(),
+        new JavaScriptWallet(walletGenerationResult.getMember("wallet"))
+    );
+  }
+
+  /**
+   * Instantiate a new wallet from a set of keys.
+   *
+   * @param publicKey  A hex encoded string representing the public key.
+   * @param privateKey A hex encoded string representing the private key.
+   * @param isTest     Whether the address is for use on a test network.
+   * @return A new {@link JavaScriptWallet}.
+   * @throws XRPException If either input key is malformed.
+   */
+  public JavaScriptWallet walletFromKeys(String publicKey, String privateKey, boolean isTest) throws XRPException {
+    Value wallet = this.wallet.newInstance(publicKey, privateKey, isTest);
+    if (wallet.isNull()) {
+      throw new XRPException(XRPExceptionType.INVALID_INPUTS, "Invalid inputs");
     }
+    return new JavaScriptWallet(wallet);
+  }
 
-    public static JavaScriptWalletFactory get() {
-        return sharedJavaScriptWalletFactory;
+  /**
+   * Initialize a new wallet from a seed.
+   *
+   * @param seed   A base58check encoded seed for the wallet.
+   * @param isTest Whether the address is for use on a test network.
+   * @return A new {@link JavaScriptWallet}.
+   * @throws XRPException If the seed is malformed.
+   */
+  public JavaScriptWallet walletFromSeed(String seed, boolean isTest) throws XRPException {
+    Value wallet = this.wallet.invokeMember("generateWalletFromSeed", seed, isTest);
+    if (wallet.isNull()) {
+      throw new XRPException(XRPExceptionType.INVALID_INPUTS, "Invalid Seed");
     }
+    return new JavaScriptWallet(wallet);
+  }
 
-    public String getDefaultDerivationPath() throws JavaScriptLoaderException {
-        Value getDefaultDerivationPathFunction = JavaScriptLoader.loadResource("getDefaultDerivationPath", wallet);
-        return getDefaultDerivationPathFunction.execute().asString();
+  /**
+   * Create a new HD Wallet.
+   *
+   * @param mnemonic       A space separated mnemonic.
+   * @param derivationPath A derivation. If null, the default derivation path will be used.
+   * @param isTest         Whether the address is for use on a test network.
+   * @return A new {@link JavaScriptWallet}.
+   * @throws XRPException If the mnemonic or derivation path are malformed.
+   */
+  public JavaScriptWallet walletFromMnemonicAndDerivationPath(
+      String mnemonic,
+      String derivationPath,
+      boolean isTest
+  ) throws XRPException {
+    try {
+      String normalizedDerivationPath = derivationPath != null ? derivationPath : this.getDefaultDerivationPath();
+      Value wallet = this.wallet.invokeMember("generateWalletFromMnemonic", mnemonic, normalizedDerivationPath, isTest);
+
+      if (wallet.isNull()) {
+        throw new XRPException(XRPExceptionType.INVALID_INPUTS, invalidMnemonicOrDerivationPathMessage);
+      }
+
+      return new JavaScriptWallet(wallet);
+    } catch (PolyglotException exception) {
+      throw new XRPException(XRPExceptionType.INVALID_INPUTS, invalidMnemonicOrDerivationPathMessage);
+    } catch (JavaScriptLoaderException exception) {
+      throw new XRPException(XRPExceptionType.INVALID_INPUTS, invalidMnemonicOrDerivationPathMessage);
     }
+  }
 
-    /**
-     * Generate a random Wallet.
-     *
-     * @param isTest Whether the address is for use on a test network.
-     * @return A {WalletGenerationResult} containing the artifacts of the generation process.
-     */
-    public JavaScriptWalletGenerationResult generateRandomWallet(boolean isTest) {
-        byte[] randomBytes = randomBytes(16);
-        String hexRandomBytes = Utils.byteArrayToHex(randomBytes);
+  private byte[] randomBytes(int numBytes) {
+    SecureRandom random = new SecureRandom();
+    byte[] bytes = new byte[numBytes];
+    random.nextBytes(bytes);
 
-        Value walletGenerationResult = this.wallet.invokeMember("generateRandomWallet", hexRandomBytes, isTest);
-        return new JavaScriptWalletGenerationResult(
-            walletGenerationResult.getMember("mnemonic").asString(),
-            walletGenerationResult.getMember("derivationPath").asString(),
-            new JavaScriptWallet(walletGenerationResult.getMember("wallet"))
-        );
-    }
-
-    /**
-     * Instantiate a new wallet from a set of keys.
-     *
-     * @param publicKey A hex encoded string representing the public key.
-     * @param privateKey A hex encoded string representing the private key.
-     * @param isTest Whether the address is for use on a test network.
-     * @throws XRPException If either input key is malformed.
-     * @return A new {@link JavaScriptWallet}.
-     */
-    public JavaScriptWallet walletFromKeys(String publicKey, String privateKey, boolean isTest) throws XRPException {
-        Value wallet = this.wallet.newInstance(publicKey, privateKey, isTest);
-        if (wallet.isNull()) {
-            throw new XRPException(XRPExceptionType.INVALID_INPUTS, "Invalid inputs");
-        }
-        return new JavaScriptWallet(wallet);
-    }
-
-    /**
-     * Initialize a new wallet from a seed.
-     *
-     * @param seed A base58check encoded seed for the wallet.
-     * @param isTest Whether the address is for use on a test network.
-     * @throws XRPException If the seed is malformed.
-     * @return A new {@link JavaScriptWallet}.
-     */
-    public JavaScriptWallet walletFromSeed(String seed, boolean isTest) throws XRPException {
-        Value wallet = this.wallet.invokeMember("generateWalletFromSeed", seed, isTest);
-        if (wallet.isNull()) {
-            throw new XRPException(XRPExceptionType.INVALID_INPUTS, "Invalid Seed");
-        }
-        return new JavaScriptWallet(wallet);
-    }
-
-    /**
-     * Create a new HD Wallet.
-     *
-     * @param mnemonic       A space separated mnemonic.
-     * @param derivationPath A derivation. If null, the default derivation path will be used.
-     * @param isTest Whether the address is for use on a test network.
-     * @throws XRPException If the mnemonic or derivation path are malformed.
-     * @return A new {@link JavaScriptWallet}.
-     */
-    public JavaScriptWallet walletFromMnemonicAndDerivationPath(String mnemonic, String derivationPath, boolean isTest) throws XRPException {
-        try {
-            String normalizedDerivationPath = derivationPath != null ? derivationPath : this.getDefaultDerivationPath();
-            Value wallet = this.wallet.invokeMember("generateWalletFromMnemonic", mnemonic, normalizedDerivationPath, isTest);
-
-            if (wallet.isNull()) {
-                throw new XRPException(XRPExceptionType.INVALID_INPUTS, invalidMnemonicOrDerivationPathMessage);
-            }
-
-            return new JavaScriptWallet(wallet);
-        } catch (PolyglotException exception) {
-            throw new XRPException(XRPExceptionType.INVALID_INPUTS, invalidMnemonicOrDerivationPathMessage);
-        } catch (JavaScriptLoaderException exception) {
-            throw new XRPException(XRPExceptionType.INVALID_INPUTS, invalidMnemonicOrDerivationPathMessage);
-        }
-    }
-
-    private byte[] randomBytes(int numBytes) {
-        SecureRandom random = new SecureRandom();
-        byte bytes[] = new byte[numBytes];
-        random.nextBytes(bytes);
-
-        return bytes;
-    }
+    return bytes;
+  }
 }

--- a/src/main/java/io/xpring/xrpl/javascript/JavaScriptWalletGenerationResult.java
+++ b/src/main/java/io/xpring/xrpl/javascript/JavaScriptWalletGenerationResult.java
@@ -2,23 +2,47 @@ package io.xpring.xrpl.javascript;
 
 import io.xpring.xrpl.Wallet;
 
-/** Contains JavaScript artifacts of generating a new Wallet. */
+/**
+ * Contains JavaScript artifacts of generating a new Wallet.
+ */
 public class JavaScriptWalletGenerationResult {
-    /** The mnemonic of the newly generated {@link Wallet}. */
-    private String mnemonic;
-    public String getMnemonic() { return mnemonic; }
+  /**
+   * The mnemonic of the newly generated {@link Wallet}.
+   */
+  private String mnemonic;
 
-    /** The derivation path of the newly generated {@link Wallet}. */
-    private String derivationPath;
-    public String getDerivationPath() { return derivationPath; }
+  public String getMnemonic() {
+    return mnemonic;
+  }
 
-    /** The newly generated {@link Wallet}. */
-    private JavaScriptWallet wallet;
-    public JavaScriptWallet getWallet()  { return wallet; }
+  /**
+   * The derivation path of the newly generated {@link Wallet}.
+   */
+  private String derivationPath;
 
-    public JavaScriptWalletGenerationResult(String mnemonic, String derivationPath, JavaScriptWallet wallet) {
-        this.mnemonic = mnemonic;
-        this.derivationPath = derivationPath;
-        this.wallet = wallet;
-    }
+  public String getDerivationPath() {
+    return derivationPath;
+  }
+
+  /**
+   * The newly generated {@link Wallet}.
+   */
+  private JavaScriptWallet wallet;
+
+  public JavaScriptWallet getWallet() {
+    return wallet;
+  }
+
+  /**
+   * Create a new JavaScriptWalletGenerationResult.
+   *
+   * @param mnemonic       The mnemonic that generated the wallet.
+   * @param derivationPath The derivation path that generated the wallet.
+   * @param wallet         The newly generated wallet.
+   */
+  public JavaScriptWalletGenerationResult(String mnemonic, String derivationPath, JavaScriptWallet wallet) {
+    this.mnemonic = mnemonic;
+    this.derivationPath = derivationPath;
+    this.wallet = wallet;
+  }
 }

--- a/src/main/java/io/xpring/xrpl/model/XRPCurrency.java
+++ b/src/main/java/io/xpring/xrpl/model/XRPCurrency.java
@@ -1,42 +1,43 @@
 package io.xpring.xrpl.model;
 
-import org.xrpl.rpc.v1.Currency;
 import org.immutables.value.Value;
+import org.xrpl.rpc.v1.Currency;
 
 /**
- * An issued currency on the XRP LEdger
+ * An issued currency on the XRP Ledger.
  *
  * @see "https://xrpl.org/currency-formats.html#currency-codes"
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 @Value.Immutable
 public interface XRPCurrency {
-    static ImmutableXRPCurrency.Builder builder() {
-        return ImmutableXRPCurrency.builder();
-    }
+  static ImmutableXRPCurrency.Builder builder() {
+    return ImmutableXRPCurrency.builder();
+  }
 
-    /**
-     * @return 3 character currency ASCII code
-     */
-    String name();
+  /**
+   * The 3 character currency ASCII code.
+   */
+  String name();
 
-    /**
-     * @return 160 bit currency code. 20 bytes
-     */
-    byte[] code();
+  /**
+   * The 160 bit currency code. 20 bytes.
+   */
+  byte[] code();
 
-    /**
-     * Constructs an {@link XRPCurrency} from a {@link Currency}
-     * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/amount.proto#L41">
-     *     Currency protocol buffer</a>
-     *
-     * @param currency a {@link Currency} (protobuf object) whose field values will be used
-     *                 to construct an {@link XRPCurrency}
-     * @return an {@link XRPCurrency} with its fields set via the analogous protobuf fields.
-     */
-    static XRPCurrency from(Currency currency) {
-        return builder()
-                .name(currency.getName())
-                .code(currency.getCode().toByteArray())
-                .build();
-    }
+  /**
+   * Constructs an {@link XRPCurrency} from a {@link Currency}.
+   *
+   * @param currency a {@link Currency} (protobuf object) whose field values will be used
+   *                 to construct an {@link XRPCurrency}
+   * @return an {@link XRPCurrency} with its fields set via the analogous protobuf fields.
+   * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/amount.proto#L41">
+   * Currency protocol buffer</a>
+   */
+  static XRPCurrency from(Currency currency) {
+    return builder()
+        .name(currency.getName())
+        .code(currency.getCode().toByteArray())
+        .build();
+  }
 }

--- a/src/main/java/io/xpring/xrpl/model/XRPCurrencyAmount.java
+++ b/src/main/java/io/xpring/xrpl/model/XRPCurrencyAmount.java
@@ -1,69 +1,74 @@
 package io.xpring.xrpl.model;
 
-import io.xpring.ilp.model.AccountBalance;
-import org.interledger.spsp.server.grpc.GetBalanceResponse;
-import org.xrpl.rpc.v1.CurrencyAmount;
+
 import org.immutables.value.Value;
+import org.xrpl.rpc.v1.CurrencyAmount;
 import org.xrpl.rpc.v1.IssuedCurrencyAmount;
 
 import javax.annotation.Nullable;
 
 /**
- * An amount of currency on the XRP Ledger
+ * An amount of currency on the XRP Ledger.
+ *
  * @see "https://xrpl.org/basic-data-types.html#specifying-currency-amounts"
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 @Value.Immutable
 public interface XRPCurrencyAmount {
-    static ImmutableXRPCurrencyAmount.Builder builder() {
-        return ImmutableXRPCurrencyAmount.builder();
-    }
+  static ImmutableXRPCurrencyAmount.Builder builder() {
+    return ImmutableXRPCurrencyAmount.builder();
+  }
 
-    /**
-     * @return An amount of XRP, specified in drops.
-     * Mutually exclusive fields - only drops XOR issuedCurrency should be set.
-     */
-     @Nullable
-     String drops();
+  /**
+   * An amount of XRP, specified in drops.
+   * <p>
+   * Note: Mutually exclusive fields - only drops XOR issuedCurrency should be set.
+   * </p>
+   */
+  @Nullable
+  String drops();
 
-    /**
-     * @return An amount of an issued currency.
-     * Mutually exclusive fields - only drops XOR issuedCurrency should be set.
-     */
-    @Nullable
-    XRPIssuedCurrency issuedCurrency();
+  /**
+   * An amount of an issued currency.
+   * <p>
+   * Note: Mutually exclusive fields - only drops XOR issuedCurrency should be set.
+   * </p>
+   */
+  @Nullable
+  XRPIssuedCurrency issuedCurrency();
 
-    /**
-     * Constructs an {@link XRPCurrencyAmount} from a {@link CurrencyAmount}
-     * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/amount.proto#L10">
-     *     CurrencyAmount protocol buffer</a>
-     *
-     * @param currencyAmount a {@link CurrencyAmount} (protobuf object) whose field values will be used
-     *                           to construct an {@link XRPCurrencyAmount}
-     * @return an {@link XRPCurrencyAmount} with its fields set via the analogous protobuf fields.
-     */
-    static XRPCurrencyAmount from(CurrencyAmount currencyAmount) throws NumberFormatException {
-        switch (currencyAmount.getAmountCase()) {
-            // Mutually exclusive: either drops or issuedCurrency is set in an XRPCurrencyAmount
-            case ISSUED_CURRENCY_AMOUNT: {
-                IssuedCurrencyAmount issuedCurrencyAmount = currencyAmount.getIssuedCurrencyAmount();
-                if (issuedCurrencyAmount != null) {
-                    XRPIssuedCurrency xrpIssuedCurrency = XRPIssuedCurrency.from(issuedCurrencyAmount);
-                    if (xrpIssuedCurrency != null) {
-                        return builder().issuedCurrency(xrpIssuedCurrency).build();
-                    }
-                }
-                // if AmountCase is ISSUED_CURRENCY_AMOUNT, we must be able to convert this to an XRPIssuedCurrency
-                return null;
-            }
-            case XRP_AMOUNT: {
-                long numericDrops = currencyAmount.getXrpAmount().getDrops();
-                String drops = Long.toString(numericDrops);
-                return builder().drops(drops)
-                                .build();
-            }
-            // if no AmountCase is set (e.g. empty CurrencyAmount protobuf was passed to constructor)
-            default:
-                return null;
+  /**
+   * Constructs an {@link XRPCurrencyAmount} from a {@link CurrencyAmount}.
+   *
+   * @param currencyAmount a {@link CurrencyAmount} (protobuf object) whose field values will be used
+   *                       to construct an {@link XRPCurrencyAmount}
+   * @return an {@link XRPCurrencyAmount} with its fields set via the analogous protobuf fields.
+   * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/amount.proto#L10">
+   * CurrencyAmount protocol buffer</a>
+   */
+  static XRPCurrencyAmount from(CurrencyAmount currencyAmount) throws NumberFormatException {
+    switch (currencyAmount.getAmountCase()) {
+      // Mutually exclusive: either drops or issuedCurrency is set in an XRPCurrencyAmount
+      case ISSUED_CURRENCY_AMOUNT: {
+        IssuedCurrencyAmount issuedCurrencyAmount = currencyAmount.getIssuedCurrencyAmount();
+        if (issuedCurrencyAmount != null) {
+          XRPIssuedCurrency xrpIssuedCurrency = XRPIssuedCurrency.from(issuedCurrencyAmount);
+          if (xrpIssuedCurrency != null) {
+            return builder().issuedCurrency(xrpIssuedCurrency).build();
+          }
         }
+        // if AmountCase is ISSUED_CURRENCY_AMOUNT, we must be able to convert this to an XRPIssuedCurrency
+        return null;
+      }
+      case XRP_AMOUNT: {
+        long numericDrops = currencyAmount.getXrpAmount().getDrops();
+        String drops = Long.toString(numericDrops);
+        return builder().drops(drops)
+            .build();
+      }
+      // if no AmountCase is set (e.g. empty CurrencyAmount protobuf was passed to constructor)
+      default:
+        return null;
     }
+  }
 }

--- a/src/main/java/io/xpring/xrpl/model/XRPIssuedCurrency.java
+++ b/src/main/java/io/xpring/xrpl/model/XRPIssuedCurrency.java
@@ -1,55 +1,58 @@
 package io.xpring.xrpl.model;
 
-import org.xrpl.rpc.v1.IssuedCurrencyAmount;
-import java.math.BigInteger;
 import org.immutables.value.Value;
+import org.xrpl.rpc.v1.IssuedCurrencyAmount;
+
+import java.math.BigInteger;
 
 /**
- * An issued currency on the XRP Ledger
+ * An issued currency on the XRP Ledger.
+ *
  * @see "https://xrpl.org/basic-data-types.html#specifying-currency-amounts"
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 @Value.Immutable
 public interface XRPIssuedCurrency {
-    static ImmutableXRPIssuedCurrency.Builder builder() {
-        return ImmutableXRPIssuedCurrency.builder();
+  static ImmutableXRPIssuedCurrency.Builder builder() {
+    return ImmutableXRPIssuedCurrency.builder();
+  }
+
+  /**
+   * The currency used to value the amount.
+   */
+  XRPCurrency currency();
+
+  /**
+   * The value of the amount.
+   */
+  BigInteger value();
+
+  /**
+   * Unique account address of the entity issuing the currency.
+   */
+  String issuer();
+
+  /**
+   * Constructs an {@link XRPIssuedCurrency} from a {@link IssuedCurrencyAmount}.
+   *
+   * @param issuedCurrency a {@link IssuedCurrencyAmount} (protobuf object) whose field values will be used
+   *                       to construct an {@link XRPIssuedCurrency}
+   * @return an {@link XRPIssuedCurrency} with its fields set via the analogous protobuf fields.
+   * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/amount.proto#L28">
+   * IssuedCurrencyAmount protocol buffer</a>
+   */
+  static XRPIssuedCurrency from(IssuedCurrencyAmount issuedCurrency) {
+    BigInteger value;
+    try {
+      value = new BigInteger((issuedCurrency.getValue()));
+    } catch (NumberFormatException error) {
+      throw error;
     }
 
-    /**
-     * @return The currency used to value the amount.
-     */
-    XRPCurrency currency();
-
-    /**
-     * @return The value of the amount.
-     */
-    BigInteger value();
-
-    /**
-     * @return Unique account address of the entity issuing the currency.
-     */
-    String issuer();
-
-    /**
-     * Constructs an {@link XRPIssuedCurrency} from a {@link IssuedCurrencyAmount}
-     * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/amount.proto#L28">
-     *     IssuedCurrencyAmount protocol buffer</a>
-     *
-     * @param issuedCurrency a {@link IssuedCurrencyAmount} (protobuf object) whose field values will be used
-     *                 to construct an {@link XRPIssuedCurrency}
-     * @return an {@link XRPIssuedCurrency} with its fields set via the analogous protobuf fields.
-     */
-    static XRPIssuedCurrency from(IssuedCurrencyAmount issuedCurrency) {
-        BigInteger value;
-        try {
-            value = new BigInteger((issuedCurrency.getValue()));
-        } catch (NumberFormatException error) {
-            throw error;
-        }
-
-        return builder()
-                .currency(XRPCurrency.from(issuedCurrency.getCurrency()))
-                .value(value)
-                .issuer(issuedCurrency.getIssuer().getAddress())
-                .build();
-    }
+    return builder()
+        .currency(XRPCurrency.from(issuedCurrency.getCurrency()))
+        .value(value)
+        .issuer(issuedCurrency.getIssuer().getAddress())
+        .build();
+  }
 }

--- a/src/main/java/io/xpring/xrpl/model/XRPMemo.java
+++ b/src/main/java/io/xpring/xrpl/model/XRPMemo.java
@@ -1,64 +1,70 @@
 package io.xpring.xrpl.model;
 
 import com.google.protobuf.ByteString;
-import org.xrpl.rpc.v1.Memo;
 import org.immutables.value.Value;
+import org.xrpl.rpc.v1.Memo;
 
 import javax.annotation.Nullable;
 
 /**
  * Represents a memo on the XRPLedger.
+ *
  * @see "https://xrpl.org/transaction-common-fields.html#memos-field"
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 @Value.Immutable
 public interface XRPMemo {
-    static ImmutableXRPMemo.Builder builder() {
-        return ImmutableXRPMemo.builder();
-    }
+  static ImmutableXRPMemo.Builder builder() {
+    return ImmutableXRPMemo.builder();
+  }
 
-    /**
-     * @return Arbitrary hex value, conventionally containing the content of the memo.
-     */
-    @Nullable
-    byte[] data();
+  /**
+   * Arbitrary hex value, conventionally containing the content of the memo.
+   */
+  @Nullable
+  byte[] data();
 
-    /**
-     * @return Hex value representing characters allowed in URLs.
-     * Conventionally containing information on how the memo is encoded, for example as a MIME type.
-     */
-    @Nullable
-    byte[] format();
+  /**
+   * Hex value representing characters allowed in URLs.
+   * <p>
+   * Conventionally containing information on how the memo is encoded, for example as a MIME type.
+   * </p>
+   */
+  @Nullable
+  byte[] format();
 
-    /**
-     * @return Hex value representing characters allowed in URLs.
-     * Conventionally, a unique relation (according to RFC 5988) that defines the format of this memo.
-     */
-    @Nullable
-    byte[] type();
+  /**
+   * Hex value representing characters allowed in URLs.
+   * <p>
+   * Conventionally, a unique relation (according to RFC 5988) that defines the format of this memo.
+   * </p>
+   */
+  @Nullable
+  byte[] type();
 
-    /**
-     * Constructs an {@link XRPMemo} from a {@link Memo}
-     * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L80">
-     *     Memo protocol buffer</a>
-     *
-     * @param memo a {@link Memo} (protobuf object) whose field values will be used
-     *                 to construct an {@link XRPMemo}
-     * @return an {@link XRPMemo} with its fields set via the analogous protobuf fields.
-     */
-    static XRPMemo from(Memo memo) {
-        ByteString memoData = memo.getMemoData().getValue();
-        byte[] data = memoData.equals(ByteString.EMPTY) ? null : memoData.toByteArray();
+  /**
+   * Constructs an {@link XRPMemo} from a {@link Memo}.
+   *
+   * @param memo a {@link Memo} (protobuf object) whose field values will be used
+   *             to construct an {@link XRPMemo}
+   * @return an {@link XRPMemo} with its fields set via the analogous protobuf fields.
+   * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L80">
+   * Memo protocol buffer</a>
+   */
+  static XRPMemo from(Memo memo) {
+    ByteString memoData = memo.getMemoData().getValue();
+    byte[] data = memoData.equals(ByteString.EMPTY) ? null : memoData.toByteArray();
 
-        ByteString memoFormat = memo.getMemoFormat().getValue();
-        byte[] format = memoFormat.equals(ByteString.EMPTY) ? null : memoFormat.toByteArray();
+    ByteString memoFormat = memo.getMemoFormat().getValue();
+    byte[] format = memoFormat.equals(ByteString.EMPTY) ? null : memoFormat.toByteArray();
 
-        ByteString memoType = memo.getMemoType().getValue();
-        byte[] type = memoType.equals(ByteString.EMPTY) ? null : memoType.toByteArray();
+    ByteString memoType = memo.getMemoType().getValue();
+    byte[] type = memoType.equals(ByteString.EMPTY) ? null : memoType.toByteArray();
 
-        return XRPMemo.builder()
-                    .data(data)
-                    .format(format)
-                    .type(type)
-                    .build();
-    }
+    return XRPMemo.builder()
+        .data(data)
+        .format(format)
+        .type(type)
+        .build();
+  }
 }

--- a/src/main/java/io/xpring/xrpl/model/XRPPath.java
+++ b/src/main/java/io/xpring/xrpl/model/XRPPath.java
@@ -1,42 +1,44 @@
 package io.xpring.xrpl.model;
 
-import org.xrpl.rpc.v1.Payment.Path;
 import org.immutables.value.Value;
+import org.xrpl.rpc.v1.Payment.Path;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 /**
  * A path in the XRP Ledger.
+ *
  * @see "https://xrpl.org/paths.html"
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 @Value.Immutable
 public interface XRPPath {
-    static ImmutableXRPPath.Builder builder() {
-        return ImmutableXRPPath.builder();
-    }
+  static ImmutableXRPPath.Builder builder() {
+    return ImmutableXRPPath.builder();
+  }
 
-    /**
-     * @return List of XRPPathElements that make up this XRPPath
-     */
-    List<XRPPathElement> pathElements();
+  /**
+   * List of XRPPathElements that make up this XRPPath.
+   */
+  List<XRPPathElement> pathElements();
 
-    /**
-     * Constructs an {@link XRPPath} from a {@link org.xrpl.rpc.v1.Payment.Path}
-     * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L237">
-     *     Path protocol buffer</a>
-     *
-     * @param path a {@link org.xrpl.rpc.v1.Payment.Path} (protobuf object) whose field values will be used
-     *                 to construct an {@link XRPPath}
-     * @return an {@link XRPPath} with its fields set via the analogous protobuf fields.
-     */
-    static XRPPath from(Path path) {
-        List<XRPPathElement> pathElements = path.getElementsList()
-                                            .stream()
-                                            .map(pathElement -> XRPPathElement.from(pathElement))
-                                            .collect(Collectors.toList());
-        return builder()
-                .pathElements(pathElements)
-                .build();
-    }
+  /**
+   * Constructs an {@link XRPPath} from a {@link org.xrpl.rpc.v1.Payment.Path}.
+   *
+   * @param path a {@link org.xrpl.rpc.v1.Payment.Path} (protobuf object) whose field values will be used
+   *             to construct an {@link XRPPath}
+   * @return an {@link XRPPath} with its fields set via the analogous protobuf fields.
+   * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L237">
+   * Path protocol buffer</a>
+   */
+  static XRPPath from(Path path) {
+    List<XRPPathElement> pathElements = path.getElementsList()
+        .stream()
+        .map(XRPPathElement::from)
+        .collect(Collectors.toList());
+    return builder()
+        .pathElements(pathElements)
+        .build();
+  }
 }

--- a/src/main/java/io/xpring/xrpl/model/XRPPathElement.java
+++ b/src/main/java/io/xpring/xrpl/model/XRPPathElement.java
@@ -1,55 +1,60 @@
 package io.xpring.xrpl.model;
 
-import org.xrpl.rpc.v1.Payment.PathElement;
 import org.immutables.value.Value;
+import org.xrpl.rpc.v1.Payment.PathElement;
 
 /**
  * A path step in an XRP Ledger Path.
+ *
  * @see "https://xrpl.org/paths.html#path-steps"
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 @Value.Immutable
 public interface XRPPathElement {
-    static ImmutableXRPPathElement.Builder builder() {
-        return ImmutableXRPPathElement.builder();
-    }
+  static ImmutableXRPPathElement.Builder builder() {
+    return ImmutableXRPPathElement.builder();
+  }
 
-    /**
-     * @return (Optional) If present, this path step represents rippling through the specified address.
-     * MUST NOT be provided if this path element specifies the currency or issuer fields.
-     */
-    String account();
+  /**
+   * If present, this path step represents rippling through the specified address.
+   * <p>
+   * This field is optional. MUST NOT be provided if this path element specifies the currency or issuer fields.
+   * </p>
+   */
+  String account();
 
-    /**
-     * @return (Optional) If present, this path element represents changing currencies through an order book.
-     * The currency specified indicates the new currency.
-     * MUST NOT be provided if this path element specifies the account field.
-     */
-    XRPCurrency currency();
+  /**
+   * If present, this path element represents changing currencies through an order book.
+   * <p>
+   * This field is optional. The currency specified indicates the new currency. MUST NOT be provided if this path
+   * element specifies the account field.
+   * </p>
+   */
+  XRPCurrency currency();
 
-    /**
-     *
-     * @return (Optional) If present, this path element represents changing currencies and this address
-     * defines the issuer of the new currency. If omitted in a path element with a non-XRP currency,
-     * a previous element of the path defines the issuer. If present when currency is omitted,
-     * indicates a path element that uses an order book between same-named currencies with different issuers.
-     * MUST be omitted if the currency is XRP. MUST NOT be provided if this element specifies the account field.
-     */
-    String issuer();
+  /**
+   * (Optional) If present, this path element represents changing currencies and this address
+   * defines the issuer of the new currency. If omitted in a path element with a non-XRP currency,
+   * a previous element of the path defines the issuer. If present when currency is omitted,
+   * indicates a path element that uses an order book between same-named currencies with different issuers.
+   * MUST be omitted if the currency is XRP. MUST NOT be provided if this element specifies the account field.
+   */
+  String issuer();
 
-    /**
-     * Constructs an {@link XRPPathElement} from a {@link org.xrpl.rpc.v1.Payment.PathElement}
-     * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L227">
-     *     PathElement protocol buffer</a>
-     *
-     * @param pathElement a {@link org.xrpl.rpc.v1.Payment.PathElement} (protobuf object) whose field values will be used
-     *                 to construct an {@link XRPPathElement}
-     * @return an {@link XRPPathElement} with its fields set via the analogous protobuf fields.
-     */
-    static XRPPathElement from(PathElement pathElement) {
-        return builder()
-                .account(pathElement.getAccount().getAddress())
-                .currency(XRPCurrency.from(pathElement.getCurrency()))
-                .issuer(pathElement.getIssuer().getAddress())
-                .build();
-    }
+  /**
+   * Constructs an {@link XRPPathElement} from a {@link org.xrpl.rpc.v1.Payment.PathElement}.
+   *
+   * @param pathElement a {@link org.xrpl.rpc.v1.Payment.PathElement} (protobuf object) whose field values will be used
+   *                    to construct an {@link XRPPathElement}
+   * @return an {@link XRPPathElement} with its fields set via the analogous protobuf fields.
+   * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L227">
+   * PathElement protocol buffer</a>
+   */
+  static XRPPathElement from(PathElement pathElement) {
+    return builder()
+        .account(pathElement.getAccount().getAddress())
+        .currency(XRPCurrency.from(pathElement.getCurrency()))
+        .issuer(pathElement.getIssuer().getAddress())
+        .build();
+  }
 }

--- a/src/main/java/io/xpring/xrpl/model/XRPPayment.java
+++ b/src/main/java/io/xpring/xrpl/model/XRPPayment.java
@@ -1,131 +1,141 @@
 package io.xpring.xrpl.model;
 
+import org.immutables.value.Value;
 import org.xrpl.rpc.v1.Payment;
+
 import java.util.List;
 import java.util.stream.Collectors;
-
-import org.immutables.value.Value;
 import javax.annotation.Nullable;
 
 /**
  * A payment on the XRP Ledger.
+ *
  * @see "https://xrpl.org/payment.html"
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 @Value.Immutable
 public interface XRPPayment {
-    static ImmutableXRPPayment.Builder builder() {
-        return ImmutableXRPPayment.builder();
+  static ImmutableXRPPayment.Builder builder() {
+    return ImmutableXRPPayment.builder();
+  }
+
+  /**
+   * The amount of currency to deliver.
+   */
+  XRPCurrencyAmount amount();
+
+  /**
+   * The unique address of the account receiving the payment.
+   */
+  String destination();
+
+  /**
+   * (Optional) Arbitrary tag that identifies the reason for the payment.
+   */
+  @Nullable
+  Integer destinationTag();
+
+  /**
+   * (Optional) Minimum amount of destination currency this transaction should deliver.
+   */
+  @Nullable
+  XRPCurrencyAmount deliverMin();
+
+  /**
+   * (Optional) Arbitrary 256-bit hash representing a specific reason or identifier for this payment.
+   */
+  @Nullable
+  byte[] invoiceID();
+
+  /**
+   * Array of payment paths to be used for this transaction.
+   * <p>
+   * Must be omitted for XRP-to-XRP transactions.
+   * </p>
+   */
+  @Nullable
+  List<XRPPath> paths();
+
+  /**
+   * (Optional) Highest amount of source currency this transaction is allowed to cost.
+   */
+  @Nullable
+  XRPCurrencyAmount sendMax();
+
+  /**
+   * Constructs an {@link XRPPayment} from a {@link org.xrpl.rpc.v1.Payment}.
+   *
+   * @param payment a {@link org.xrpl.rpc.v1.Payment} (protobuf object) whose field values will be used
+   *                to construct an {@link XRPPayment}
+   * @return an {@link XRPPayment} with its fields set via the analogous protobuf fields.
+   * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L224">
+   * Payment protocol buffer</a>
+   */
+  static XRPPayment from(Payment payment) {
+    // amount is required
+    XRPCurrencyAmount amount = XRPCurrencyAmount.from(payment.getAmount().getValue());
+    if (amount == null) {
+      return null;
     }
 
-    /**
-     * @return The amount of currency to deliver.
-     */
-    XRPCurrencyAmount amount();
-
-    /**
-     * @return The unique address of the account receiving the payment.
-     */
-    String destination();
-
-    /**
-     * @return (Optional) Arbitrary tag that identifies the reason for the payment.
-     */
-    @Nullable
-    Integer destinationTag();
-
-    /**
-     * @return (Optional) Minimum amount of destination currency this transaction should deliver.
-     */
-    @Nullable
-    XRPCurrencyAmount deliverMin();
-
-    /**
-     * @return (Optional) Arbitrary 256-bit hash representing a specific reason or identifier for this payment.
-     */
-    @Nullable
-    byte[] invoiceID();
-
-    /**
-     * @return (Optional) Array of payment paths to be used for this transaction.
-     * Must be omitted for XRP-to-XRP transactions.
-     */
-    @Nullable
-    List<XRPPath> paths();
-
-    /**
-     * @return (Optional) Highest amount of source currency this transaction is allowed to cost.
-     */
-    @Nullable
-    XRPCurrencyAmount sendMax();
-
-    /**
-     * Constructs an {@link XRPPayment} from a {@link org.xrpl.rpc.v1.Payment}
-     * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L224">
-     *     Payment protocol buffer</a>
-     *
-     * @param payment a {@link org.xrpl.rpc.v1.Payment} (protobuf object) whose field values will be used
-     *                 to construct an {@link XRPPayment}
-     * @return an {@link XRPPayment} with its fields set via the analogous protobuf fields.
-     */
-    static XRPPayment from(Payment payment) {
-        // amount is required
-        XRPCurrencyAmount amount = XRPCurrencyAmount.from(payment.getAmount().getValue());
-        if (amount == null) { return null; }
-
-        // destination is required
-        if (!payment.hasDestination() || payment.getDestination().getValue().getAddress().isEmpty()) {
-            return null;
-        }
-        String destination = payment.getDestination().getValue().getAddress();
-
-        Integer destinationTag;
-        if (payment.hasDestinationTag()) {
-            destinationTag = payment.getDestinationTag().getValue();
-        } else {
-            destinationTag = null;
-        }
-
-        // If the deliverMin field is set, it must be able to be transformed into an XRPCurrencyAmount.
-        XRPCurrencyAmount deliverMin;
-        if (payment.hasDeliverMin()) {
-            deliverMin = XRPCurrencyAmount.from(payment.getDeliverMin().getValue());
-            if (deliverMin == null) { return null; }
-        } else {
-            deliverMin = null;
-        }
-
-        byte[] invoiceID;
-        if (payment.hasInvoiceId()) {
-            invoiceID = payment.getInvoiceId().getValue().toByteArray();
-        } else {
-            invoiceID = null;
-        }
-
-        List<XRPPath> paths = payment.getPathsList()
-                                     .stream()
-                                     .map(path -> XRPPath.from(path))
-                                     .collect(Collectors.toList());
-        if (paths.isEmpty()) {
-            paths = null;
-        }
-
-        // If the sendMax field is set, it must be able to be transformed into an XRPCurrencyAmount.
-        XRPCurrencyAmount sendMax;
-        if (payment.hasSendMax()) {
-            sendMax = XRPCurrencyAmount.from(payment.getSendMax().getValue());
-            if (sendMax == null) { return null; }
-        } else {
-            sendMax = null;
-        }
-
-        return builder()
-                .amount(amount)
-                .destination(destination)
-                .destinationTag(destinationTag)
-                .deliverMin(deliverMin)
-                .invoiceID(invoiceID)
-                .paths(paths)
-                .sendMax(sendMax)
-                .build();
+    // destination is required
+    if (!payment.hasDestination() || payment.getDestination().getValue().getAddress().isEmpty()) {
+      return null;
     }
+    final String destination = payment.getDestination().getValue().getAddress();
+
+    Integer destinationTag;
+    if (payment.hasDestinationTag()) {
+      destinationTag = payment.getDestinationTag().getValue();
+    } else {
+      destinationTag = null;
+    }
+
+    // If the deliverMin field is set, it must be able to be transformed into an XRPCurrencyAmount.
+    XRPCurrencyAmount deliverMin;
+    if (payment.hasDeliverMin()) {
+      deliverMin = XRPCurrencyAmount.from(payment.getDeliverMin().getValue());
+      if (deliverMin == null) {
+        return null;
+      }
+    } else {
+      deliverMin = null;
+    }
+
+    byte[] invoiceID;
+    if (payment.hasInvoiceId()) {
+      invoiceID = payment.getInvoiceId().getValue().toByteArray();
+    } else {
+      invoiceID = null;
+    }
+
+    List<XRPPath> paths = payment.getPathsList()
+        .stream()
+        .map(XRPPath::from)
+        .collect(Collectors.toList());
+    if (paths.isEmpty()) {
+      paths = null;
+    }
+
+    // If the sendMax field is set, it must be able to be transformed into an XRPCurrencyAmount.
+    XRPCurrencyAmount sendMax;
+    if (payment.hasSendMax()) {
+      sendMax = XRPCurrencyAmount.from(payment.getSendMax().getValue());
+      if (sendMax == null) {
+        return null;
+      }
+    } else {
+      sendMax = null;
+    }
+
+    return builder()
+        .amount(amount)
+        .destination(destination)
+        .destinationTag(destinationTag)
+        .deliverMin(deliverMin)
+        .invoiceID(invoiceID)
+        .paths(paths)
+        .sendMax(sendMax)
+        .build();
+  }
 }

--- a/src/main/java/io/xpring/xrpl/model/XRPSigner.java
+++ b/src/main/java/io/xpring/xrpl/model/XRPSigner.java
@@ -1,61 +1,63 @@
 package io.xpring.xrpl.model;
 
 import com.google.protobuf.ByteString;
-import org.xrpl.rpc.v1.Signer;
 import org.immutables.value.Value;
+import org.xrpl.rpc.v1.Signer;
 
 import javax.annotation.Nullable;
 
 /**
  * Represents a signer of a transaction on the XRP Ledger.
+ *
  * @see "https://xrpl.org/transaction-common-fields.html#signers-field"
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 @Value.Immutable
 public interface XRPSigner {
-    static ImmutableXRPSigner.Builder builder() {
-        return ImmutableXRPSigner.builder();
-    }
+  static ImmutableXRPSigner.Builder builder() {
+    return ImmutableXRPSigner.builder();
+  }
 
-    /**
-     * @return The address associated with this signature, as it appears in the SignerList.
-     */
-    String account();
+  /**
+   * The address associated with this signature, as it appears in the SignerList.
+   */
+  String account();
 
-    /**
-     * @return The public key used to create this signature.
-     */
-    @Nullable
-    byte[] signingPublicKey();
+  /**
+   * The public key used to create this signature.
+   */
+  @Nullable
+  byte[] signingPublicKey();
 
-    /**
-     * @return A signature for this transaction, verifiable using the SigningPubKey.
-     */
-    @Nullable
-    byte[] transactionSignature();
+  /**
+   * A signature for this transaction, verifiable using the SigningPubKey.
+   */
+  @Nullable
+  byte[] transactionSignature();
 
-    /**
-     * Constructs an {@link XRPSigner} from a {@link Signer}
-     * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L90">
-     *     Signer protocol buffer</a>
-     *
-     * @param signer a {@link Signer} (protobuf object) whose field values will be used
-     *                 to construct an {@link XRPSigner}
-     * @return an {@link XRPSigner} with its fields set via the analogous protobuf fields.
-     */
-    static XRPSigner from(Signer signer) {
-        String address = signer.getAccount().getValue().getAddress();
-        String account = address.isEmpty() ? null : address;
+  /**
+   * Constructs an {@link XRPSigner} from a {@link Signer}.
+   *
+   * @param signer a {@link Signer} (protobuf object) whose field values will be used
+   *               to construct an {@link XRPSigner}
+   * @return an {@link XRPSigner} with its fields set via the analogous protobuf fields.
+   * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L90">
+   * Signer protocol buffer</a>
+   */
+  static XRPSigner from(Signer signer) {
+    String address = signer.getAccount().getValue().getAddress();
+    String account = address.isEmpty() ? null : address;
 
-        ByteString publicKey = signer.getSigningPublicKey().getValue();
-        byte[] signingPublicKey = publicKey.equals(ByteString.EMPTY) ? null : publicKey.toByteArray();
+    ByteString publicKey = signer.getSigningPublicKey().getValue();
+    byte[] signingPublicKey = publicKey.equals(ByteString.EMPTY) ? null : publicKey.toByteArray();
 
-        ByteString txnSignature = signer.getTransactionSignature().getValue();
-        byte[] transactionSignature = txnSignature.equals(ByteString.EMPTY) ? null : txnSignature.toByteArray();
+    ByteString txnSignature = signer.getTransactionSignature().getValue();
+    byte[] transactionSignature = txnSignature.equals(ByteString.EMPTY) ? null : txnSignature.toByteArray();
 
-        return XRPSigner.builder()
-                .account(account)
-                .signingPublicKey(signingPublicKey)
-                .transactionSignature(transactionSignature)
-                .build();
-    }
+    return XRPSigner.builder()
+        .account(account)
+        .signingPublicKey(signingPublicKey)
+        .transactionSignature(transactionSignature)
+        .build();
+  }
 }

--- a/src/main/java/io/xpring/xrpl/model/XRPTransaction.java
+++ b/src/main/java/io/xpring/xrpl/model/XRPTransaction.java
@@ -2,13 +2,13 @@ package io.xpring.xrpl.model;
 
 import com.google.protobuf.ByteString;
 import io.xpring.xrpl.TransactionType;
+import org.immutables.value.Value;
 import org.xrpl.rpc.v1.Payment;
 import org.xrpl.rpc.v1.Transaction;
-import org.immutables.value.Value;
 
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /**
  * A transaction on the XRP Ledger.
@@ -16,172 +16,182 @@ import java.util.stream.Collectors;
  * @see "https://xrpl.org/transaction-formats.html"
  */
 // TODO(amiecorso): Modify this object to use X-Address format.
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 @Value.Immutable
 public interface XRPTransaction {
-    static ImmutableXRPTransaction.Builder builder() {
-        return ImmutableXRPTransaction.builder();
+  static ImmutableXRPTransaction.Builder builder() {
+    return ImmutableXRPTransaction.builder();
+  }
+
+  /**
+   * The unique address of the account that initiated the transaction.
+   */
+  String account();
+
+  /**
+   * (Optional) Hash value identifying another transaction.
+   * <p>
+   * If provided, this transaction is only valid if the sending account's previously-sent transaction matches the
+   * provided hash.
+   * </p>
+   */
+  @Nullable
+  byte[] accountTransactionID();
+
+  /**
+   * Integer amount of XRP, in drops, to be destroyed as a cost for distributing this transaction to the network.
+   */
+  Long fee();
+
+  /**
+   * (Optional) Set of bit-flags for this transaction.
+   */
+  @Nullable
+  Integer flags();
+
+  /**
+   * (Optional; strongly recommended) Highest ledger index this transaction can appear in.
+   * <p>
+   * Specifying this field places a strict upper limit on how long the transaction can wait to be validated or rejected.
+   * </p>
+   */
+  @Nullable
+  Integer lastLedgerSequence();
+
+  /**
+   * (Optional) Additional arbitrary information used to identify this transaction.
+   */
+  @Nullable
+  List<XRPMemo> memos();
+
+  /**
+   * The sequence number of the account sending the transaction.
+   * <p>
+   * A transaction is only valid if the Sequence number is exactly 1 greater than the previous transaction from the same
+   * account.
+   * </p>
+   */
+  Integer sequence();
+
+  /**
+   * (Optional) Array of objects that represent a multi-signature which authorizes this transaction.
+   */
+  @Nullable
+  List<XRPSigner> signers();
+
+  /**
+   * Hex representation of the public key that corresponds to the private key used to sign this transaction.
+   * <p>
+   * If an empty string, indicates a multi-signature is present in the Signers field instead.
+   * </p>
+   */
+  byte[] signingPublicKey();
+
+  /**
+   * (Optional) Arbitrary integer used to identify the reason for this payment or a sender on whose behalf this
+   * transaction is made.
+   * <p>
+   * Conventionally, a refund should specify the initial payment's SourceTag as the refund payment's DestinationTag.
+   * </p>
+   */
+  @Nullable
+  Integer sourceTag();
+
+  /**
+   * The signature that verifies this transaction as originating from the account it says it is from.
+   */
+  byte[] transactionSignature();
+
+  /**
+   * The type of transaction.
+   */
+  TransactionType type();
+
+  /**
+   * An XRPPayment object representing the additional fields present in a PAYMENT transaction.
+   *
+   * @see "https://xrpl.org/payment.html#payment-fields"
+   */
+  XRPPayment paymentFields();
+
+  /**
+   * Constructs an {@link XRPTransaction} from a {@link Transaction}.
+   *
+   * @param transaction a {@link Transaction} (protobuf object) whose field values will be used
+   *                    to construct an {@link XRPTransaction}
+   * @return an {@link XRPTransaction} with its fields set via the analogous protobuf fields.
+   * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L13">
+   * Transaction protocol buffer</a>
+   */
+  static XRPTransaction from(Transaction transaction) {
+    final String account = transaction.getAccount().getValue().getAddress();
+
+    ByteString accountTransactionIDByteString = transaction.getAccountTransactionId().getValue();
+    final byte[] accountTransactionID = accountTransactionIDByteString.equals(ByteString.EMPTY)
+        ? null : accountTransactionIDByteString.toByteArray();
+
+    final Long fee = transaction.getFee().getDrops();
+
+    final Integer flags = transaction.getFlags().getValue();
+
+    final Integer lastLedgerSequence = transaction.getLastLedgerSequence().getValue();
+
+    List<XRPMemo> memos = transaction.getMemosList()
+        .stream()
+        .map(XRPMemo::from)
+        .collect(Collectors.toList());
+    if (memos.isEmpty()) {
+      memos = null;
     }
 
-    /**
-     * @return The unique address of the account that initiated the transaction.
-     */
-    String account();
+    Integer sequence = transaction.getSequence().getValue();
 
-    /**
-     * @return (Optional) Hash value identifying another transaction.
-     * If provided, this transaction is only valid if the sending account's previously-sent
-     * transaction matches the provided hash.
-     */
-    @Nullable
-    byte[] accountTransactionID();
-
-    /**
-     * @return Integer amount of XRP, in drops, to be destroyed as a cost for distributing
-     * this transaction to the network.
-     */
-    Long fee();
-
-    /**
-     * @return (Optional) Set of bit-flags for this transaction.
-     */
-    @Nullable
-    Integer flags();
-
-    /**
-     * @return (Optional; strongly recommended) Highest ledger index this transaction can appear in.
-     * Specifying this field places a strict upper limit on how long the transaction can wait
-     * to be validated or rejected.
-     */
-    @Nullable
-    Integer lastLedgerSequence();
-
-    /**
-     * @return (Optional) Additional arbitrary information used to identify this transaction.
-     */
-    @Nullable
-    List<XRPMemo> memos();
-
-    /**
-     * @return The sequence number of the account sending the transaction.
-     * A transaction is only valid if the Sequence number is exactly 1 greater
-     * than the previous transaction from the same account.
-     */
-    Integer sequence();
-
-    /**
-     * @return (Optional) Array of objects that represent a multi-signature which authorizes this transaction.
-     */
-    @Nullable
-    List<XRPSigner> signers();
-
-    /**
-     * @return Hex representation of the public key that corresponds to the private key used to sign this transaction.
-     * If an empty string, indicates a multi-signature is present in the Signers field instead.
-     */
-    byte[] signingPublicKey();
-
-    /**
-     * @return (Optional) Arbitrary integer used to identify the reason for this payment,
-     * or a sender on whose behalf this transaction is made.
-     * Conventionally, a refund should specify the initial payment's SourceTag as the refund payment's DestinationTag.
-     */
-    @Nullable
-    Integer sourceTag();
-
-    /**
-     * @return The signature that verifies this transaction as originating from the account it says it is from.
-     */
-    byte[] transactionSignature();
-
-    /**
-     * @return The type of transaction.
-     */
-    TransactionType type();
-
-    /**
-     * @return an XRPPayment object representing the additional fields present in a PAYMENT transaction.
-     * @see "https://xrpl.org/payment.html#payment-fields"
-     */
-    XRPPayment paymentFields();
-
-    /**
-     * Constructs an {@link XRPTransaction} from a {@link Transaction}
-     * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L13">
-     *     Transaction protocol buffer</a>
-     *
-     * @param transaction a {@link Transaction} (protobuf object) whose field values will be used
-     *                 to construct an {@link XRPTransaction}
-     * @return an {@link XRPTransaction} with its fields set via the analogous protobuf fields.
-     */
-    static XRPTransaction from(Transaction transaction) {
-        String account = transaction.getAccount().getValue().getAddress();
-
-        ByteString accountTransactionIDByteString = transaction.getAccountTransactionId().getValue();
-        byte[] accountTransactionID = accountTransactionIDByteString.equals(ByteString.EMPTY) ?
-                null : accountTransactionIDByteString.toByteArray();
-
-        Long fee = transaction.getFee().getDrops();
-
-        Integer flags = transaction.getFlags().getValue();
-
-        Integer lastLedgerSequence = transaction.getLastLedgerSequence().getValue();
-
-        List<XRPMemo> memos = transaction.getMemosList()
-                .stream()
-                .map(memo -> XRPMemo.from(memo))
-                .collect(Collectors.toList());
-        if (memos.isEmpty()) {
-            memos = null;
-        }
-
-        Integer sequence = transaction.getSequence().getValue();
-
-        List<XRPSigner> signers = transaction.getSignersList()
-                .stream()
-                .map(signer -> XRPSigner.from(signer))
-                .collect(Collectors.toList());
-        if (signers.isEmpty()) {
-            signers = null;
-        }
-
-        byte[] signingPublicKey = transaction.getSigningPublicKey().getValue().toByteArray();
-
-        Integer sourceTag = transaction.getSourceTag().getValue();
-
-        byte[] transactionSignature = transaction.getTransactionSignature().getValue().toByteArray();
-
-        TransactionType type;
-        XRPPayment paymentFields;
-        switch (transaction.getTransactionDataCase()) {
-            case PAYMENT: {
-                Payment payment = transaction.getPayment();
-                paymentFields = XRPPayment.from(payment);
-                if (paymentFields == null) {
-                    return null;
-                }
-                type = TransactionType.PAYMENT;
-                break;
-            }
-            default: {
-                // unsupported transaction type
-                return null;
-            }
-        }
-
-        return XRPTransaction.builder()
-                .account(account)
-                .accountTransactionID(accountTransactionID)
-                .fee(fee)
-                .flags(flags)
-                .lastLedgerSequence(lastLedgerSequence)
-                .memos(memos)
-                .sequence(sequence)
-                .signers(signers)
-                .signingPublicKey(signingPublicKey)
-                .sourceTag(sourceTag)
-                .transactionSignature(transactionSignature)
-                .type(type)
-                .paymentFields(paymentFields)
-                .build();
+    List<XRPSigner> signers = transaction.getSignersList()
+        .stream()
+        .map(XRPSigner::from)
+        .collect(Collectors.toList());
+    if (signers.isEmpty()) {
+      signers = null;
     }
+
+    byte[] signingPublicKey = transaction.getSigningPublicKey().getValue().toByteArray();
+
+    Integer sourceTag = transaction.getSourceTag().getValue();
+
+    byte[] transactionSignature = transaction.getTransactionSignature().getValue().toByteArray();
+
+    TransactionType type;
+    XRPPayment paymentFields;
+    switch (transaction.getTransactionDataCase()) {
+      case PAYMENT: {
+        Payment payment = transaction.getPayment();
+        paymentFields = XRPPayment.from(payment);
+        if (paymentFields == null) {
+          return null;
+        }
+        type = TransactionType.PAYMENT;
+        break;
+      }
+      default: {
+        // unsupported transaction type
+        return null;
+      }
+    }
+
+    return XRPTransaction.builder()
+        .account(account)
+        .accountTransactionID(accountTransactionID)
+        .fee(fee)
+        .flags(flags)
+        .lastLedgerSequence(lastLedgerSequence)
+        .memos(memos)
+        .sequence(sequence)
+        .signers(signers)
+        .signingPublicKey(signingPublicKey)
+        .sourceTag(sourceTag)
+        .transactionSignature(transactionSignature)
+        .type(type)
+        .paymentFields(paymentFields)
+        .build();
+  }
 }

--- a/src/test/java/io/xpring/common/Result.java
+++ b/src/test/java/io/xpring/common/Result.java
@@ -5,20 +5,20 @@ import java.util.Optional;
 /**
  * Represents a result monad of type `Type` or an error of type `ErrorType`.
  */
-public class Result<Type, ErrorType extends Throwable> {
-  private Optional<Type> value;
-  private Optional<ErrorType> error;
+public class Result<T, E extends Throwable> {
+  private Optional<T> value;
+  private Optional<E> error;
 
-  private Result(Type value, ErrorType error) {
+  private Result(T value, E error) {
     this.value = Optional.ofNullable(value);
     this.error = Optional.ofNullable(error);
   }
 
-  public static <Type, ErrorType extends Throwable> Result<Type, ErrorType> ok(Type value) {
-    return new Result<Type, ErrorType>(value, null);
+  public static <T, E extends Throwable> Result<T, E> ok(T value) {
+    return new Result<T, E>(value, null);
   }
 
-  public static <Type, ErrorType extends Throwable> Result<Type, ErrorType> error(ErrorType error) {
+  public static <T, E extends Throwable> Result<T, E> error(E error) {
     return new Result<>(null, error);
   }
 
@@ -26,11 +26,11 @@ public class Result<Type, ErrorType extends Throwable> {
     return error.isPresent();
   }
 
-  public Type getValue() {
+  public T getValue() {
     return value.get();
   }
 
-  public ErrorType getError() {
+  public E getError() {
     return error.get();
   }
 }

--- a/src/test/java/io/xpring/ilp/DefaultIlpClientTest.java
+++ b/src/test/java/io/xpring/ilp/DefaultIlpClientTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import java.io.IOException;
 
 /**
- * Unit tests for {@link io.xpring.ilp.DefaultIlpClient}
+ * Unit tests for {@link io.xpring.ilp.DefaultIlpClient}.
  */
 public class DefaultIlpClientTest {
 
@@ -41,30 +41,33 @@ public class DefaultIlpClientTest {
   private GetBalanceResponse getBalanceResponse;
   private SendPaymentResponse sendPaymentResponse;
   public static final PaymentRequest mockPaymentRequest = PaymentRequest.builder()
-    .amount(UnsignedLong.valueOf(1000))
-    .destinationPaymentPointer("$foo.dev/bar")
-    .senderAccountId("baz")
-    .build();
+      .amount(UnsignedLong.valueOf(1000))
+      .destinationPaymentPointer("$foo.dev/bar")
+      .senderAccountId("baz")
+      .build();
 
+  /**
+   * Set up responses.
+   */
   @Before
   public void setUp() {
     int clearingBalance = 10;
     int prepaidAmount = 100;
     getBalanceResponse = GetBalanceResponse.newBuilder()
-      .setAccountId("bob")
-      .setAssetCode("XRP")
-      .setAssetScale(9)
-      .setNetBalance(clearingBalance + prepaidAmount)
-      .setClearingBalance(clearingBalance)
-      .setPrepaidAmount(prepaidAmount)
-      .build();
+        .setAccountId("bob")
+        .setAssetCode("XRP")
+        .setAssetScale(9)
+        .setNetBalance(clearingBalance + prepaidAmount)
+        .setClearingBalance(clearingBalance)
+        .setPrepaidAmount(prepaidAmount)
+        .build();
 
     sendPaymentResponse = SendPaymentResponse.newBuilder()
-      .setOriginalAmount(1000)
-      .setAmountDelivered(1000)
-      .setAmountSent(1000)
-      .setSuccessfulPayment(true)
-      .build();
+        .setOriginalAmount(1000)
+        .setAmountDelivered(1000)
+        .setAmountSent(1000)
+        .setSuccessfulPayment(true)
+        .build();
   }
 
   @Test
@@ -92,9 +95,9 @@ public class DefaultIlpClientTest {
     // WHEN the balance is retrieved for "bob" with an access token prefixed with "Bearer "
     // THEN an IlpException in thrown
     assertThrows(
-      IlpException.INVALID_ACCESS_TOKEN.getMessage(),
-      IlpException.class,
-      () -> client.getBalance("bob", "Bearer password")
+        IlpException.INVALID_ACCESS_TOKEN.getMessage(),
+        IlpException.class,
+        () -> client.getBalance("bob", "Bearer password")
     );
   }
 
@@ -171,9 +174,9 @@ public class DefaultIlpClientTest {
     // WHEN a payment is sent with an access token prefixed with "Bearer "
     // THEN an IlpException in thrown
     assertThrows(
-      IlpException.INVALID_ACCESS_TOKEN.getMessage(),
-      IlpException.class,
-      () -> client.sendPayment(mockPaymentRequest, "Bearer bob")
+        IlpException.INVALID_ACCESS_TOKEN.getMessage(),
+        IlpException.class,
+        () -> client.sendPayment(mockPaymentRequest, "Bearer bob")
     );
   }
 
@@ -232,13 +235,13 @@ public class DefaultIlpClientTest {
    */
   private DefaultIlpClient getSuccessfulClient() throws IOException {
     return getClient(
-      Result.ok(getBalanceResponse),
-      Result.ok(sendPaymentResponse)
+        Result.ok(getBalanceResponse),
+        Result.ok(sendPaymentResponse)
     );
   }
 
   /**
-   * Convenience method to get a DefaultIlpClient whose network calls cause exceptions with exceptionStatus
+   * Convenience method to get a DefaultIlpClient whose network calls cause exceptions with exceptionStatus.
    *
    * @param exceptionStatus The {@link Status} of the {@link StatusRuntimeException} thrown by the network calls
    * @return a {@link DefaultIlpClient} whose network calls cause exceptions
@@ -246,8 +249,8 @@ public class DefaultIlpClientTest {
    */
   private DefaultIlpClient getFailingClient(Status exceptionStatus) throws IOException {
     return getClient(
-            Result.error(new StatusRuntimeException(exceptionStatus)),
-            Result.error(new StatusRuntimeException(exceptionStatus))
+        Result.error(new StatusRuntimeException(exceptionStatus)),
+        Result.error(new StatusRuntimeException(exceptionStatus))
     );
   }
 
@@ -258,7 +261,7 @@ public class DefaultIlpClientTest {
                                      Result<SendPaymentResponse, Throwable> sendPaymentResponse) throws IOException {
 
     BalanceServiceGrpc.BalanceServiceImplBase balanceServiceImpl = getBalanceService(
-      getBalanceResult
+        getBalanceResult
     );
 
     IlpOverHttpServiceGrpc.IlpOverHttpServiceImplBase ilpOverHttpServiceImpl = ilpOverHttpService(sendPaymentResponse);
@@ -268,83 +271,85 @@ public class DefaultIlpClientTest {
 
     // Create a server, add service, start, and register for automatic graceful shutdown.
     grpcCleanup.register(InProcessServerBuilder
-      .forName(serverName)
-      .directExecutor()
-      .addService(balanceServiceImpl)
-      .addService(ilpOverHttpServiceImpl)
-      .build()
-      .start());
+        .forName(serverName)
+        .directExecutor()
+        .addService(balanceServiceImpl)
+        .addService(ilpOverHttpServiceImpl)
+        .build()
+        .start());
 
     // Create a client channel and register for automatic graceful shutdown.
     ManagedChannel channel = grpcCleanup.register(
-      InProcessChannelBuilder.forName(serverName).directExecutor().build());
+        InProcessChannelBuilder.forName(serverName).directExecutor().build());
 
     // Create a new XRPClient using the in-process channel;
     return new DefaultIlpClient(channel);
   }
 
-  private IlpOverHttpServiceGrpc.IlpOverHttpServiceImplBase ilpOverHttpService(Result<SendPaymentResponse, Throwable> sendPaymentResponse) {
+  private IlpOverHttpServiceGrpc.IlpOverHttpServiceImplBase ilpOverHttpService(
+      Result<SendPaymentResponse, Throwable> sendPaymentResponse
+  ) {
     return mock(IlpOverHttpServiceGrpc.IlpOverHttpServiceImplBase.class, delegatesTo(
-      new IlpOverHttpServiceGrpc.IlpOverHttpServiceImplBase() {
-        @Override
-        public void sendMoney(SendPaymentRequest request, StreamObserver<SendPaymentResponse> responseObserver) {
-          if (sendPaymentResponse.isError()) {
-            responseObserver.onError(new Throwable(sendPaymentResponse.getError()));
-          } else {
-            responseObserver.onNext(sendPaymentResponse.getValue());
-            responseObserver.onCompleted();
+        new IlpOverHttpServiceGrpc.IlpOverHttpServiceImplBase() {
+          @Override
+          public void sendMoney(SendPaymentRequest request, StreamObserver<SendPaymentResponse> responseObserver) {
+            if (sendPaymentResponse.isError()) {
+              responseObserver.onError(new Throwable(sendPaymentResponse.getError()));
+            } else {
+              responseObserver.onNext(sendPaymentResponse.getValue());
+              responseObserver.onCompleted();
+            }
           }
-        }
-      }));
+        }));
   }
 
   /**
    * Return a BalanceServiceGrpc implementation which returns the given results for network calls.
    */
   private BalanceServiceGrpc.BalanceServiceImplBase getBalanceService(
-    Result<GetBalanceResponse, Throwable> getBalanceResult
+      Result<GetBalanceResponse, Throwable> getBalanceResult
   ) {
     return mock(BalanceServiceGrpc.BalanceServiceImplBase.class, delegatesTo(
-      new BalanceServiceGrpc.BalanceServiceImplBase() {
-        @Override
-        public void getBalance(GetBalanceRequest request, StreamObserver<GetBalanceResponse> responseObserver) {
-          if (getBalanceResult.isError()) {
-            responseObserver.onError(new Throwable(getBalanceResult.getError()));
-          } else {
-            responseObserver.onNext(getBalanceResult.getValue());
-            responseObserver.onCompleted();
+        new BalanceServiceGrpc.BalanceServiceImplBase() {
+          @Override
+          public void getBalance(GetBalanceRequest request, StreamObserver<GetBalanceResponse> responseObserver) {
+            if (getBalanceResult.isError()) {
+              responseObserver.onError(new Throwable(getBalanceResult.getError()));
+            } else {
+              responseObserver.onNext(getBalanceResult.getValue());
+              responseObserver.onCompleted();
+            }
           }
-        }
-      }));
+        }));
   }
 
   /**
-   * Assert that a call to {@link DefaultIlpClient#getBalance} with the
-   * given {@link DefaultIlpClient} throws the given exception
+   * Assert that a call to {@link DefaultIlpClient#getBalance} with the given {@link DefaultIlpClient} throws the given
+   * exception.
    *
-   * @param client a {@link DefaultIlpClient} to test
+   * @param client            a {@link DefaultIlpClient} to test
    * @param expectedException the {@link IlpException} that client should throw
    */
   private void assertGetBalanceThrows(DefaultIlpClient client, IlpException expectedException) {
     assertThrows(
-      expectedException.getMessage(),
-      IlpException.class,
-      () -> client.getBalance("bob", "password")
+        expectedException.getMessage(),
+        IlpException.class,
+        () -> client.getBalance("bob", "password")
     );
   }
 
   /**
-   * Assert that a call to {@link DefaultIlpClient#sendPayment} with the
-   * given {@link DefaultIlpClient} throws the given exception
+   * Assert that a call to {@link DefaultIlpClient#sendPayment} with the given {@link DefaultIlpClient} throws the given
+   * exception.
    *
-   * @param client a {@link DefaultIlpClient} to test
+   * @param client            a {@link DefaultIlpClient} to test
    * @param expectedException the {@link IlpException} that client should throw
    */
   private void assertSendPaymentThrows(DefaultIlpClient client, IlpException expectedException) {
     assertThrows(
-      expectedException.getMessage(),
-      IlpException.class,
-      () -> client.sendPayment(mockPaymentRequest, "password")
+        expectedException.getMessage(),
+        IlpException.class,
+        () -> client.sendPayment(mockPaymentRequest, "password")
     );
   }
 }

--- a/src/test/java/io/xpring/ilp/IlpIntegrationTests.java
+++ b/src/test/java/io/xpring/ilp/IlpIntegrationTests.java
@@ -50,19 +50,19 @@ public class IlpIntegrationTests {
 
     // WHEN a payment is sent from the sender to the receiver
     PaymentRequest paymentRequest = PaymentRequest.builder()
-      .amount(UnsignedLong.valueOf(10))
-      .destinationPaymentPointer("$xpring.money/sdk_account2")
-      .senderAccountId("sdk_account1")
-      .build();
+        .amount(UnsignedLong.valueOf(10))
+        .destinationPaymentPointer("$xpring.money/sdk_account2")
+        .senderAccountId("sdk_account1")
+        .build();
 
     PaymentResult response = client.sendPayment(paymentRequest, "password");
 
     PaymentResult expected = PaymentResult.builder()
-      .originalAmount(UnsignedLong.valueOf(10))
-      .amountSent(UnsignedLong.valueOf(10))
-      .amountDelivered(UnsignedLong.valueOf(10))
-      .successfulPayment(true)
-      .build();
+        .originalAmount(UnsignedLong.valueOf(10))
+        .amountSent(UnsignedLong.valueOf(10))
+        .amountDelivered(UnsignedLong.valueOf(10))
+        .successfulPayment(true)
+        .build();
 
     // THEN the response should equal the mocked response above
     assertThat(response).isEqualToComparingFieldByField(expected);

--- a/src/test/java/io/xpring/ilp/util/IlpAuthConstants.java
+++ b/src/test/java/io/xpring/ilp/util/IlpAuthConstants.java
@@ -4,8 +4,9 @@ import org.interledger.spsp.server.grpc.CreateAccountResponse;
 
 /**
  * Defines the keys that will be present in {@link CreateAccountResponse#getCustomSettingsMap()}.
- *
+ * <p>
  * These keys follow a hierarchical dot-notation format, and mirror the keys created on the Java connector exactly.
+ * </p>
  */
 public class IlpAuthConstants {
 

--- a/src/test/java/io/xpring/payid/PayIDClientTest.java
+++ b/src/test/java/io/xpring/payid/PayIDClientTest.java
@@ -1,108 +1,120 @@
 package io.xpring.payid;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.Assert.assertEquals;
+
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.xpring.common.XRPLNetwork;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.junit.Assert.*;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class PayIDClientTest {
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort().dynamicHttpsPort());
+  @Rule
+  public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort().dynamicHttpsPort());
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
-    @Test
-    public void testXRPAddressForPayIDInvalidPaymentPointer() throws PayIDException {
-        // GIVEN a PayIDClient and an invalid PayID.
-        String invalidPayID = "xpring.money/georgewashington"; // Does not start with '$'
-        PayIDClient payIDClient = new PayIDClient(XRPLNetwork.MAIN);
+  @Test
+  public void testXRPAddressForPayIDInvalidPaymentPointer() throws PayIDException {
+    // GIVEN a PayIDClient and an invalid PayID.
+    String invalidPayID = "xpring.money/georgewashington"; // Does not start with '$'
+    PayIDClient payIDClient = new PayIDClient(XRPLNetwork.MAIN);
 
-        // WHEN an XRPAddress is requested for an invalid pay ID THEN an invalid payment pointer error is thrown.
-        // TODO(keefertaylor): Tighten this condition to verify the exception is as expected.
-        expectedException.expect(PayIDException.class);
-        payIDClient.xrpAddressForPayID(invalidPayID);
-    }
+    // WHEN an XRPAddress is requested for an invalid pay ID THEN an invalid payment pointer error is thrown.
+    // TODO(keefertaylor): Tighten this condition to verify the exception is as expected.
+    expectedException.expect(PayIDException.class);
+    payIDClient.xrpAddressForPayID(invalidPayID);
+  }
 
-    @Test
-    public void testXRPAddressForPayIDSuccess() throws PayIDException {
-        // GIVEN a PayID client, valid PayID and mocked networking to return a match for the PayID.
-        String payID = "$localhost:" + wireMockRule.httpsPort() + "/georgewashington";
-        PayIDClient client = new PayIDClient(XRPLNetwork.MAIN);
-        client.setEnableSSLVerification(false);
-        String xrpAddress = "X7cBcY4bdTTzk3LHmrKAK6GyrirkXfLHGFxzke5zTmYMfw4";
+  @Test
+  public void testXRPAddressForPayIDSuccess() throws PayIDException {
+    // GIVEN a PayID client, valid PayID and mocked networking to return a match for the PayID.
+    String payID = "$localhost:" + wireMockRule.httpsPort() + "/georgewashington";
+    PayIDClient client = new PayIDClient(XRPLNetwork.MAIN);
+    client.setEnableSSLVerification(false);
+    String xrpAddress = "X7cBcY4bdTTzk3LHmrKAK6GyrirkXfLHGFxzke5zTmYMfw4";
 
-        stubFor(get(urlEqualTo("/georgewashington"))
-                .willReturn(aResponse()
-                        .withStatus(200)
-                        .withHeader("Content-Type", "application/xrpl-mainnet+json")
-                        .withBody("{ addressDetailsType: 'CryptoAddressDetails', addressDetails: { address: 'X7cBcY4bdTTzk3LHmrKAK6GyrirkXfLHGFxzke5zTmYMfw4' }}")));
+    stubFor(get(urlEqualTo("/georgewashington"))
+        .willReturn(aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/xrpl-mainnet+json")
+            .withBody("{ "
+                + "addressDetailsType: 'CryptoAddressDetails', "
+                + "addressDetails: { "
+                + "address: 'X7cBcY4bdTTzk3LHmrKAK6GyrirkXfLHGFxzke5zTmYMfw4' "
+                + "}"
+                + "}"
+            )
+        )
+    );
 
-        // WHEN an XRP address is requested.
-        String address = client.xrpAddressForPayID(payID);
+    // WHEN an XRP address is requested.
+    String address = client.xrpAddressForPayID(payID);
 
-        // THEN the address is the one returned in the response.
-        assertEquals(address, "X7cBcY4bdTTzk3LHmrKAK6GyrirkXfLHGFxzke5zTmYMfw4");
-    }
+    // THEN the address is the one returned in the response.
+    assertEquals(address, "X7cBcY4bdTTzk3LHmrKAK6GyrirkXfLHGFxzke5zTmYMfw4");
+  }
 
-    @Test
-    public void testXRPAddressForPayIDMatchNotFound() throws PayIDException {
-        // GIVEN a PayID client, valid PayID and mocked networking to return a 404 for the payID.
-        String payID = "$localhost:" + wireMockRule.httpsPort() + "/georgewashington";
-        PayIDClient client = new PayIDClient(XRPLNetwork.MAIN);
-        client.setEnableSSLVerification(false);
-        String xrpAddress = "X7cBcY4bdTTzk3LHmrKAK6GyrirkXfLHGFxzke5zTmYMfw4";
+  @Test
+  public void testXRPAddressForPayIDMatchNotFound() throws PayIDException {
+    // GIVEN a PayID client, valid PayID and mocked networking to return a 404 for the payID.
+    final String payID = "$localhost:" + wireMockRule.httpsPort() + "/georgewashington";
+    PayIDClient client = new PayIDClient(XRPLNetwork.MAIN);
+    client.setEnableSSLVerification(false);
+    String xrpAddress = "X7cBcY4bdTTzk3LHmrKAK6GyrirkXfLHGFxzke5zTmYMfw4";
 
-        stubFor(get(urlEqualTo("/georgewashington"))
-                .willReturn(aResponse()
-                        .withStatus(404)));
+    stubFor(get(urlEqualTo("/georgewashington"))
+        .willReturn(aResponse()
+            .withStatus(404)));
 
-        // WHEN an XRPAddress is requested THEN a mapping not found error is thrown.
-        // TODO(keefertaylor): Tighten this condition to verify the exception is as expected.
-        expectedException.expect(PayIDException.class);
-        client.xrpAddressForPayID(payID);
-    }
+    // WHEN an XRPAddress is requested THEN a mapping not found error is thrown.
+    // TODO(keefertaylor): Tighten this condition to verify the exception is as expected.
+    expectedException.expect(PayIDException.class);
+    client.xrpAddressForPayID(payID);
+  }
 
-    @Test
-    public void testXRPAddressForPayIDBadMIMEType() throws PayIDException {
-        // GIVEN a PayID client, valid PayID and mocked networking to return a 415 for the payID.
-        String payID = "$localhost:" + wireMockRule.httpsPort() + "/georgewashington";
-        PayIDClient client = new PayIDClient(XRPLNetwork.MAIN);
-        client.setEnableSSLVerification(false);
-        String xrpAddress = "X7cBcY4bdTTzk3LHmrKAK6GyrirkXfLHGFxzke5zTmYMfw4";
+  @Test
+  public void testXRPAddressForPayIDBadMIMEType() throws PayIDException {
+    // GIVEN a PayID client, valid PayID and mocked networking to return a 415 for the payID.
+    final String payID = "$localhost:" + wireMockRule.httpsPort() + "/georgewashington";
+    PayIDClient client = new PayIDClient(XRPLNetwork.MAIN);
+    client.setEnableSSLVerification(false);
+    String xrpAddress = "X7cBcY4bdTTzk3LHmrKAK6GyrirkXfLHGFxzke5zTmYMfw4";
 
-        stubFor(get(urlEqualTo("/georgewashington"))
-                .willReturn(aResponse()
-                        .withStatus(415)));
+    stubFor(get(urlEqualTo("/georgewashington"))
+        .willReturn(aResponse()
+            .withStatus(415)));
 
-        // WHEN an XRPAddress is requested THEN a unexpected response error is thrown.
-        // TODO(keefertaylor): Tighten this condition to verify the exception is as expected.
-        expectedException.expect(PayIDException.class);
-        client.xrpAddressForPayID(payID);
-    }
+    // WHEN an XRPAddress is requested THEN a unexpected response error is thrown.
+    // TODO(keefertaylor): Tighten this condition to verify the exception is as expected.
+    expectedException.expect(PayIDException.class);
+    client.xrpAddressForPayID(payID);
+  }
 
-    @Test
-    public void testXRPAddressForPayIDServerFailure() throws PayIDException {
-        // GIVEN a PayID client, valid PayID and mocked networking to return a 503 for the payID.
-        String payID = "$localhost:" + wireMockRule.httpsPort() + "/georgewashington";
-        PayIDClient client = new PayIDClient(XRPLNetwork.MAIN);
-        client.setEnableSSLVerification(false);
-        String xrpAddress = "X7cBcY4bdTTzk3LHmrKAK6GyrirkXfLHGFxzke5zTmYMfw4";
+  @Test
+  public void testXRPAddressForPayIDServerFailure() throws PayIDException {
+    // GIVEN a PayID client, valid PayID and mocked networking to return a 503 for the payID.
+    final String payID = "$localhost:" + wireMockRule.httpsPort() + "/georgewashington";
+    PayIDClient client = new PayIDClient(XRPLNetwork.MAIN);
+    client.setEnableSSLVerification(false);
+    String xrpAddress = "X7cBcY4bdTTzk3LHmrKAK6GyrirkXfLHGFxzke5zTmYMfw4";
 
-        stubFor(get(urlEqualTo("/georgewashington"))
-                .willReturn(aResponse()
-                        .withStatus(503)));
+    stubFor(get(urlEqualTo("/georgewashington"))
+        .willReturn(aResponse()
+            .withStatus(503)));
 
-        // WHEN an XRPAddress is requested THEN a unexpected response error is thrown.
-        // TODO(keefertaylor): Tighten this condition to verify the exception is as expected.
-        expectedException.expect(PayIDException.class);
-        client.xrpAddressForPayID(payID);
-    }
+    // WHEN an XRPAddress is requested THEN a unexpected response error is thrown.
+    // TODO(keefertaylor): Tighten this condition to verify the exception is as expected.
+    expectedException.expect(PayIDException.class);
+    client.xrpAddressForPayID(payID);
+  }
 }
 

--- a/src/test/java/io/xpring/payid/PayIDIntegrationTest.java
+++ b/src/test/java/io/xpring/payid/PayIDIntegrationTest.java
@@ -1,51 +1,55 @@
 package io.xpring.payid;
 
+import static org.junit.Assert.assertEquals;
+
 import io.xpring.common.XRPLNetwork;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static org.junit.Assert.*;
-
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class PayIDIntegrationTest {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
-    @Test
-    public void testXRPAddressForPayIDKnownAddressMainnet() throws PayIDException {
-        // GIVEN a Pay ID that will resolve on Mainnet.
-        PayIDClient payIDClient = new PayIDClient(XRPLNetwork.MAIN);
-        String payID = "$dev.payid.xpring.money/hbergren";
+  @Test
+  @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+  public void testXRPAddressForPayIDKnownAddressMainnet() throws PayIDException {
+    // GIVEN a Pay ID that will resolve on Mainnet.
+    PayIDClient payIDClient = new PayIDClient(XRPLNetwork.MAIN);
+    String payID = "$dev.payid.xpring.money/hbergren";
 
-        // WHEN it is resolved to an XRP address
-        String xrpAddress = payIDClient.xrpAddressForPayID(payID);
+    // WHEN it is resolved to an XRP address
+    String xrpAddress = payIDClient.xrpAddressForPayID(payID);
 
-        // THEN the address is the expected value.
-        assertEquals(xrpAddress, "X7zmKiqEhMznSXgj9cirEnD5sWo3iZSbeFRexSFN1xZ8Ktn");
-    }
+    // THEN the address is the expected value.
+    assertEquals(xrpAddress, "X7zmKiqEhMznSXgj9cirEnD5sWo3iZSbeFRexSFN1xZ8Ktn");
+  }
 
-    @Test
-    public void testXRPAddressForPayIDKnownAddressTestnet() throws PayIDException {
-        // GIVEN a Pay ID that will resolve on Testnet.
-        PayIDClient payIDClient = new PayIDClient(XRPLNetwork.TEST);
-        String payID = "$dev.payid.xpring.money/hbergren";
+  @Test
+  @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+  public void testXRPAddressForPayIDKnownAddressTestnet() throws PayIDException {
+    // GIVEN a Pay ID that will resolve on Testnet.
+    PayIDClient payIDClient = new PayIDClient(XRPLNetwork.TEST);
+    String payID = "$dev.payid.xpring.money/hbergren";
 
-        // WHEN it is resolved to an XRP address
-        String xrpAddress = payIDClient.xrpAddressForPayID(payID);
+    // WHEN it is resolved to an XRP address
+    String xrpAddress = payIDClient.xrpAddressForPayID(payID);
 
-        // THEN the address is the expected value.
-        assertEquals(xrpAddress, "TVacixsWrqyWCr98eTYP7FSzE9NwupESR4TrnijN7fccNiS");
-    }
+    // THEN the address is the expected value.
+    assertEquals(xrpAddress, "TVacixsWrqyWCr98eTYP7FSzE9NwupESR4TrnijN7fccNiS");
+  }
 
-    @Test
-    public void testXRPAddressForPayIDKnownAddressDevnet() throws PayIDException {
-        // GIVEN a Pay ID that will not resolve on Devnet.
-        PayIDClient payIDClient = new PayIDClient(XRPLNetwork.DEV);
-        String payID = "$dev.payid.xpring.money/hbergren";
+  @Test
+  @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+  public void testXRPAddressForPayIDKnownAddressDevnet() throws PayIDException {
+    // GIVEN a Pay ID that will not resolve on Devnet.
+    PayIDClient payIDClient = new PayIDClient(XRPLNetwork.DEV);
+    String payID = "$dev.payid.xpring.money/hbergren";
 
-        // WHEN it is resolved to an XRP address THEN a PayID is thrown.
-        // TODO(keefertaylor): Tighten this condition to verify the exception is as expected.
-        expectedException.expect(PayIDException.class);
-        payIDClient.xrpAddressForPayID(payID);
-    }
+    // WHEN it is resolved to an XRP address THEN a PayID is thrown.
+    // TODO(keefertaylor): Tighten this condition to verify the exception is as expected.
+    expectedException.expect(PayIDException.class);
+    payIDClient.xrpAddressForPayID(payID);
+  }
 }

--- a/src/test/java/io/xpring/payid/PayIDUtilsTest.java
+++ b/src/test/java/io/xpring/payid/PayIDUtilsTest.java
@@ -1,83 +1,86 @@
 package io.xpring.payid;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.interledger.spsp.PaymentPointer;
+
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class PayIDUtilsTest {
-    @Test
-    public void testParsePaymentPointerHostAndPath() {
-        // GIVEN a payment pointer with a host and a path.
-        String rawPaymentPointer = "$example.com/foo";
+  @Test
+  public void testParsePaymentPointerHostAndPath() {
+    // GIVEN a payment pointer with a host and a path.
+    String rawPaymentPointer = "$example.com/foo";
 
-        // WHEN it is parsed to a PaymentPointer object
-        PaymentPointer paymentPointer = PayIDUtils.parsePayID(rawPaymentPointer);
+    // WHEN it is parsed to a PaymentPointer object
+    PaymentPointer paymentPointer = PayIDUtils.parsePayID(rawPaymentPointer);
 
-        // THEN the host and path are set correctly.
-        assertEquals(paymentPointer.host(), "example.com");
-        assertEquals(paymentPointer.path(), "/foo");
-    }
+    // THEN the host and path are set correctly.
+    assertEquals(paymentPointer.host(), "example.com");
+    assertEquals(paymentPointer.path(), "/foo");
+  }
 
-    @Test
-    public void testParsePaymentPointerWithWellKnownPath() {
-        // GIVEN a payment pointer with a well known path.
-        String rawPaymentPointer = "$example.com";
+  @Test
+  public void testParsePaymentPointerWithWellKnownPath() {
+    // GIVEN a payment pointer with a well known path.
+    String rawPaymentPointer = "$example.com";
 
-        // WHEN it is parsed to a PaymentPointer object
-        PaymentPointer paymentPointer = PayIDUtils.parsePayID(rawPaymentPointer);
+    // WHEN it is parsed to a PaymentPointer object
+    PaymentPointer paymentPointer = PayIDUtils.parsePayID(rawPaymentPointer);
 
-        // THEN the host and path are set correctly.
-        assertEquals(paymentPointer.host(), "example.com");
-        assertEquals(paymentPointer.path(), PaymentPointer.WELL_KNOWN);
-    }
+    // THEN the host and path are set correctly.
+    assertEquals(paymentPointer.host(), "example.com");
+    assertEquals(paymentPointer.path(), PaymentPointer.WELL_KNOWN);
+  }
 
-    @Test
-    public void testParsePaymentPointerWithWellKnownPathAndTrailingSlash() {
-        // GIVEN a payment pointer with a well known path and a trailing slash.
-        String rawPaymentPointer = "$example.com";
+  @Test
+  public void testParsePaymentPointerWithWellKnownPathAndTrailingSlash() {
+    // GIVEN a payment pointer with a well known path and a trailing slash.
+    String rawPaymentPointer = "$example.com";
 
-        // WHEN it is parsed to a PaymentPointer object
-        PaymentPointer paymentPointer = PayIDUtils.parsePayID(rawPaymentPointer);
+    // WHEN it is parsed to a PaymentPointer object
+    PaymentPointer paymentPointer = PayIDUtils.parsePayID(rawPaymentPointer);
 
-        // THEN the host and path are set correctly.
-        assertEquals(paymentPointer.host(), "example.com");
-        assertEquals(paymentPointer.path(), PaymentPointer.WELL_KNOWN);
-    }
+    // THEN the host and path are set correctly.
+    assertEquals(paymentPointer.host(), "example.com");
+    assertEquals(paymentPointer.path(), PaymentPointer.WELL_KNOWN);
+  }
 
-    @Test
-    public void testParsePaymentPointerIncorrectPrefix() {
-        // GIVEN a payment pointer without a '$' prefix
-        String rawPaymentPointer = "example.com/";
+  @Test
+  public void testParsePaymentPointerIncorrectPrefix() {
+    // GIVEN a payment pointer without a '$' prefix
+    String rawPaymentPointer = "example.com/";
 
-        // WHEN it is parsed to a PaymentPointer object
-        PaymentPointer paymentPointer = PayIDUtils.parsePayID(rawPaymentPointer);
+    // WHEN it is parsed to a PaymentPointer object
+    PaymentPointer paymentPointer = PayIDUtils.parsePayID(rawPaymentPointer);
 
-        // THEN the result is null
-        assertNull(paymentPointer);
-    }
+    // THEN the result is null
+    assertNull(paymentPointer);
+  }
 
-    @Test
-    public void testParsePaymentPointerEmptyHost() {
-        // GIVEN a payment pointer without a host.
-        String rawPaymentPointer = "$";
+  @Test
+  public void testParsePaymentPointerEmptyHost() {
+    // GIVEN a payment pointer without a host.
+    String rawPaymentPointer = "$";
 
-        // WHEN it is parsed to a PaymentPointer object
-        PaymentPointer paymentPointer = PayIDUtils.parsePayID(rawPaymentPointer);
+    // WHEN it is parsed to a PaymentPointer object
+    PaymentPointer paymentPointer = PayIDUtils.parsePayID(rawPaymentPointer);
 
-        // THEN the result is null
-        assertNull(paymentPointer);
-    }
+    // THEN the result is null
+    assertNull(paymentPointer);
+  }
 
-    @Test
-    public void testParsePaymentPointerNonAscii() {
-        // GIVEN a payment pointer with non-ascii characters.
-        String rawPaymentPointer = "$ZA̡͊͠͝LGΌ IS̯͈͕̹̘̱ͮ TO͇̹̺ͅƝ̴ȳ̳ TH̘Ë͖́̉ ͠P̯͍̭O̚N̐Y̡";
+  @Test
+  public void testParsePaymentPointerNonAscii() {
+    // GIVEN a payment pointer with non-ascii characters.
+    String rawPaymentPointer = "$ZA̡͊͠͝LGΌ IS̯͈͕̹̘̱ͮ TO͇̹̺ͅƝ̴ȳ̳ TH̘Ë͖́̉ ͠P̯͍̭O̚N̐Y̡";
 
-        // WHEN it is parsed to a PaymentPointer object
-        PaymentPointer paymentPointer = PayIDUtils.parsePayID(rawPaymentPointer);
+    // WHEN it is parsed to a PaymentPointer object
+    PaymentPointer paymentPointer = PayIDUtils.parsePayID(rawPaymentPointer);
 
-        // THEN the result is null
-        assertNull(paymentPointer);
-    }
+    // THEN the result is null
+    assertNull(paymentPointer);
+  }
 }

--- a/src/test/java/io/xpring/payid/fakes/FakePayIDClient.java
+++ b/src/test/java/io/xpring/payid/fakes/FakePayIDClient.java
@@ -1,31 +1,36 @@
 package io.xpring.payid.fakes;
 
+import io.xpring.common.Result;
 import io.xpring.payid.PayIDClientInterface;
 import io.xpring.payid.PayIDException;
-import io.xpring.common.Result;
 
 /**
  * Fakes a PayID client.
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class FakePayIDClient implements PayIDClientInterface {
-    /** Results from method calls. */
-    private Result<String, PayIDException> xrpAddressForPayIDResult;
+  /**
+   * Results from method calls.
+   */
+  @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+  private Result<String, PayIDException> xrpAddressForPayIDResult;
 
-    /**
-     * Initialize a new fake Pay ID client.
-     *
-     * @param xrpAddressForPayIDResult The result that will be returned from `xrpAddressForPayID`.
-     */
-    public FakePayIDClient(Result<String, PayIDException> xrpAddressForPayIDResult) {
-        this.xrpAddressForPayIDResult = xrpAddressForPayIDResult;
-    }
+  /**
+   * Initialize a new fake Pay ID client.
+   *
+   * @param xrpAddressForPayIDResult The result that will be returned from `xrpAddressForPayID`.
+   */
+  @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+  public FakePayIDClient(Result<String, PayIDException> xrpAddressForPayIDResult) {
+    this.xrpAddressForPayIDResult = xrpAddressForPayIDResult;
+  }
 
-    @Override
-    public String xrpAddressForPayID(String payID) throws PayIDException {
-        if (this.xrpAddressForPayIDResult.isError()) {
-            throw this.xrpAddressForPayIDResult.getError();
-        } else {
-            return xrpAddressForPayIDResult.getValue();
-        }
+  @Override
+  public String xrpAddressForPayID(String payID) throws PayIDException {
+    if (this.xrpAddressForPayIDResult.isError()) {
+      throw this.xrpAddressForPayIDResult.getError();
+    } else {
+      return xrpAddressForPayIDResult.getValue();
     }
+  }
 }

--- a/src/test/java/io/xpring/xrpl/DefaultXRPClientTest.java
+++ b/src/test/java/io/xpring/xrpl/DefaultXRPClientTest.java
@@ -1,25 +1,42 @@
 package io.xpring.xrpl;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.Mockito.mock;
 
 import com.google.protobuf.ByteString;
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
 import io.xpring.common.Result;
 import io.xpring.xrpl.helpers.XRPTestUtils;
 import io.xpring.xrpl.model.XRPTransaction;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import io.grpc.testing.GrpcCleanupRule;
-import io.grpc.inprocess.InProcessServerBuilder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.AdditionalAnswers.delegatesTo;
-import io.grpc.ManagedChannel;
-import io.grpc.inprocess.InProcessChannelBuilder;
-import io.grpc.StatusRuntimeException;
-import io.grpc.Status;
-import org.xrpl.rpc.v1.*;
-import org.xrpl.rpc.v1.Common.*;
+import org.xrpl.rpc.v1.AccountRoot;
+import org.xrpl.rpc.v1.Common.Balance;
+import org.xrpl.rpc.v1.CurrencyAmount;
+import org.xrpl.rpc.v1.Fee;
+import org.xrpl.rpc.v1.GetAccountInfoRequest;
+import org.xrpl.rpc.v1.GetAccountInfoResponse;
+import org.xrpl.rpc.v1.GetAccountTransactionHistoryRequest;
+import org.xrpl.rpc.v1.GetAccountTransactionHistoryResponse;
+import org.xrpl.rpc.v1.GetFeeRequest;
+import org.xrpl.rpc.v1.GetFeeResponse;
+import org.xrpl.rpc.v1.GetTransactionRequest;
+import org.xrpl.rpc.v1.GetTransactionResponse;
+import org.xrpl.rpc.v1.Meta;
+import org.xrpl.rpc.v1.SubmitTransactionRequest;
+import org.xrpl.rpc.v1.SubmitTransactionResponse;
+import org.xrpl.rpc.v1.TransactionResult;
+import org.xrpl.rpc.v1.XRPDropsAmount;
+import org.xrpl.rpc.v1.XRPLedgerAPIServiceGrpc;
+
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.List;
@@ -27,562 +44,582 @@ import java.util.List;
 /**
  * Unit tests for {@link DefaultXRPClient}.
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class DefaultXRPClientTest {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
-    @Rule
-    public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+  @Rule
+  public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
 
-    /** The DefaultXRPClient under test. */
-    private DefaultXRPClient client;
+  /**
+   * The DefaultXRPClient under test.
+   */
+  private DefaultXRPClient client;
 
-    /** An address on the XRP Ledger. */
-    private static final String XRPL_ADDRESS = "XVwDxLQ4SN9pEBQagTNHwqpFkPgGppXqrMoTmUcSKdCtcK5";
+  /**
+   * An address on the XRP Ledger.
+   */
+  private static final String XRPL_ADDRESS = "XVwDxLQ4SN9pEBQagTNHwqpFkPgGppXqrMoTmUcSKdCtcK5";
 
-    /** Mocked values in responses from the gRPC server. */
-    private static final long DROPS_OF_XRP_IN_ACCOUNT = 10;
-    private static final String TRANSACTION_BLOB = "DEADBEEF";
-    private static final Throwable GENERIC_ERROR = new Throwable("Mocked network error");
-    private static final String TRANSACTION_STATUS_SUCCESS = "tesSUCCESS";
-    private static final String [] TRANSACTION_FAILURE_STATUS_CODES = {
-            "tefFAILURE",
-            "tecCLAIM",
-            "telBAD_PUBLIC_KEY",
-            "temBAD_FEE",
-            "terRETRY"
-    };
-    private static final String TRANSACTION_HASH = "DEADBEEF";
-    private static final long MINIMUM_FEE = 12;
-    private static final int LAST_LEDGER_SEQUENCE = 20;
+  /**
+   * Mocked values in responses from the gRPC server.
+   */
+  private static final long DROPS_OF_XRP_IN_ACCOUNT = 10;
+  private static final String TRANSACTION_BLOB = "DEADBEEF";
+  private static final Throwable GENERIC_ERROR = new Throwable("Mocked network error");
+  private static final String TRANSACTION_STATUS_SUCCESS = "tesSUCCESS";
+  private static final String[] TRANSACTION_FAILURE_STATUS_CODES = {
+      "tefFAILURE",
+      "tecCLAIM",
+      "telBAD_PUBLIC_KEY",
+      "temBAD_FEE",
+      "terRETRY"
+  };
+  private static final String TRANSACTION_HASH = "DEADBEEF";
+  private static final long MINIMUM_FEE = 12;
+  private static final int LAST_LEDGER_SEQUENCE = 20;
 
-    /** The seed for a wallet with funds on the XRP Ledger test net. */
-    private static final String WALLET_SEED = "snYP7oArxKepd3GPDcrjMsJYiJeJB";
+  /**
+   * The seed for a wallet with funds on the XRP Ledger test net.
+   */
+  private static final String WALLET_SEED = "snYP7oArxKepd3GPDcrjMsJYiJeJB";
 
-    /** Drops of XRP to send. */
-    private static final BigInteger AMOUNT = new BigInteger("1");
+  /**
+   * Drops of XRP to send.
+   */
+  private static final BigInteger AMOUNT = new BigInteger("1");
 
-    @Test
-    public void getBalanceTest() throws IOException, XRPException {
-        // GIVEN a DefaultXRPClient with mocked networking which will succeed.
-        DefaultXRPClient client = getClient();
+  @Test
+  public void getBalanceTest() throws IOException, XRPException {
+    // GIVEN a DefaultXRPClient with mocked networking which will succeed.
+    DefaultXRPClient client = getClient();
 
-        // WHEN the balance is retrieved.
-        BigInteger balance = client.getBalance(XRPL_ADDRESS);
+    // WHEN the balance is retrieved.
+    BigInteger balance = client.getBalance(XRPL_ADDRESS);
 
-        // THEN the balance returned is the the same as the mocked response.
-        assertThat(balance).isEqualTo(BigInteger.valueOf(DROPS_OF_XRP_IN_ACCOUNT));
+    // THEN the balance returned is the the same as the mocked response.
+    assertThat(balance).isEqualTo(BigInteger.valueOf(DROPS_OF_XRP_IN_ACCOUNT));
+  }
+
+  @Test
+  public void getBalanceWithClassicAddressTest() throws IOException, XRPException {
+    // GIVEN a classic address.
+    ClassicAddress classicAddress = Utils.decodeXAddress(XRPL_ADDRESS);
+    DefaultXRPClient client = getClient();
+
+    // WHEN the balance for the classic address is retrieved THEN an error is thrown.
+    expectedException.expect(XRPException.class);
+    client.getBalance(classicAddress.address());
+  }
+
+  @Test
+  public void getBalanceTestWithFailedAccountInfo() throws IOException, XRPException {
+    // GIVEN a XRPClient with mocked networking which will fail to retrieve account info.
+    Result<GetAccountInfoResponse, Throwable> accountInfoResult = Result.error(GENERIC_ERROR);
+    DefaultXRPClient client = getClient(
+        accountInfoResult,
+        Result.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS)),
+        Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
+        Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
+        Result.ok(makeGetAccountTransactionHistoryResponse())
+    );
+
+    // WHEN the balance is retrieved THEN an error is thrown.
+    expectedException.expect(Exception.class);
+    client.getBalance(XRPL_ADDRESS);
+  }
+
+
+  @Test
+  public void paymentStatusWithUnvalidatedTransactionAndFailureCode() throws IOException, XRPException {
+    // Iterate over different types of transaction status codes which represent failures.
+    for (String transactionFailureCode : TRANSACTION_FAILURE_STATUS_CODES) {
+      // GIVEN an XRPClient which will return an unvalidated transaction with a failed code.
+      DefaultXRPClient client = getClient(
+          Result.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
+          Result.ok(makeTransactionStatus(false, transactionFailureCode)),
+          Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
+          Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
+          Result.ok(makeGetAccountTransactionHistoryResponse())
+      );
+
+      // WHEN the payment status is retrieved.
+      io.xpring.xrpl.TransactionStatus paymentStatus = client.getPaymentStatus(TRANSACTION_HASH);
+
+      // THEN the status is PENDING.
+      assertThat(paymentStatus).isEqualTo(io.xpring.xrpl.TransactionStatus.PENDING);
     }
+  }
 
-    @Test
-    public void getBalanceWithClassicAddressTest() throws IOException, XRPException {
-        // GIVEN a classic address.
-        ClassicAddress classicAddress = Utils.decodeXAddress(XRPL_ADDRESS);
-        DefaultXRPClient client = getClient();
+  @Test
+  public void paymentStatusWithUnvalidatedTransactionAndSuccessCode() throws IOException, XRPException {
+    // GIVEN an XRPClient which will return an unvalidated transaction with a success code.
+    DefaultXRPClient client = getClient(
+        Result.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
+        Result.ok(makeTransactionStatus(false, TRANSACTION_STATUS_SUCCESS)),
+        Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
+        Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
+        Result.ok(makeGetAccountTransactionHistoryResponse())
+    );
 
-        // WHEN the balance for the classic address is retrieved THEN an error is thrown.
-        expectedException.expect(XRPException.class);
-        client.getBalance(classicAddress.address());
+    // WHEN the payment status is retrieved.
+    io.xpring.xrpl.TransactionStatus paymentStatus = client.getPaymentStatus(TRANSACTION_HASH);
+
+    // THEN the status is PENDING.
+    assertThat(paymentStatus).isEqualTo(io.xpring.xrpl.TransactionStatus.PENDING);
+  }
+
+  @Test
+  public void paymentStatusWithValidatedTransactionAndFailureCode() throws IOException, XRPException {
+    // Iterate over different types of transaction status codes which represent failures.
+    for (String transactionFailureCode : TRANSACTION_FAILURE_STATUS_CODES) {
+      // GIVEN an XRPClient which will return an validated transaction with a failed code.
+      DefaultXRPClient client = getClient(
+          Result.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
+          Result.ok(makeTransactionStatus(true, transactionFailureCode)),
+          Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
+          Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
+          Result.ok(makeGetAccountTransactionHistoryResponse())
+      );
+
+      // WHEN the payment status is retrieved.
+      io.xpring.xrpl.TransactionStatus paymentStatus = client.getPaymentStatus(TRANSACTION_HASH);
+
+      // THEN the status is FAILED.
+      assertThat(paymentStatus).isEqualTo(io.xpring.xrpl.TransactionStatus.FAILED);
     }
+  }
 
-    @Test
-    public void getBalanceTestWithFailedAccountInfo() throws IOException, XRPException {
-        // GIVEN a XRPClient with mocked networking which will fail to retrieve account info.
-        Result<GetAccountInfoResponse, Throwable> accountInfoResult = Result.error(GENERIC_ERROR);
-        DefaultXRPClient client = getClient(
-                accountInfoResult,
-                Result.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS)),
-                Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
-                Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
-                Result.ok(makeGetAccountTransactionHistoryResponse())
-        );
+  @Test
+  public void paymentStatusWithValidatedTransactionAndSuccessCode() throws IOException, XRPException {
+    // GIVEN an XRPClient which will return an validated transaction with a success code.
+    DefaultXRPClient client = getClient(
+        Result.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
+        Result.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS)),
+        Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
+        Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
+        Result.ok(makeGetAccountTransactionHistoryResponse())
+    );
 
-        // WHEN the balance is retrieved THEN an error is thrown.
-        expectedException.expect(Exception.class);
-        client.getBalance(XRPL_ADDRESS);
-    }
+    // WHEN the payment status is retrieved.
+    io.xpring.xrpl.TransactionStatus paymentStatus = client.getPaymentStatus(TRANSACTION_HASH);
 
+    // THEN the status is SUCCEEDED.
+    assertThat(paymentStatus).isEqualTo(io.xpring.xrpl.TransactionStatus.SUCCEEDED);
+  }
 
-    @Test
-    public void paymentStatusWithUnvalidatedTransactionAndFailureCode() throws IOException, XRPException {
-        // Iterate over different types of transaction status codes which represent failures.
-        for (String transactionFailureCode : TRANSACTION_FAILURE_STATUS_CODES) {
-            // GIVEN an XRPClient which will return an unvalidated transaction with a failed code.
-            DefaultXRPClient client = getClient(
-                    Result.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
-                    Result.ok(makeTransactionStatus(false, transactionFailureCode)),
-                    Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
-                    Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
-                    Result.ok(makeGetAccountTransactionHistoryResponse())
-            );
+  @Test
+  public void paymentStatusWithNodeError() throws IOException, XRPException {
+    // GIVEN an XRPClient which will error when a transaction status is requested..
+    DefaultXRPClient client = getClient(
+        Result.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
+        Result.error(GENERIC_ERROR),
+        Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
+        Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
+        Result.ok(makeGetAccountTransactionHistoryResponse())
+    );
 
-            // WHEN the payment status is retrieved.
-            io.xpring.xrpl.TransactionStatus paymentStatus = client.getPaymentStatus(TRANSACTION_HASH);
+    // WHEN the payment status is retrieved THEN an error is thrown..
+    expectedException.expect(Exception.class);
+    client.getPaymentStatus(TRANSACTION_HASH);
+  }
 
-            // THEN the status is PENDING.
-            assertThat(paymentStatus).isEqualTo(io.xpring.xrpl.TransactionStatus.PENDING);
-        }
-    }
+  @Test
+  public void submitTransactionTest() throws IOException, XRPException {
+    // GIVEN an XRPClient with mocked networking which will succeed.
+    DefaultXRPClient client = getClient();
+    Wallet wallet = new Wallet(WALLET_SEED);
 
-    @Test
-    public void paymentStatusWithUnvalidatedTransactionAndSuccessCode() throws IOException, XRPException {
-        // GIVEN an XRPClient which will return an unvalidated transaction with a success code.
-        DefaultXRPClient client = getClient(
-                Result.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
-                Result.ok(makeTransactionStatus(false, TRANSACTION_STATUS_SUCCESS)),
-                Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
-                Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
-                Result.ok(makeGetAccountTransactionHistoryResponse())
-        );
+    // WHEN a transaction is sent.
+    String transactionHash = client.send(AMOUNT, XRPL_ADDRESS, wallet);
 
-        // WHEN the payment status is retrieved.
-        io.xpring.xrpl.TransactionStatus paymentStatus = client.getPaymentStatus(TRANSACTION_HASH);
+    // THEN the transaction hash is the same as the hash of the mocked transaction blob in the response.
+    assertThat(transactionHash).isEqualTo(TRANSACTION_HASH.toLowerCase());
+  }
 
-        // THEN the status is PENDING.
-        assertThat(paymentStatus).isEqualTo(io.xpring.xrpl.TransactionStatus.PENDING);
-    }
+  @Test
+  public void submitTransactionWithClassicAddress() throws IOException, XRPException {
+    // GIVEN a classic address.
+    DefaultXRPClient client = getClient();
+    ClassicAddress classicAddress = Utils.decodeXAddress(XRPL_ADDRESS);
+    Wallet wallet = new Wallet(WALLET_SEED);
 
-    @Test
-    public void paymentStatusWithValidatedTransactionAndFailureCode() throws IOException, XRPException {
-        // Iterate over different types of transaction status codes which represent failures.
-        for (String transactionFailureCode : TRANSACTION_FAILURE_STATUS_CODES) {
-            // GIVEN an XRPClient which will return an validated transaction with a failed code.
-            DefaultXRPClient client = getClient(
-                    Result.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
-                    Result.ok(makeTransactionStatus(true, transactionFailureCode)),
-                    Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
-                    Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
-                    Result.ok(makeGetAccountTransactionHistoryResponse())
-            );
+    // WHEN XRP is sent to the classic address THEN an error is thrown.
+    expectedException.expect(XRPException.class);
+    client.send(AMOUNT, classicAddress.address(), wallet);
+  }
 
-            // WHEN the payment status is retrieved.
-            io.xpring.xrpl.TransactionStatus paymentStatus = client.getPaymentStatus(TRANSACTION_HASH);
+  @Test
+  public void submitTransactionWithFailedAccountInfo() throws IOException, XRPException {
+    // GIVEN a XRPClient which will fail to return account info.
+    Result<GetAccountInfoResponse, Throwable> accountInfoResult = Result.error(GENERIC_ERROR);
+    DefaultXRPClient client = getClient(
+        accountInfoResult,
+        Result.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS)),
+        Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
+        Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
+        Result.ok(makeGetAccountTransactionHistoryResponse())
+    );
+    Wallet wallet = new Wallet(WALLET_SEED);
 
-            // THEN the status is FAILED.
-            assertThat(paymentStatus).isEqualTo(io.xpring.xrpl.TransactionStatus.FAILED);
-        }
-    }
+    // WHEN XRP is sent then THEN an error is thrown.
+    expectedException.expect(Exception.class);
+    client.send(AMOUNT, XRPL_ADDRESS, wallet);
+  }
 
-    @Test
-    public void paymentStatusWithValidatedTransactionAndSuccessCode() throws IOException, XRPException {
-        // GIVEN an XRPClient which will return an validated transaction with a success code.
-        DefaultXRPClient client = getClient(
-                Result.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
-                Result.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS)),
-                Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
-                Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
-                Result.ok(makeGetAccountTransactionHistoryResponse())
-        );
-
-        // WHEN the payment status is retrieved.
-        io.xpring.xrpl.TransactionStatus paymentStatus = client.getPaymentStatus(TRANSACTION_HASH);
-
-        // THEN the status is SUCCEEDED.
-        assertThat(paymentStatus).isEqualTo(io.xpring.xrpl.TransactionStatus.SUCCEEDED);
-    }
-
-    @Test
-    public void paymentStatusWithNodeError() throws IOException, XRPException {
-        // GIVEN an XRPClient which will error when a transaction status is requested..
-        DefaultXRPClient client = getClient(
-                Result.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
-                Result.error(GENERIC_ERROR),
-                Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
-                Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
-                Result.ok(makeGetAccountTransactionHistoryResponse())
-        );
-
-        // WHEN the payment status is retrieved THEN an error is thrown..
-        expectedException.expect(Exception.class);
-        client.getPaymentStatus(TRANSACTION_HASH);
-    }
-
-    @Test
-    public void submitTransactionTest() throws IOException, XRPException {
-        // GIVEN an XRPClient with mocked networking which will succeed.
-        DefaultXRPClient client = getClient();
-        Wallet wallet = new Wallet(WALLET_SEED);
-
-        // WHEN a transaction is sent.
-        String transactionHash = client.send(AMOUNT, XRPL_ADDRESS, wallet);
-
-        // THEN the transaction hash is the same as the hash of the mocked transaction blob in the response.
-        assertThat(transactionHash).isEqualTo(TRANSACTION_HASH.toLowerCase());
-    }
-
-    @Test
-    public void submitTransactionWithClassicAddress() throws IOException, XRPException {
-        // GIVEN a classic address.
-        DefaultXRPClient client = getClient();
-        ClassicAddress classicAddress = Utils.decodeXAddress(XRPL_ADDRESS);
-        Wallet wallet = new Wallet(WALLET_SEED);
-
-        // WHEN XRP is sent to the classic address THEN an error is thrown.
-        expectedException.expect(XRPException.class);
-        client.send(AMOUNT, classicAddress.address(), wallet);
-    }
-
-    @Test
-    public void submitTransactionWithFailedAccountInfo() throws IOException, XRPException {
-        // GIVEN a XRPClient which will fail to return account info.
-        Result<GetAccountInfoResponse, Throwable> accountInfoResult = Result.error(GENERIC_ERROR);
-        DefaultXRPClient client = getClient(
-                accountInfoResult,
-                Result.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS)),
-                Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
-                Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
-                Result.ok(makeGetAccountTransactionHistoryResponse())
-        );
-        Wallet wallet = new Wallet(WALLET_SEED);
-
-        // WHEN XRP is sent then THEN an error is thrown.
-        expectedException.expect(Exception.class);
-        client.send(AMOUNT, XRPL_ADDRESS, wallet);
-    }
-
-    @Test
-    public void submitTransactionWithFailedFee() throws IOException, XRPException {
-        // GIVEN a XRPClient which will fail to retrieve a fee.
-        Result<GetFeeResponse, Throwable> feeResult = Result.error(GENERIC_ERROR);
-        DefaultXRPClient client = getClient(
-                Result.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
-                Result.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS)),
-                feeResult,
+  @Test
+  public void submitTransactionWithFailedFee() throws IOException, XRPException {
+    // GIVEN a XRPClient which will fail to retrieve a fee.
+    Result<GetFeeResponse, Throwable> feeResult = Result.error(GENERIC_ERROR);
+    DefaultXRPClient client = getClient(
+        Result.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
+        Result.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS)),
+        feeResult,
 
         Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
-                Result.ok(makeGetAccountTransactionHistoryResponse())
-        );
-        Wallet wallet = new Wallet(WALLET_SEED);
+        Result.ok(makeGetAccountTransactionHistoryResponse())
+    );
+    Wallet wallet = new Wallet(WALLET_SEED);
 
-        // WHEN XRP is sent then THEN an error is thrown.
-        expectedException.expect(Exception.class);
-        client.send(AMOUNT, XRPL_ADDRESS, wallet);
-    }
-
-
-    @Test
-    public void submitTransactionWithFailedSubmit() throws IOException, XRPException {
-        // GIVEN a XRPClient which will fail to submit a transaction.
-        Result<SubmitTransactionResponse, Throwable> submitResult = Result.error(GENERIC_ERROR);
-        DefaultXRPClient client = getClient(
-                Result.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
-                Result.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS)),
-                Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
-                submitResult,
-                Result.ok(makeGetAccountTransactionHistoryResponse())
-        );
-        Wallet wallet = new Wallet(WALLET_SEED);
-
-        // WHEN XRP is sent then THEN an error is thrown.
-        expectedException.expect(Exception.class);
-        client.send(AMOUNT, XRPL_ADDRESS, wallet);
-    }
-
-    @Test
-    public void paymentHistoryWithSuccessfulResponseTest() throws IOException, XRPException {
-        // GIVEN a DefaultXRPClient with mocked networking that will succeed.
-        DefaultXRPClient xrpClient = getClient();
-
-        // WHEN the payment history for an address is requested.
-        List<XRPTransaction> paymentHistory = xrpClient.paymentHistory(XRPL_ADDRESS);
-
-        List<XRPTransaction> expectedPaymentHistory = XRPTestUtils.transactionHistoryToPaymentsList(
-                                                                        makeGetAccountTransactionHistoryResponse());
-
-        // THEN the payment history is returned as expected.
-        assertThat(paymentHistory).isEqualTo(expectedPaymentHistory);
-    }
-
-    @Test
-    public void paymentHistoryWithClassicAddressTest() throws IOException, XRPException {
-        // GIVEN an XRPClient and a classic address
-        DefaultXRPClient xrpClient = getClient();
-        ClassicAddress classicAddress = Utils.decodeXAddress(XRPL_ADDRESS);
-
-        // WHEN the payment history for an account is requested THEN an error to use X-Addresses is thrown.
-        expectedException.expect(XRPException.class);
-        xrpClient.paymentHistory(classicAddress.address());
-    }
-
-    @Test
-    public void paymentHistoryWithNetworkFailureTest() throws IOException, XRPException {
-        // GIVEN an XRPClient which will return a network error when calling paymentHistory.
-        Result<GetAccountTransactionHistoryResponse, Throwable> getAccountTransactionHistoryResponse =
-                Result.error(GENERIC_ERROR);
-        DefaultXRPClient xrpClient = getClient(
-                Result.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
-                Result.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS)),
-                Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
-                Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
-                getAccountTransactionHistoryResponse);
-
-        // WHEN the payment history is requested THEN an error is propagated.
-        expectedException.expect(Exception.class);
-        xrpClient.paymentHistory(XRPL_ADDRESS);
-    }
-
-    @Test
-    public void paymentHistoryWithSomeNonPaymentTransactionsTest() throws IOException, XRPException {
-        // GIVEN an XRPClient client which will return a transaction history which contains non-payment transactions.
-        Result<GetAccountTransactionHistoryResponse, Throwable> getAccountTransactionHistoryResponse =
-                Result.ok(FakeXRPProtobufs.mixedGetAccountTransactionHistoryResponse);
-
-        DefaultXRPClient xrpClient = getClient(
-                Result.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
-                Result.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS)),
-                Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
-                Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
-                getAccountTransactionHistoryResponse);
-
-        // WHEN the transactionHistory is requested.
-        List<XRPTransaction> transactionHistory = xrpClient.paymentHistory(XRPL_ADDRESS);
-
-        // THEN the returned transactions are conversions of the inputs with non-payment transactions filtered.
-        List<XRPTransaction> expectedTransactionHistory = XRPTestUtils.transactionHistoryToPaymentsList(
-                                                            FakeXRPProtobufs.mixedGetAccountTransactionHistoryResponse);
-    }
-
-    @Test
-    public void paymentHistoryWithInvalidPaymentTest() throws IOException, XRPException {
-        // GIVEN an XRPClient client which will return a transaction history which contains a malformed payment.
-        Result<GetAccountTransactionHistoryResponse, Throwable> getAccountTransactionHistoryResponse =
-                Result.ok(FakeXRPProtobufs.invalidPaymentGetAccountTransactionHistoryResponse);
-
-        DefaultXRPClient xrpClient = getClient(
-                Result.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
-                Result.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS)),
-                Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
-                Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
-                getAccountTransactionHistoryResponse);
-
-        // WHEN the transactionHistory is requested THEN a conversion error is thrown.
-        expectedException.expect(XRPException.class);
-        xrpClient.paymentHistory(XRPL_ADDRESS);
-    }
-
-    @Test
-    public void accountExistsTest() throws IOException, XRPException {
-        // GIVEN a DefaultXRPClient with mocked networking which will succeed.
-        DefaultXRPClient client = getClient();
-
-        // WHEN the account is checked
-        boolean exists = client.accountExists(XRPL_ADDRESS);
-
-        // THEN the existence of the account is the the same as the mocked response.
-        assertThat(exists).isEqualTo(true);
-    }
-
-    @Test
-    public void accountExistsWithClassicAddressTest() throws IOException, XRPException {
-        // GIVEN a classic address.
-        ClassicAddress classicAddress = Utils.decodeXAddress(XRPL_ADDRESS);
-        DefaultXRPClient client = getClient();
-
-        // WHEN the existence of the account is checked for the classic address THEN an error is thrown.
-        expectedException.expect(XRPException.class);
-        client.accountExists(classicAddress.address());
-    }
-
-    @Test
-    public void accountExistsTestWithNotFoundError() throws IOException, XRPException {
-        // GIVEN a XRPClient with mocked networking which will fail to retrieve account info w/ NOT_FOUND error code.
-        StatusRuntimeException notFoundError = new StatusRuntimeException(Status.NOT_FOUND);
-        Result<GetAccountInfoResponse, Throwable> accountInfoResult = Result.error(notFoundError);
-        DefaultXRPClient client = getClient(
-                accountInfoResult,
-                Result.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS)),
-                Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
-                Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
-                Result.ok(makeGetAccountTransactionHistoryResponse())
-        );
-
-        // WHEN the existence of the account is checked
-        boolean exists = client.accountExists(XRPL_ADDRESS);
-
-        // THEN false is returned.
-        assertThat(exists).isEqualTo(false);
-    }
-
-    @Test
-    public void accountExistsTestWithUnkonwnError() throws IOException, XRPException {
-        // GIVEN a XpringClient with mocked networking which will fail to retrieve account info w/ UNKNOWN error code.
-        StatusRuntimeException notFoundError = new StatusRuntimeException(Status.UNKNOWN);
-        Result<GetAccountInfoResponse, Throwable> accountInfoResult = Result.error(notFoundError);
-        DefaultXRPClient client = getClient(
-                accountInfoResult,
-                Result.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS)),
-                Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
-                Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
-                Result.ok(makeGetAccountTransactionHistoryResponse())
-        );
-
-        // WHEN the existence of the account is checked THEN the error is re-thrown.
-        expectedException.expect(StatusRuntimeException.class);
-        client.getBalance(XRPL_ADDRESS);
-    }
-
-    /**
-     * Convenience method to get an XRPClient which has successful network calls.
-     */
-    private DefaultXRPClient getClient() throws IOException {
-        return getClient(
-                Result.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
-                Result.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS)),
-                Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
-                Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
-                Result.ok(makeGetAccountTransactionHistoryResponse())
-        );
-    }
-
-    /**
-     * Return an XRPClient which returns the given results for network calls.
-     */
-    private DefaultXRPClient getClient(
-            Result<GetAccountInfoResponse, Throwable> getAccountInfoResponseResult,
-            Result<GetTransactionResponse, Throwable> GetTransactionResponseResult,
-            Result<GetFeeResponse, Throwable> getFeeResult,
-            Result<SubmitTransactionResponse, Throwable> submitTransactionResult,
-            Result<GetAccountTransactionHistoryResponse, Throwable> getAccountTransactionHistoryResult
-    ) throws IOException {
-        XRPLedgerAPIServiceGrpc.XRPLedgerAPIServiceImplBase serviceImpl = getService(
-                getAccountInfoResponseResult,
-                GetTransactionResponseResult,
-                getFeeResult,
-                submitTransactionResult,
-                getAccountTransactionHistoryResult
-        );
-
-        // Generate a unique in-process server name.
-        String serverName = InProcessServerBuilder.generateName();
-
-        // Create a server, add service, start, and register for automatic graceful shutdown.
-        grpcCleanup.register(InProcessServerBuilder
-                .forName(serverName).directExecutor().addService(serviceImpl).build().start());
-
-        // Create a client channel and register for automatic graceful shutdown.
-        ManagedChannel channel = grpcCleanup.register(
-                InProcessChannelBuilder.forName(serverName).directExecutor().build());
-
-        // Create a new XRPClient using the in-process channel;
-        return new DefaultXRPClient(channel);
-    }
+    // WHEN XRP is sent then THEN an error is thrown.
+    expectedException.expect(Exception.class);
+    client.send(AMOUNT, XRPL_ADDRESS, wallet);
+  }
 
 
-    /**
-     * Return an XRPLedgerService implementation which returns the given results for network calls.
-     */
-    private XRPLedgerAPIServiceGrpc.XRPLedgerAPIServiceImplBase getService(
-            Result<GetAccountInfoResponse, Throwable> getAccountInfoResult,
-            Result<GetTransactionResponse, Throwable> GetTransactionResponseResult,
-            Result<GetFeeResponse, Throwable> getFeeResult,
-            Result<SubmitTransactionResponse, Throwable> submitTransactionResult,
-            Result<GetAccountTransactionHistoryResponse, Throwable> getTransactionHistoryResult
-    ) {
-        return mock(XRPLedgerAPIServiceGrpc.XRPLedgerAPIServiceImplBase.class, delegatesTo(
-                new XRPLedgerAPIServiceGrpc.XRPLedgerAPIServiceImplBase() {
-                    @Override
-                    public void getAccountInfo(GetAccountInfoRequest request, StreamObserver<GetAccountInfoResponse> responseObserver) {
-                        if (getAccountInfoResult.isError()) {
-                            responseObserver.onError(getAccountInfoResult.getError());
-                        } else {
-                            responseObserver.onNext(getAccountInfoResult.getValue());
-                            responseObserver.onCompleted();
-                        }
-                    }
+  @Test
+  public void submitTransactionWithFailedSubmit() throws IOException, XRPException {
+    // GIVEN a XRPClient which will fail to submit a transaction.
+    Result<SubmitTransactionResponse, Throwable> submitResult = Result.error(GENERIC_ERROR);
+    DefaultXRPClient client = getClient(
+        Result.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
+        Result.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS)),
+        Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
+        submitResult,
+        Result.ok(makeGetAccountTransactionHistoryResponse())
+    );
+    Wallet wallet = new Wallet(WALLET_SEED);
 
-                    @Override
-                    public void getTransaction(GetTransactionRequest request, StreamObserver<GetTransactionResponse> responseObserver) {
-                        if (GetTransactionResponseResult.isError()) {
-                            responseObserver.onError(new Throwable(GetTransactionResponseResult.getError()));
-                        } else {
-                            responseObserver.onNext(GetTransactionResponseResult.getValue());
-                            responseObserver.onCompleted();
-                        }
-                    }
+    // WHEN XRP is sent then THEN an error is thrown.
+    expectedException.expect(Exception.class);
+    client.send(AMOUNT, XRPL_ADDRESS, wallet);
+  }
 
-                    @Override
-                    public void getFee(GetFeeRequest request,
-                                       StreamObserver<GetFeeResponse> responseObserver) {
-                        if (getFeeResult.isError()) {
-                            responseObserver.onError(getFeeResult.getError());
-                        } else {
-                            responseObserver.onNext(getFeeResult.getValue());
-                            responseObserver.onCompleted();
-                        }
-                    }
+  @Test
+  public void paymentHistoryWithSuccessfulResponseTest() throws IOException, XRPException {
+    // GIVEN a DefaultXRPClient with mocked networking that will succeed.
+    DefaultXRPClient xrpClient = getClient();
 
-                    @Override
-                    public void submitTransaction(SubmitTransactionRequest request,
-                                                  StreamObserver<SubmitTransactionResponse> responseObserver) {
-                        if (submitTransactionResult.isError()) {
-                            responseObserver.onError(submitTransactionResult.getError());
-                        } else {
-                            responseObserver.onNext(submitTransactionResult.getValue());
-                            responseObserver.onCompleted();
-                        }
-                    }
+    // WHEN the payment history for an address is requested.
+    List<XRPTransaction> paymentHistory = xrpClient.paymentHistory(XRPL_ADDRESS);
 
-                    @Override
-                    public void getAccountTransactionHistory(GetAccountTransactionHistoryRequest request,
-                                                  StreamObserver<GetAccountTransactionHistoryResponse> responseObserver) {
-                        if (getTransactionHistoryResult.isError()) {
-                            responseObserver.onError(getTransactionHistoryResult.getError());
-                        } else {
-                            responseObserver.onNext(getTransactionHistoryResult.getValue());
-                            responseObserver.onCompleted();
-                        }
-                    }
-                }
-                ));
-    }
+    List<XRPTransaction> expectedPaymentHistory = XRPTestUtils.transactionHistoryToPaymentsList(
+        makeGetAccountTransactionHistoryResponse());
 
-    /**
-     * Make a SubmitSignedTransaction response protocol buffer with the given inputs.
-     */
-    private SubmitTransactionResponse makeSubmitTransactionResponse(String hash) {
-        ByteString bytes = ByteString.copyFrom(Utils.hexStringToByteArray(hash));
-        return SubmitTransactionResponse.newBuilder().setHash(bytes).build();
-    }
+    // THEN the payment history is returned as expected.
+    assertThat(paymentHistory).isEqualTo(expectedPaymentHistory);
+  }
 
-    /**
-     * Make a GetFeeResponse protocol buffer with the given inputs.
-     */
-    private GetFeeResponse makeGetFeeResponse(long minimumFee, int lastLedgerSequence) {
-        XRPDropsAmount minimumDrops = XRPDropsAmount.newBuilder().setDrops(minimumFee).build();
-        Fee fee = Fee.newBuilder().setMinimumFee(minimumDrops).build();
-        return GetFeeResponse.newBuilder().setLedgerCurrentIndex(lastLedgerSequence).setFee(fee).build();
-    }
+  @Test
+  public void paymentHistoryWithClassicAddressTest() throws IOException, XRPException {
+    // GIVEN an XRPClient and a classic address
+    DefaultXRPClient xrpClient = getClient();
+    ClassicAddress classicAddress = Utils.decodeXAddress(XRPL_ADDRESS);
 
-    /**
-     * Make an GetAccountInfoResponse protocol buffer with the given balance.
-     */
-    private GetAccountInfoResponse makeGetAccountInfoResponse(long balance) {
-        XRPDropsAmount xrpAccountBalance = XRPDropsAmount.newBuilder().setDrops(balance).build();
-        CurrencyAmount currencyAccountBalance = CurrencyAmount.newBuilder().setXrpAmount(xrpAccountBalance).build();
-        Balance accountBalance = Balance.newBuilder().setValue(currencyAccountBalance).build();
+    // WHEN the payment history for an account is requested THEN an error to use X-Addresses is thrown.
+    expectedException.expect(XRPException.class);
+    xrpClient.paymentHistory(classicAddress.address());
+  }
 
-        AccountRoot accountData = AccountRoot.newBuilder().setBalance(accountBalance).build();
-        return GetAccountInfoResponse.newBuilder().setAccountData(accountData).build();
-    }
+  @Test
+  public void paymentHistoryWithNetworkFailureTest() throws IOException, XRPException {
+    // GIVEN an XRPClient which will return a network error when calling paymentHistory.
+    Result<GetAccountTransactionHistoryResponse, Throwable> getAccountTransactionHistoryResponse =
+        Result.error(GENERIC_ERROR);
+    DefaultXRPClient xrpClient = getClient(
+        Result.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
+        Result.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS)),
+        Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
+        Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
+        getAccountTransactionHistoryResponse);
 
-    /**
-     * Make a GetTransactionResponse.
-     */
-    private GetTransactionResponse makeTransactionStatus(Boolean validated, String result) {
-        TransactionResult transactionResult = TransactionResult.newBuilder()
-                .setResult(result)
-                .build();
-        Meta meta = Meta.newBuilder().setTransactionResult(transactionResult).build();
+    // WHEN the payment history is requested THEN an error is propagated.
+    expectedException.expect(Exception.class);
+    xrpClient.paymentHistory(XRPL_ADDRESS);
+  }
 
-        return GetTransactionResponse.newBuilder().setValidated(validated).setMeta(meta).build();
-    }
+  @Test
+  public void paymentHistoryWithSomeNonPaymentTransactionsTest() throws IOException, XRPException {
+    // GIVEN an XRPClient client which will return a transaction history which contains non-payment transactions.
+    Result<GetAccountTransactionHistoryResponse, Throwable> getAccountTransactionHistoryResponse =
+        Result.ok(FakeXRPProtobufs.mixedGetAccountTransactionHistoryResponse);
 
-    /**
-     * Make a GetAccountTransactionHistoryResponse.
-     *
-     * Note: Delegates to FakeXRPProtobufs for re-usability.
-     */
-    private GetAccountTransactionHistoryResponse makeGetAccountTransactionHistoryResponse() {
-        return FakeXRPProtobufs.paymentOnlyGetAccountTransactionHistoryResponse;
-    }
+    DefaultXRPClient xrpClient = getClient(
+        Result.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
+        Result.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS)),
+        Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
+        Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
+        getAccountTransactionHistoryResponse);
+
+    // WHEN the transactionHistory is requested.
+    List<XRPTransaction> transactionHistory = xrpClient.paymentHistory(XRPL_ADDRESS);
+
+    // THEN the returned transactions are conversions of the inputs with non-payment transactions filtered.
+    List<XRPTransaction> expectedTransactionHistory = XRPTestUtils.transactionHistoryToPaymentsList(
+        FakeXRPProtobufs.mixedGetAccountTransactionHistoryResponse);
+  }
+
+  @Test
+  public void paymentHistoryWithInvalidPaymentTest() throws IOException, XRPException {
+    // GIVEN an XRPClient client which will return a transaction history which contains a malformed payment.
+    Result<GetAccountTransactionHistoryResponse, Throwable> getAccountTransactionHistoryResponse =
+        Result.ok(FakeXRPProtobufs.invalidPaymentGetAccountTransactionHistoryResponse);
+
+    DefaultXRPClient xrpClient = getClient(
+        Result.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
+        Result.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS)),
+        Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
+        Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
+        getAccountTransactionHistoryResponse);
+
+    // WHEN the transactionHistory is requested THEN a conversion error is thrown.
+    expectedException.expect(XRPException.class);
+    xrpClient.paymentHistory(XRPL_ADDRESS);
+  }
+
+  @Test
+  public void accountExistsTest() throws IOException, XRPException {
+    // GIVEN a DefaultXRPClient with mocked networking which will succeed.
+    DefaultXRPClient client = getClient();
+
+    // WHEN the account is checked
+    boolean exists = client.accountExists(XRPL_ADDRESS);
+
+    // THEN the existence of the account is the the same as the mocked response.
+    assertThat(exists).isEqualTo(true);
+  }
+
+  @Test
+  public void accountExistsWithClassicAddressTest() throws IOException, XRPException {
+    // GIVEN a classic address.
+    ClassicAddress classicAddress = Utils.decodeXAddress(XRPL_ADDRESS);
+    DefaultXRPClient client = getClient();
+
+    // WHEN the existence of the account is checked for the classic address THEN an error is thrown.
+    expectedException.expect(XRPException.class);
+    client.accountExists(classicAddress.address());
+  }
+
+  @Test
+  public void accountExistsTestWithNotFoundError() throws IOException, XRPException {
+    // GIVEN a XRPClient with mocked networking which will fail to retrieve account info w/ NOT_FOUND error code.
+    StatusRuntimeException notFoundError = new StatusRuntimeException(Status.NOT_FOUND);
+    Result<GetAccountInfoResponse, Throwable> accountInfoResult = Result.error(notFoundError);
+    DefaultXRPClient client = getClient(
+        accountInfoResult,
+        Result.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS)),
+        Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
+        Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
+        Result.ok(makeGetAccountTransactionHistoryResponse())
+    );
+
+    // WHEN the existence of the account is checked
+    boolean exists = client.accountExists(XRPL_ADDRESS);
+
+    // THEN false is returned.
+    assertThat(exists).isEqualTo(false);
+  }
+
+  @Test
+  public void accountExistsTestWithUnkonwnError() throws IOException, XRPException {
+    // GIVEN a XpringClient with mocked networking which will fail to retrieve account info w/ UNKNOWN error code.
+    StatusRuntimeException notFoundError = new StatusRuntimeException(Status.UNKNOWN);
+    Result<GetAccountInfoResponse, Throwable> accountInfoResult = Result.error(notFoundError);
+    DefaultXRPClient client = getClient(
+        accountInfoResult,
+        Result.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS)),
+        Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
+        Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
+        Result.ok(makeGetAccountTransactionHistoryResponse())
+    );
+
+    // WHEN the existence of the account is checked THEN the error is re-thrown.
+    expectedException.expect(StatusRuntimeException.class);
+    client.getBalance(XRPL_ADDRESS);
+  }
+
+  /**
+   * Convenience method to get an XRPClient which has successful network calls.
+   */
+  private DefaultXRPClient getClient() throws IOException {
+    return getClient(
+        Result.ok(makeGetAccountInfoResponse(DROPS_OF_XRP_IN_ACCOUNT)),
+        Result.ok(makeTransactionStatus(true, TRANSACTION_STATUS_SUCCESS)),
+        Result.ok(makeGetFeeResponse(MINIMUM_FEE, LAST_LEDGER_SEQUENCE)),
+        Result.ok(makeSubmitTransactionResponse(TRANSACTION_HASH)),
+        Result.ok(makeGetAccountTransactionHistoryResponse())
+    );
+  }
+
+  /**
+   * Return an XRPClient which returns the given results for network calls.
+   */
+  private DefaultXRPClient getClient(
+      Result<GetAccountInfoResponse, Throwable> getAccountInfoResponseResult,
+      Result<GetTransactionResponse, Throwable> getTransactionResponseResult,
+      Result<GetFeeResponse, Throwable> getFeeResult,
+      Result<SubmitTransactionResponse, Throwable> submitTransactionResult,
+      Result<GetAccountTransactionHistoryResponse, Throwable> getAccountTransactionHistoryResult
+  ) throws IOException {
+    XRPLedgerAPIServiceGrpc.XRPLedgerAPIServiceImplBase serviceImpl = getService(
+        getAccountInfoResponseResult,
+        getTransactionResponseResult,
+        getFeeResult,
+        submitTransactionResult,
+        getAccountTransactionHistoryResult
+    );
+
+    // Generate a unique in-process server name.
+    String serverName = InProcessServerBuilder.generateName();
+
+    // Create a server, add service, start, and register for automatic graceful shutdown.
+    grpcCleanup.register(InProcessServerBuilder
+        .forName(serverName).directExecutor().addService(serviceImpl).build().start());
+
+    // Create a client channel and register for automatic graceful shutdown.
+    ManagedChannel channel = grpcCleanup.register(
+        InProcessChannelBuilder.forName(serverName).directExecutor().build());
+
+    // Create a new XRPClient using the in-process channel;
+    return new DefaultXRPClient(channel);
+  }
+
+
+  /**
+   * Return an XRPLedgerService implementation which returns the given results for network calls.
+   */
+  private XRPLedgerAPIServiceGrpc.XRPLedgerAPIServiceImplBase getService(
+      Result<GetAccountInfoResponse, Throwable> getAccountInfoResult,
+      Result<GetTransactionResponse, Throwable> getTransactionResponseResult,
+      Result<GetFeeResponse, Throwable> getFeeResult,
+      Result<SubmitTransactionResponse, Throwable> submitTransactionResult,
+      Result<GetAccountTransactionHistoryResponse, Throwable> getTransactionHistoryResult
+  ) {
+    return mock(XRPLedgerAPIServiceGrpc.XRPLedgerAPIServiceImplBase.class, delegatesTo(
+        new XRPLedgerAPIServiceGrpc.XRPLedgerAPIServiceImplBase() {
+          @Override
+          public void getAccountInfo(
+              GetAccountInfoRequest request,
+              StreamObserver<GetAccountInfoResponse> responseObserver
+          ) {
+            if (getAccountInfoResult.isError()) {
+              responseObserver.onError(getAccountInfoResult.getError());
+            } else {
+              responseObserver.onNext(getAccountInfoResult.getValue());
+              responseObserver.onCompleted();
+            }
+          }
+
+          @Override
+          public void getTransaction(
+              GetTransactionRequest request,
+              StreamObserver<GetTransactionResponse> responseObserver
+          ) {
+            if (getTransactionResponseResult.isError()) {
+              responseObserver.onError(new Throwable(getTransactionResponseResult.getError()));
+            } else {
+              responseObserver.onNext(getTransactionResponseResult.getValue());
+              responseObserver.onCompleted();
+            }
+          }
+
+          @Override
+          public void getFee(GetFeeRequest request,
+                             StreamObserver<GetFeeResponse> responseObserver) {
+            if (getFeeResult.isError()) {
+              responseObserver.onError(getFeeResult.getError());
+            } else {
+              responseObserver.onNext(getFeeResult.getValue());
+              responseObserver.onCompleted();
+            }
+          }
+
+          @Override
+          public void submitTransaction(SubmitTransactionRequest request,
+                                        StreamObserver<SubmitTransactionResponse> responseObserver) {
+            if (submitTransactionResult.isError()) {
+              responseObserver.onError(submitTransactionResult.getError());
+            } else {
+              responseObserver.onNext(submitTransactionResult.getValue());
+              responseObserver.onCompleted();
+            }
+          }
+
+          @Override
+          public void getAccountTransactionHistory(
+              GetAccountTransactionHistoryRequest request,
+              StreamObserver<GetAccountTransactionHistoryResponse> responseObserver
+          ) {
+            if (getTransactionHistoryResult.isError()) {
+              responseObserver.onError(getTransactionHistoryResult.getError());
+            } else {
+              responseObserver.onNext(getTransactionHistoryResult.getValue());
+              responseObserver.onCompleted();
+            }
+          }
+        }
+    ));
+  }
+
+  /**
+   * Make a SubmitSignedTransaction response protocol buffer with the given inputs.
+   */
+  private SubmitTransactionResponse makeSubmitTransactionResponse(String hash) {
+    ByteString bytes = ByteString.copyFrom(Utils.hexStringToByteArray(hash));
+    return SubmitTransactionResponse.newBuilder().setHash(bytes).build();
+  }
+
+  /**
+   * Make a GetFeeResponse protocol buffer with the given inputs.
+   */
+  private GetFeeResponse makeGetFeeResponse(long minimumFee, int lastLedgerSequence) {
+    XRPDropsAmount minimumDrops = XRPDropsAmount.newBuilder().setDrops(minimumFee).build();
+    Fee fee = Fee.newBuilder().setMinimumFee(minimumDrops).build();
+    return GetFeeResponse.newBuilder().setLedgerCurrentIndex(lastLedgerSequence).setFee(fee).build();
+  }
+
+  /**
+   * Make an GetAccountInfoResponse protocol buffer with the given balance.
+   */
+  private GetAccountInfoResponse makeGetAccountInfoResponse(long balance) {
+    XRPDropsAmount xrpAccountBalance = XRPDropsAmount.newBuilder().setDrops(balance).build();
+    CurrencyAmount currencyAccountBalance = CurrencyAmount.newBuilder().setXrpAmount(xrpAccountBalance).build();
+    Balance accountBalance = Balance.newBuilder().setValue(currencyAccountBalance).build();
+
+    AccountRoot accountData = AccountRoot.newBuilder().setBalance(accountBalance).build();
+    return GetAccountInfoResponse.newBuilder().setAccountData(accountData).build();
+  }
+
+  /**
+   * Make a GetTransactionResponse.
+   */
+  private GetTransactionResponse makeTransactionStatus(Boolean validated, String result) {
+    TransactionResult transactionResult = TransactionResult.newBuilder()
+        .setResult(result)
+        .build();
+    Meta meta = Meta.newBuilder().setTransactionResult(transactionResult).build();
+
+    return GetTransactionResponse.newBuilder().setValidated(validated).setMeta(meta).build();
+  }
+
+  /**
+   * Make a GetAccountTransactionHistoryResponse.
+   * <p>
+   * Note: Delegates to FakeXRPProtobufs for re-usability.
+   * </p>
+   */
+  private GetAccountTransactionHistoryResponse makeGetAccountTransactionHistoryResponse() {
+    return FakeXRPProtobufs.paymentOnlyGetAccountTransactionHistoryResponse;
+  }
 }

--- a/src/test/java/io/xpring/xrpl/FakeXRPClient.java
+++ b/src/test/java/io/xpring/xrpl/FakeXRPClient.java
@@ -1,114 +1,129 @@
 package io.xpring.xrpl;
 
-import io.xpring.xrpl.model.XRPTransaction;
-
 import io.xpring.common.Result;
 import io.xpring.common.XRPLNetwork;
+import io.xpring.xrpl.model.XRPTransaction;
 
 import java.math.BigInteger;
 import java.util.List;
 
 /**
  * A fake XRPClient which returns the given iVars as results from XRPClientDecorator calls.
- * @Note: Since this class is passed by reference and the iVars are mutable, outputs of this class can be changed after it is injected.
+ * <p>
+ * Note: Since this class is passed by reference and the iVars are mutable, outputs of this class can be changed after
+ * it is injected.
+ * </p>
  */
-public class FakeXRPClient implements  XRPClientDecorator, XRPClientInterface {
-    private XRPLNetwork network;
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+public class FakeXRPClient implements XRPClientDecorator, XRPClientInterface {
+  private XRPLNetwork network;
 
-    public Result<BigInteger, XRPException> getBalanceResult;
-    public Result<TransactionStatus, XRPException> paymentStatusResult;
-    public Result<String, XRPException> sendResult;
-    public Result<Integer, XRPException> latestValidatedLedgerResult;
-    public Result<RawTransactionStatus, XRPException> rawTransactionStatusResult;
-    public Result<List<XRPTransaction>, XRPException> paymentHistoryResult;
-    public Result<Boolean, XRPException> accountExistsResult;
+  public Result<BigInteger, XRPException> getBalanceResult;
+  public Result<TransactionStatus, XRPException> paymentStatusResult;
+  public Result<String, XRPException> sendResult;
+  public Result<Integer, XRPException> latestValidatedLedgerResult;
+  public Result<RawTransactionStatus, XRPException> rawTransactionStatusResult;
+  public Result<List<XRPTransaction>, XRPException> paymentHistoryResult;
+  public Result<Boolean, XRPException> accountExistsResult;
 
-    public FakeXRPClient(
-            XRPLNetwork network,
-            Result<BigInteger, XRPException> getBalanceResult,
-            Result<TransactionStatus, XRPException> paymentStatusResult,
-            Result<String, XRPException> sendResult,
-            Result<Integer, XRPException> latestValidatedLedgerResult,
-            Result<RawTransactionStatus, XRPException> rawTransactionStatusResult,
-            Result<List<XRPTransaction>, XRPException> paymentHistoryResult,
-            Result<Boolean, XRPException> accountExistsResult
-    ) {
-        this.network = network;
-        this.getBalanceResult = getBalanceResult;
-        this.paymentStatusResult = paymentStatusResult;
-        this.sendResult = sendResult;
-        this.latestValidatedLedgerResult = latestValidatedLedgerResult;
-        this.rawTransactionStatusResult = rawTransactionStatusResult;
-        this.paymentHistoryResult = paymentHistoryResult;
-        this.accountExistsResult = accountExistsResult;
+  /**
+   * Create a new FakeXRPClient.
+   *
+   * @param network The network the client is attached to.
+   * @param getBalanceResult The result of a call to get a balance of an account.
+   * @param paymentStatusResult The result of a call to get a payment status.
+   * @param sendResult The result of sending a payment.
+   * @param latestValidatedLedgerResult The result of requesting the latest validated ledger sequence number.
+   * @param rawTransactionStatusResult The result of requesting a raw transaction status.
+   * @param paymentHistoryResult The result of requesting payment history.
+   * @param accountExistsResult The result of checking existence of an account.
+   */
+  public FakeXRPClient(
+      XRPLNetwork network,
+      Result<BigInteger, XRPException> getBalanceResult,
+      Result<TransactionStatus, XRPException> paymentStatusResult,
+      Result<String, XRPException> sendResult,
+      Result<Integer, XRPException> latestValidatedLedgerResult,
+      Result<RawTransactionStatus, XRPException> rawTransactionStatusResult,
+      Result<List<XRPTransaction>, XRPException> paymentHistoryResult,
+      Result<Boolean, XRPException> accountExistsResult
+  ) {
+    this.network = network;
+    this.getBalanceResult = getBalanceResult;
+    this.paymentStatusResult = paymentStatusResult;
+    this.sendResult = sendResult;
+    this.latestValidatedLedgerResult = latestValidatedLedgerResult;
+    this.rawTransactionStatusResult = rawTransactionStatusResult;
+    this.paymentHistoryResult = paymentHistoryResult;
+    this.accountExistsResult = accountExistsResult;
+  }
+
+  @Override
+  public XRPLNetwork getNetwork() {
+    return this.network;
+  }
+
+  @Override
+  public BigInteger getBalance(String xrplAccountAddress) throws XRPException {
+    if (this.getBalanceResult.isError()) {
+      throw this.getBalanceResult.getError();
+    } else {
+      return getBalanceResult.getValue();
     }
+  }
 
-    @Override
-    public XRPLNetwork getNetwork() {
-        return this.network;
+  @Override
+  public TransactionStatus getPaymentStatus(String transactionHash) throws XRPException {
+    if (this.paymentStatusResult.isError()) {
+      throw this.paymentStatusResult.getError();
+    } else {
+      return paymentStatusResult.getValue();
     }
+  }
 
-    @Override
-    public BigInteger getBalance(String xrplAccountAddress) throws XRPException {
-        if (this.getBalanceResult.isError()) {
-            throw this.getBalanceResult.getError();
-        } else {
-            return getBalanceResult.getValue();
-        }
+  @Override
+  public String send(BigInteger amount, String destinationAddress, Wallet sourceWallet) throws XRPException {
+    if (this.sendResult.isError()) {
+      throw this.sendResult.getError();
+    } else {
+      return sendResult.getValue();
     }
+  }
 
-    @Override
-    public TransactionStatus getPaymentStatus(String transactionHash) throws XRPException {
-        if (this.paymentStatusResult.isError()) {
-            throw this.paymentStatusResult.getError();
-        } else {
-            return paymentStatusResult.getValue();
-        }
+  @Override
+  public int getLatestValidatedLedgerSequence() throws XRPException {
+    if (this.latestValidatedLedgerResult.isError()) {
+      throw this.latestValidatedLedgerResult.getError();
+    } else {
+      return latestValidatedLedgerResult.getValue();
     }
+  }
 
-    @Override
-    public String send(BigInteger amount, String destinationAddress, Wallet sourceWallet) throws XRPException {
-        if (this.sendResult.isError()) {
-            throw this.sendResult.getError();
-        } else {
-            return sendResult.getValue();
-        }
+  @Override
+  public RawTransactionStatus getRawTransactionStatus(String transactionHash) throws XRPException {
+    if (this.rawTransactionStatusResult.isError()) {
+      throw this.rawTransactionStatusResult.getError();
+    } else {
+      return rawTransactionStatusResult.getValue();
     }
+  }
 
-    @Override
-    public int getLatestValidatedLedgerSequence() throws XRPException {
-        if (this.latestValidatedLedgerResult.isError()) {
-            throw this.latestValidatedLedgerResult.getError();
-        } else {
-            return latestValidatedLedgerResult.getValue();
-        }
+  @Override
+  public boolean accountExists(String address) throws XRPException {
+    if (this.accountExistsResult.isError()) {
+      throw this.accountExistsResult.getError();
+    } else {
+      return accountExistsResult.getValue();
     }
+  }
 
-    @Override
-    public RawTransactionStatus getRawTransactionStatus(String transactionHash) throws XRPException {
-        if (this.rawTransactionStatusResult.isError()) {
-            throw this.rawTransactionStatusResult.getError();
-        } else {
-            return rawTransactionStatusResult.getValue();
-        }
+
+  @Override
+  public List<XRPTransaction> paymentHistory(String xrplAccountAddress) throws XRPException {
+    if (this.paymentHistoryResult.isError()) {
+      throw this.paymentHistoryResult.getError();
+    } else {
+      return paymentHistoryResult.getValue();
     }
-
-    @Override
-    public boolean accountExists(String address) throws XRPException {
-        if (this.accountExistsResult.isError()) {
-            throw this.accountExistsResult.getError();
-        } else {
-            return accountExistsResult.getValue();
-        }
-    }
-
-
-    @Override
-    public List<XRPTransaction> paymentHistory(String xrplAccountAddress) throws XRPException {
-        if (this.paymentHistoryResult.isError()) {
-            throw this.paymentHistoryResult.getError();
-        } else {
-            return paymentHistoryResult.getValue();
-        }
-    }
+  }
 }

--- a/src/test/java/io/xpring/xrpl/FakeXRPProtobufs.java
+++ b/src/test/java/io/xpring/xrpl/FakeXRPProtobufs.java
@@ -1,393 +1,429 @@
 package io.xpring.xrpl;
+
 import com.google.protobuf.ByteString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xrpl.rpc.v1.*;
+import org.xrpl.rpc.v1.AccountAddress;
+import org.xrpl.rpc.v1.CheckCash;
+import org.xrpl.rpc.v1.Common.Account;
+import org.xrpl.rpc.v1.Common.AccountTransactionID;
+import org.xrpl.rpc.v1.Common.Amount;
+import org.xrpl.rpc.v1.Common.DeliverMin;
+import org.xrpl.rpc.v1.Common.Destination;
+import org.xrpl.rpc.v1.Common.DestinationTag;
+import org.xrpl.rpc.v1.Common.Flags;
+import org.xrpl.rpc.v1.Common.InvoiceID;
+import org.xrpl.rpc.v1.Common.LastLedgerSequence;
+import org.xrpl.rpc.v1.Common.MemoData;
+import org.xrpl.rpc.v1.Common.MemoFormat;
+import org.xrpl.rpc.v1.Common.MemoType;
+import org.xrpl.rpc.v1.Common.SendMax;
+import org.xrpl.rpc.v1.Common.Sequence;
+import org.xrpl.rpc.v1.Common.SigningPublicKey;
+import org.xrpl.rpc.v1.Common.SourceTag;
+import org.xrpl.rpc.v1.Common.TransactionSignature;
+import org.xrpl.rpc.v1.Currency;
+import org.xrpl.rpc.v1.CurrencyAmount;
+import org.xrpl.rpc.v1.GetAccountTransactionHistoryResponse;
+import org.xrpl.rpc.v1.GetTransactionResponse;
+import org.xrpl.rpc.v1.IssuedCurrencyAmount;
+import org.xrpl.rpc.v1.Memo;
+import org.xrpl.rpc.v1.Payment;
 import org.xrpl.rpc.v1.Signer;
+import org.xrpl.rpc.v1.Transaction;
+import org.xrpl.rpc.v1.XRPDropsAmount;
 
 import java.io.UnsupportedEncodingException;
 
-/** Common set of fake objects - protobuf and native Java conversions - for testing */
+/**
+ * Common set of fake objects - protobuf and native Java conversions - for testing.
+ */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class FakeXRPProtobufs {
-    static private final Logger logger = LoggerFactory.getLogger(FakeXRPProtobufs.class);
+  private static final Logger logger = LoggerFactory.getLogger(FakeXRPProtobufs.class);
 
-    // primitive test values
-    static String testCurrencyName = "currencyName";
-    static ByteString testCurrencyCode;
+  // primitive test values
+  static String testCurrencyName = "currencyName";
+  static ByteString testCurrencyCode;
 
-    static String fakeAddress1 = "r123";
-    static String fakeAddress2 = "r456";
+  static String fakeAddress1 = "r123";
+  static String fakeAddress2 = "r456";
 
-    static {
-        try {
-            testCurrencyCode = ByteString.copyFrom("123", "Utf8");
-        } catch (UnsupportedEncodingException exception) {
-            logger.error("Can't create testCurrencyCode", exception);
-        }
+  static {
+    try {
+      testCurrencyCode = ByteString.copyFrom("123", "Utf8");
+    } catch (UnsupportedEncodingException exception) {
+      logger.error("Can't create testCurrencyCode", exception);
     }
+  }
 
-    static String testIssuedCurrencyValue = "100";
-    static String testInvalidIssuedCurrencyValue = "xrp"; // non-numeric
-    static long testDrops = 10;
+  static String testIssuedCurrencyValue = "100";
+  static String testInvalidIssuedCurrencyValue = "xrp"; // non-numeric
+  static long testDrops = 10;
 
-    static int testDestinationTag = 2;
+  static int testDestinationTag = 2;
 
-    static ByteString memoDataBytes;
-    static ByteString memoFormatBytes;
-    static ByteString memoTypeBytes;
+  static ByteString memoDataBytes;
+  static ByteString memoFormatBytes;
+  static ByteString memoTypeBytes;
 
-    static {
-        try {
-            memoDataBytes = ByteString.copyFrom("123", "Utf8");
-        } catch (UnsupportedEncodingException exception) {
-            logger.error("Can't create memoDataBytes", exception);
-        }
+  static {
+    try {
+      memoDataBytes = ByteString.copyFrom("123", "Utf8");
+    } catch (UnsupportedEncodingException exception) {
+      logger.error("Can't create memoDataBytes", exception);
     }
-    static {
-        try {
-            memoFormatBytes = ByteString.copyFrom("456", "Utf8");
-        } catch (UnsupportedEncodingException exception) {
-            logger.error("Can't create memoFormatBytes", exception);
-        }
+  }
+
+  static {
+    try {
+      memoFormatBytes = ByteString.copyFrom("456", "Utf8");
+    } catch (UnsupportedEncodingException exception) {
+      logger.error("Can't create memoFormatBytes", exception);
     }
-    static {
-        try {
-            memoTypeBytes = ByteString.copyFrom("789", "Utf8");
-        } catch (UnsupportedEncodingException exception) {
-            logger.error("Can't create memoTypeBytes", exception);
-        }
+  }
+
+  static {
+    try {
+      memoTypeBytes = ByteString.copyFrom("789", "Utf8");
+    } catch (UnsupportedEncodingException exception) {
+      logger.error("Can't create memoTypeBytes", exception);
     }
+  }
 
-    static ByteString testSigningPublicKey;
-    static {
-        try {
-            testSigningPublicKey = ByteString.copyFrom("123", "Utf8");
-        } catch (UnsupportedEncodingException exception) {
-            logger.error("Can't create testSigningPublicKey", exception);
-        }
+  static ByteString testSigningPublicKey;
+
+  static {
+    try {
+      testSigningPublicKey = ByteString.copyFrom("123", "Utf8");
+    } catch (UnsupportedEncodingException exception) {
+      logger.error("Can't create testSigningPublicKey", exception);
     }
+  }
 
-    static ByteString testTransactionSignature;
-    static {
-        try {
-            testTransactionSignature = ByteString.copyFrom("456", "Utf8");
-        } catch (UnsupportedEncodingException exception) {
-            logger.error("Can't create testTransactionSignature", exception);
-        }
+  static ByteString testTransactionSignature;
+
+  static {
+    try {
+      testTransactionSignature = ByteString.copyFrom("456", "Utf8");
+    } catch (UnsupportedEncodingException exception) {
+      logger.error("Can't create testTransactionSignature", exception);
     }
+  }
 
-    static ByteString testAccountTransactionID;
-    static {
-        try {
-            testAccountTransactionID = ByteString.copyFrom("789", "Utf8");
-        } catch (UnsupportedEncodingException exception) {
-            exception.printStackTrace();
-        }
+  static ByteString testAccountTransactionID;
+
+  static {
+    try {
+      testAccountTransactionID = ByteString.copyFrom("789", "Utf8");
+    } catch (UnsupportedEncodingException exception) {
+      exception.printStackTrace();
     }
+  }
 
-    static Integer testSequence = 1;
-    static Integer testFlags = 4;
-    static Integer testSourceTag = 6;
-    static Integer testLastLedgerSequence = 5;
+  static Integer testSequence = 1;
+  static Integer testFlags = 4;
+  static Integer testSourceTag = 6;
+  static Integer testLastLedgerSequence = 5;
 
-    // VALID OBJECTS ===============================================================
+  // VALID OBJECTS ===============================================================
 
-    // Currency proto
-    static Currency currency = Currency.newBuilder()
-                                        .setName(testCurrencyName)
-                                        .setCode(testCurrencyCode)
-                                        .build();
+  // Currency proto
+  static Currency currency = Currency.newBuilder()
+      .setName(testCurrencyName)
+      .setCode(testCurrencyCode)
+      .build();
 
-    // AccountAddress protos
-    static AccountAddress accountAddress = AccountAddress.newBuilder()
-                                                        .setAddress(fakeAddress1)
-                                                        .build();
+  // AccountAddress protos
+  static AccountAddress accountAddress = AccountAddress.newBuilder()
+      .setAddress(fakeAddress1)
+      .build();
 
-    static AccountAddress accountAddress_issuer = AccountAddress.newBuilder()
-                                                                .setAddress(fakeAddress2)
-                                                                .build();
+  static AccountAddress accountAddress_issuer = AccountAddress.newBuilder()
+      .setAddress(fakeAddress2)
+      .build();
 
-    // PathElement proto
-    static Payment.PathElement pathElement = Payment.PathElement.newBuilder()
-                                                                .setAccount(accountAddress)
-                                                                .setCurrency(currency)
-                                                                .setIssuer(accountAddress_issuer)
-                                                                .build();
+  // PathElement proto
+  static Payment.PathElement pathElement = Payment.PathElement.newBuilder()
+      .setAccount(accountAddress)
+      .setCurrency(currency)
+      .setIssuer(accountAddress_issuer)
+      .build();
 
-    // Path protos
-    static Payment.Path emptyPath = Payment.Path.newBuilder().build();
+  // Path protos
+  static Payment.Path emptyPath = Payment.Path.newBuilder().build();
 
-    static Payment.Path pathWithOneElement = Payment.Path.newBuilder()
-                                                        .addElements(pathElement)
-                                                        .build();
+  static Payment.Path pathWithOneElement = Payment.Path.newBuilder()
+      .addElements(pathElement)
+      .build();
 
-    static Payment.Path pathWithThreeElements = Payment.Path.newBuilder()
-                                                            .addElements(pathElement)
-                                                            .addElements(pathElement)
-                                                            .addElements(pathElement)
-                                                            .build();
+  static Payment.Path pathWithThreeElements = Payment.Path.newBuilder()
+      .addElements(pathElement)
+      .addElements(pathElement)
+      .addElements(pathElement)
+      .build();
 
-    // IssuedCurrencyAmount protos
-    static IssuedCurrencyAmount issuedCurrencyAmount = IssuedCurrencyAmount.newBuilder()
-                                                                            .setCurrency(currency)
-                                                                            .setIssuer(accountAddress)
-                                                                            .setValue(testIssuedCurrencyValue)
-                                                                            .build();
+  // IssuedCurrencyAmount protos
+  static IssuedCurrencyAmount issuedCurrencyAmount = IssuedCurrencyAmount.newBuilder()
+      .setCurrency(currency)
+      .setIssuer(accountAddress)
+      .setValue(testIssuedCurrencyValue)
+      .build();
 
-    // CurrencyAmount protos
-        // XRPDropsAmount proto
-    static XRPDropsAmount xrpDropsAmount = XRPDropsAmount.newBuilder().setDrops(testDrops).build();
-    static CurrencyAmount dropsCurrencyAmount = CurrencyAmount.newBuilder().setXrpAmount(xrpDropsAmount).build();
+  // CurrencyAmount protos
+  // XRPDropsAmount proto
+  static XRPDropsAmount xrpDropsAmount = XRPDropsAmount.newBuilder().setDrops(testDrops).build();
+  static CurrencyAmount dropsCurrencyAmount = CurrencyAmount.newBuilder().setXrpAmount(xrpDropsAmount).build();
 
-    static CurrencyAmount issuedCurrencyCurrencyAmount = CurrencyAmount.newBuilder()
-                                                                        .setIssuedCurrencyAmount(issuedCurrencyAmount)
-                                                                        .build();
+  static CurrencyAmount issuedCurrencyCurrencyAmount = CurrencyAmount.newBuilder()
+      .setIssuedCurrencyAmount(issuedCurrencyAmount)
+      .build();
 
-    // Payment protos
-        // Amount
-    static Common.Amount amount = Common.Amount.newBuilder().setValue(issuedCurrencyCurrencyAmount).build();
+  // Payment protos
+  // Amount
+  static Amount amount = Amount.newBuilder().setValue(issuedCurrencyCurrencyAmount).build();
 
-        // Destination
-    static Common.Destination destination = Common.Destination.newBuilder().setValue(accountAddress).build();
+  // Destination
+  static Destination destination = Destination.newBuilder().setValue(accountAddress).build();
 
-        // DestinationTag
-    static Common.DestinationTag destinationTag = Common.DestinationTag.newBuilder()
-                                                                        .setValue(testDestinationTag).build();
+  // DestinationTag
+  static DestinationTag destinationTag = DestinationTag.newBuilder()
+      .setValue(testDestinationTag).build();
 
-        // DeliverMin
-    static Common.DeliverMin deliverMin = Common.DeliverMin.newBuilder().setValue(dropsCurrencyAmount).build();
+  // DeliverMin
+  static DeliverMin deliverMin = DeliverMin.newBuilder().setValue(dropsCurrencyAmount).build();
 
-        // InvoiceID
-    static Common.InvoiceID invoiceID = Common.InvoiceID.newBuilder().setValue(testCurrencyCode).build();
+  // InvoiceID
+  static InvoiceID invoiceID = InvoiceID.newBuilder().setValue(testCurrencyCode).build();
 
-        // Paths
-    static AccountAddress accountAddress_456 = AccountAddress.newBuilder().setAddress("r456").build();
-    static AccountAddress accountAddress_789 = AccountAddress.newBuilder().setAddress("r789").build();
-    static AccountAddress accountAddress_abc = AccountAddress.newBuilder().setAddress("rabc").build();
+  // Paths
+  static AccountAddress accountAddress_456 = AccountAddress.newBuilder().setAddress("r456").build();
+  static AccountAddress accountAddress_789 = AccountAddress.newBuilder().setAddress("r789").build();
+  static AccountAddress accountAddress_abc = AccountAddress.newBuilder().setAddress("rabc").build();
 
-    static Payment.PathElement pathElement_456 = Payment.PathElement.newBuilder()
-                                                                    .setAccount(accountAddress_456).build();
-    static Payment.PathElement pathElement_789 = Payment.PathElement.newBuilder()
-                                                                    .setAccount(accountAddress_789).build();
-    static Payment.PathElement pathElement_abc = Payment.PathElement.newBuilder()
-                                                                    .setAccount(accountAddress_abc).build();
+  static Payment.PathElement pathElement_456 = Payment.PathElement.newBuilder()
+      .setAccount(accountAddress_456).build();
+  static Payment.PathElement pathElement_789 = Payment.PathElement.newBuilder()
+      .setAccount(accountAddress_789).build();
+  static Payment.PathElement pathElement_abc = Payment.PathElement.newBuilder()
+      .setAccount(accountAddress_abc).build();
 
 
-    static Payment.Path pathProtoOneElement = Payment.Path.newBuilder().addElements(pathElement_456).build();
-    static Payment.Path pathProtoTwoElements = Payment.Path.newBuilder()
-                                                            .addElements(pathElement_789)
-                                                            .addElements(pathElement_abc)
-                                                            .build();
+  static Payment.Path pathProtoOneElement = Payment.Path.newBuilder().addElements(pathElement_456).build();
+  static Payment.Path pathProtoTwoElements = Payment.Path.newBuilder()
+      .addElements(pathElement_789)
+      .addElements(pathElement_abc)
+      .build();
 
-        // SendMax
-    static Common.SendMax sendMax = Common.SendMax.newBuilder().setValue(dropsCurrencyAmount).build();
+  // SendMax
+  static SendMax sendMax = SendMax.newBuilder().setValue(dropsCurrencyAmount).build();
 
-        // finally, populate Payment
-    static Payment paymentWithAllFieldsSet = Payment.newBuilder()
-                                                    .setAmount(amount)
-                                                    .setDestination(destination)
-                                                    .setDestinationTag(destinationTag)
-                                                    .setDeliverMin(deliverMin)
-                                                    .setInvoiceId(invoiceID)
-                                                    .addPaths(pathProtoOneElement)
-                                                    .addPaths(pathProtoTwoElements)
-                                                    .setSendMax(sendMax)
-                                                    .build();
+  // finally, populate Payment
+  static Payment paymentWithAllFieldsSet = Payment.newBuilder()
+      .setAmount(amount)
+      .setDestination(destination)
+      .setDestinationTag(destinationTag)
+      .setDeliverMin(deliverMin)
+      .setInvoiceId(invoiceID)
+      .addPaths(pathProtoOneElement)
+      .addPaths(pathProtoTwoElements)
+      .setSendMax(sendMax)
+      .build();
 
-    static Payment paymentWithMandatoryFieldsSet = Payment.newBuilder()
-                                                        .setAmount(amount)
-                                                        .setDestination(destination)
-                                                        .build();
+  static Payment paymentWithMandatoryFieldsSet = Payment.newBuilder()
+      .setAmount(amount)
+      .setDestination(destination)
+      .build();
 
-    // Memo protos
-    static Common.MemoData memoData = Common.MemoData.newBuilder()
-                                                    .setValue(memoDataBytes)
-                                                    .build();
-    static Common.MemoFormat memoFormat = Common.MemoFormat.newBuilder()
-                                                        .setValue(memoFormatBytes)
-                                                        .build();
-    static Common.MemoType memoType = Common.MemoType.newBuilder()
-                                                    .setValue(memoTypeBytes)
-                                                    .build();
+  // Memo protos
+  static MemoData memoData = MemoData.newBuilder()
+      .setValue(memoDataBytes)
+      .build();
+  static MemoFormat memoFormat = MemoFormat.newBuilder()
+      .setValue(memoFormatBytes)
+      .build();
+  static MemoType memoType = MemoType.newBuilder()
+      .setValue(memoTypeBytes)
+      .build();
 
-    static Memo memoWithAllFieldsSet = Memo.newBuilder()
-                                            .setMemoData(memoData)
-                                            .setMemoFormat(memoFormat)
-                                            .setMemoType(memoType)
-                                            .build();
+  static Memo memoWithAllFieldsSet = Memo.newBuilder()
+      .setMemoData(memoData)
+      .setMemoFormat(memoFormat)
+      .setMemoType(memoType)
+      .build();
 
-    // Signer protos
-        // Account
-    static Common.Account account = Common.Account.newBuilder().setValue(accountAddress).build();
+  // Signer protos
+  // Account
+  static Account account = Account.newBuilder().setValue(accountAddress).build();
 
-        // SigningPublicKey
-    static Common.SigningPublicKey signingPublicKey = Common.SigningPublicKey.newBuilder()
-                                                                    .setValue(testSigningPublicKey)
-                                                                    .build();
-        // TransactionSignature
-    static Common.TransactionSignature transactionSignature = Common.TransactionSignature.newBuilder()
-                                                                                .setValue(testTransactionSignature)
-                                                                                .build();
+  // SigningPublicKey
+  static SigningPublicKey signingPublicKey = SigningPublicKey.newBuilder()
+      .setValue(testSigningPublicKey)
+      .build();
+  // TransactionSignature
+  static TransactionSignature transactionSignature = TransactionSignature.newBuilder()
+      .setValue(testTransactionSignature)
+      .build();
 
-    static Signer signerWithAllFieldsSet = Signer.newBuilder()
-                                        .setAccount(account)
-                                        .setSigningPublicKey(signingPublicKey)
-                                        .setTransactionSignature(transactionSignature)
-                                        .build();
+  static Signer signerWithAllFieldsSet = Signer.newBuilder()
+      .setAccount(account)
+      .setSigningPublicKey(signingPublicKey)
+      .setTransactionSignature(transactionSignature)
+      .build();
 
-    // CheckCash proto
-    static CheckCash checkCash = CheckCash.newBuilder().build();
+  // CheckCash proto
+  static CheckCash checkCash = CheckCash.newBuilder().build();
 
-    // Transaction protos
-        // Common.Sequence proto
-    static Common.Sequence sequence = Common.Sequence.newBuilder().setValue(testSequence).build();
+  // Transaction protos
+  // Common.Sequence proto
+  static Sequence sequence = Sequence.newBuilder().setValue(testSequence).build();
 
-        // Common.AccountTransactionID proto
-    static Common.AccountTransactionID accountTransactionID = Common.AccountTransactionID.newBuilder()
-                                                                                    .setValue(testAccountTransactionID)
-                                                                                    .build();
-        // Common.Flags proto
-    static Common.Flags flags = Common.Flags.newBuilder().setValue(testFlags).build();
+  // Common.AccountTransactionID proto
+  static AccountTransactionID accountTransactionID = AccountTransactionID.newBuilder()
+      .setValue(testAccountTransactionID)
+      .build();
+  // Common.Flags proto
+  static Flags flags = Flags.newBuilder().setValue(testFlags).build();
 
-        // Common.LastLedgerSequence proto
-    static Common.LastLedgerSequence lastLedgerSequence = Common.LastLedgerSequence.newBuilder()
-                                                                                .setValue(testLastLedgerSequence)
-                                                                                .build();
+  // Common.LastLedgerSequence proto
+  static LastLedgerSequence lastLedgerSequence = LastLedgerSequence.newBuilder()
+      .setValue(testLastLedgerSequence)
+      .build();
 
-        // Common.SourceTag proto
-    static Common.SourceTag sourceTag = Common.SourceTag.newBuilder().setValue(testSourceTag).build();
+  // Common.SourceTag proto
+  static SourceTag sourceTag = SourceTag.newBuilder().setValue(testSourceTag).build();
 
-    static Transaction transactionWithAllFieldsSet = Transaction.newBuilder()
-                                                                .setAccount(account)
-                                                                .setAccountTransactionId(accountTransactionID)
-                                                                .setFee(xrpDropsAmount)
-                                                                .setFlags(flags)
-                                                                .setLastLedgerSequence(lastLedgerSequence)
-                                                                .addMemos(memoWithAllFieldsSet)
-                                                                .setSequence(sequence)
-                                                                .addSigners(signerWithAllFieldsSet)
-                                                                .setSigningPublicKey(signingPublicKey)
-                                                                .setSourceTag(sourceTag)
-                                                                .setTransactionSignature(transactionSignature)
-                                                                .setPayment(paymentWithAllFieldsSet)
-                                                                .build();
+  static Transaction transactionWithAllFieldsSet = Transaction.newBuilder()
+      .setAccount(account)
+      .setAccountTransactionId(accountTransactionID)
+      .setFee(xrpDropsAmount)
+      .setFlags(flags)
+      .setLastLedgerSequence(lastLedgerSequence)
+      .addMemos(memoWithAllFieldsSet)
+      .setSequence(sequence)
+      .addSigners(signerWithAllFieldsSet)
+      .setSigningPublicKey(signingPublicKey)
+      .setSourceTag(sourceTag)
+      .setTransactionSignature(transactionSignature)
+      .setPayment(paymentWithAllFieldsSet)
+      .build();
 
-    static Transaction transactionWithOnlyMandatoryCommonFieldsSet = Transaction.newBuilder()
-                                                                        .setAccount(account)
-                                                                        .setFee(xrpDropsAmount)
-                                                                        .setSequence(sequence)
-                                                                        .setSigningPublicKey(signingPublicKey)
-                                                                        .setTransactionSignature(transactionSignature)
-                                                                        .setPayment(paymentWithAllFieldsSet)
-                                                                        .build();
+  static Transaction transactionWithOnlyMandatoryCommonFieldsSet = Transaction.newBuilder()
+      .setAccount(account)
+      .setFee(xrpDropsAmount)
+      .setSequence(sequence)
+      .setSigningPublicKey(signingPublicKey)
+      .setTransactionSignature(transactionSignature)
+      .setPayment(paymentWithAllFieldsSet)
+      .build();
 
-    static Transaction checkCashTransactionWithCommonFieldsSet = Transaction.newBuilder()
-                                                                        .setAccount(account)
-                                                                        .setFee(xrpDropsAmount)
-                                                                        .setSequence(sequence)
-                                                                        .setSigningPublicKey(signingPublicKey)
-                                                                        .setTransactionSignature(transactionSignature)
-                                                                        .setCheckCash(checkCash)
-                                                                        .build();
+  static Transaction checkCashTransactionWithCommonFieldsSet = Transaction.newBuilder()
+      .setAccount(account)
+      .setFee(xrpDropsAmount)
+      .setSequence(sequence)
+      .setSigningPublicKey(signingPublicKey)
+      .setTransactionSignature(transactionSignature)
+      .setCheckCash(checkCash)
+      .build();
 
-    // GetTransactionResponse protos
-    static GetTransactionResponse getTransactionResponsePayment1 = GetTransactionResponse.newBuilder()
-                                                                        .setTransaction(transactionWithAllFieldsSet)
-                                                                        .build();
-    static GetTransactionResponse getTransactionResponsePayment2 = GetTransactionResponse.newBuilder()
-                                                            .setTransaction(transactionWithOnlyMandatoryCommonFieldsSet)
-                                                            .build();
+  // GetTransactionResponse protos
+  static GetTransactionResponse getTransactionResponsePayment1 = GetTransactionResponse.newBuilder()
+      .setTransaction(transactionWithAllFieldsSet)
+      .build();
+  static GetTransactionResponse getTransactionResponsePayment2 = GetTransactionResponse.newBuilder()
+      .setTransaction(transactionWithOnlyMandatoryCommonFieldsSet)
+      .build();
 
-    static GetTransactionResponse getTransactionResponseCheckCash = GetTransactionResponse.newBuilder()
-                                                                .setTransaction(checkCashTransactionWithCommonFieldsSet)
-                                                                .build();
+  static GetTransactionResponse getTransactionResponseCheckCash = GetTransactionResponse.newBuilder()
+      .setTransaction(checkCashTransactionWithCommonFieldsSet)
+      .build();
 
-    // GetAccountTransactionHistoryResponse protos
-    static GetAccountTransactionHistoryResponse paymentOnlyGetAccountTransactionHistoryResponse =
-                                                            GetAccountTransactionHistoryResponse.newBuilder()
-                                                                        .addTransactions(getTransactionResponsePayment1)
-                                                                        .addTransactions(getTransactionResponsePayment2)
-                                                                        .build();
+  // GetAccountTransactionHistoryResponse protos
+  static GetAccountTransactionHistoryResponse paymentOnlyGetAccountTransactionHistoryResponse =
+      GetAccountTransactionHistoryResponse.newBuilder()
+          .addTransactions(getTransactionResponsePayment1)
+          .addTransactions(getTransactionResponsePayment2)
+          .build();
 
-    static GetAccountTransactionHistoryResponse mixedGetAccountTransactionHistoryResponse =
-                                                            GetAccountTransactionHistoryResponse.newBuilder()
-                                                                    .addTransactions(getTransactionResponsePayment1)
-                                                                    .addTransactions(getTransactionResponsePayment2)
-                                                                    .addTransactions(getTransactionResponseCheckCash)
-                                                                    .build();
-    // INVALID OBJECTS ===============================================================
+  static GetAccountTransactionHistoryResponse mixedGetAccountTransactionHistoryResponse =
+      GetAccountTransactionHistoryResponse.newBuilder()
+          .addTransactions(getTransactionResponsePayment1)
+          .addTransactions(getTransactionResponsePayment2)
+          .addTransactions(getTransactionResponseCheckCash)
+          .build();
+  // INVALID OBJECTS ===============================================================
 
-    // Invalid IssuedCurrencyAmount proto
-    static IssuedCurrencyAmount invalidIssuedCurrencyAmount = IssuedCurrencyAmount.newBuilder()
-                                                                            .setCurrency(currency)
-                                                                            .setIssuer(accountAddress)
-                                                                            .setValue(testInvalidIssuedCurrencyValue)
-                                                                            .build();
+  // Invalid IssuedCurrencyAmount proto
+  static IssuedCurrencyAmount invalidIssuedCurrencyAmount = IssuedCurrencyAmount.newBuilder()
+      .setCurrency(currency)
+      .setIssuer(accountAddress)
+      .setValue(testInvalidIssuedCurrencyValue)
+      .build();
 
-    // Invalid CurrencyAmount proto
-    static CurrencyAmount invalidCurrencyAmount = CurrencyAmount.newBuilder()
-                                                                .setIssuedCurrencyAmount(invalidIssuedCurrencyAmount)
-                                                                .build();
+  // Invalid CurrencyAmount proto
+  static CurrencyAmount invalidCurrencyAmount = CurrencyAmount.newBuilder()
+      .setIssuedCurrencyAmount(invalidIssuedCurrencyAmount)
+      .build();
 
-    // Invalid Amount proto
-    static Common.Amount invalidAmount = Common.Amount.newBuilder().setValue(invalidCurrencyAmount).build();
+  // Invalid Amount proto
+  static Amount invalidAmount = Amount.newBuilder().setValue(invalidCurrencyAmount).build();
 
-    // Invalid DeliverMin proto
-    static Common.DeliverMin invalidDeliverMin = Common.DeliverMin.newBuilder().setValue(invalidCurrencyAmount).build();
+  // Invalid DeliverMin proto
+  static DeliverMin invalidDeliverMin = DeliverMin.newBuilder().setValue(invalidCurrencyAmount).build();
 
-    // Invalid SendMax proto
-    static Common.SendMax invalidSendMax = Common.SendMax.newBuilder().setValue(invalidCurrencyAmount).build();
+  // Invalid SendMax proto
+  static SendMax invalidSendMax = SendMax.newBuilder().setValue(invalidCurrencyAmount).build();
 
-    // Invalid Payment protos
-        // invalid amount field
-    static Payment invalidPaymentBadAmount = Payment.newBuilder()
-                                                    .setAmount(invalidAmount)
-                                                    .setDestination(destination)
-                                                    .build();
+  // Invalid Payment protos
+  // invalid amount field
+  static Payment invalidPaymentBadAmount = Payment.newBuilder()
+      .setAmount(invalidAmount)
+      .setDestination(destination)
+      .build();
 
-        // invalid deliverMin field
-    static Payment invalidPaymentBadDeliverMin = Payment.newBuilder()
-                                                        .setAmount(amount)
-                                                        .setDestination(destination)
-                                                        .setDeliverMin(invalidDeliverMin)
-                                                        .build();
+  // invalid deliverMin field
+  static Payment invalidPaymentBadDeliverMin = Payment.newBuilder()
+      .setAmount(amount)
+      .setDestination(destination)
+      .setDeliverMin(invalidDeliverMin)
+      .build();
 
-        // invalid sendMax field
-    static Payment invalidPaymentBadSendMax = Payment.newBuilder()
-                                                    .setAmount(amount)
-                                                    .setDestination(destination)
-                                                    .setSendMax(invalidSendMax)
-                                                    .build();
+  // invalid sendMax field
+  static Payment invalidPaymentBadSendMax = Payment.newBuilder()
+      .setAmount(amount)
+      .setDestination(destination)
+      .setSendMax(invalidSendMax)
+      .build();
 
-    // Invalid Transaction with empty Payment
-    static Transaction invalidTransactionWithEmptyPaymentFields = Transaction.newBuilder()
-                                                                .setAccount(account)
-                                                                .setFee(xrpDropsAmount)
-                                                                .setSequence(sequence)
-                                                                .setSigningPublicKey(signingPublicKey)
-                                                                .setTransactionSignature(transactionSignature)
-                                                                .setPayment(Payment.newBuilder().build()) // empty Payment
-                                                                .build();
+  // Invalid Transaction with empty Payment
+  static Transaction invalidTransactionWithEmptyPaymentFields = Transaction.newBuilder()
+      .setAccount(account)
+      .setFee(xrpDropsAmount)
+      .setSequence(sequence)
+      .setSigningPublicKey(signingPublicKey)
+      .setTransactionSignature(transactionSignature)
+      .setPayment(Payment.newBuilder().build()) // empty Payment
+      .build();
 
-    // Invalid Transaction due to unsupported transaction type
-    static Transaction invalidTransactionUnsupportedType = Transaction.newBuilder()
-                                                                .setAccount(account)
-                                                                .setFee(xrpDropsAmount)
-                                                                .setSequence(sequence)
-                                                                .setSigningPublicKey(signingPublicKey)
-                                                                .setTransactionSignature(transactionSignature)
-                                                                .setCheckCash(checkCash) // unsupported
-                                                                .build();
+  // Invalid Transaction due to unsupported transaction type
+  static Transaction invalidTransactionUnsupportedType = Transaction.newBuilder()
+      .setAccount(account)
+      .setFee(xrpDropsAmount)
+      .setSequence(sequence)
+      .setSigningPublicKey(signingPublicKey)
+      .setTransactionSignature(transactionSignature)
+      .setCheckCash(checkCash) // unsupported
+      .build();
 
-    // Invalid GetTransactionResponse proto
-    static GetTransactionResponse invalidGetTransactionResponse = GetTransactionResponse.newBuilder()
-                                                            .setTransaction(invalidTransactionWithEmptyPaymentFields)
-                                                            .build();
+  // Invalid GetTransactionResponse proto
+  static GetTransactionResponse invalidGetTransactionResponse = GetTransactionResponse.newBuilder()
+      .setTransaction(invalidTransactionWithEmptyPaymentFields)
+      .build();
 
-    // Invalid GetAccountTransactionHistoryResponse protos
-    static GetAccountTransactionHistoryResponse invalidPaymentGetAccountTransactionHistoryResponse =
-            GetAccountTransactionHistoryResponse.newBuilder()
-                    .addTransactions(invalidGetTransactionResponse)
-                    .addTransactions(getTransactionResponsePayment1)
-                    .build();
+  // Invalid GetAccountTransactionHistoryResponse protos
+  static GetAccountTransactionHistoryResponse invalidPaymentGetAccountTransactionHistoryResponse =
+      GetAccountTransactionHistoryResponse.newBuilder()
+          .addTransactions(invalidGetTransactionResponse)
+          .addTransactions(getTransactionResponsePayment1)
+          .build();
 }

--- a/src/test/java/io/xpring/xrpl/ProtocolBufferConversionTest.java
+++ b/src/test/java/io/xpring/xrpl/ProtocolBufferConversionTest.java
@@ -2,377 +2,389 @@ package io.xpring.xrpl;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-import io.xpring.xrpl.model.*;
-
+import io.xpring.xrpl.model.XRPCurrency;
+import io.xpring.xrpl.model.XRPCurrencyAmount;
+import io.xpring.xrpl.model.XRPIssuedCurrency;
+import io.xpring.xrpl.model.XRPMemo;
+import io.xpring.xrpl.model.XRPPath;
+import io.xpring.xrpl.model.XRPPathElement;
+import io.xpring.xrpl.model.XRPPayment;
+import io.xpring.xrpl.model.XRPSigner;
+import io.xpring.xrpl.model.XRPTransaction;
 import org.junit.Rule;
 import org.junit.Test;
-
 import org.junit.rules.ExpectedException;
-import org.xrpl.rpc.v1.*;
+import org.xrpl.rpc.v1.Common.Flags;
+import org.xrpl.rpc.v1.Common.LastLedgerSequence;
+import org.xrpl.rpc.v1.Common.SourceTag;
+import org.xrpl.rpc.v1.Currency;
+import org.xrpl.rpc.v1.CurrencyAmount;
+import org.xrpl.rpc.v1.Memo;
+import org.xrpl.rpc.v1.Payment;
+import org.xrpl.rpc.v1.Payment.PathElement;
 import org.xrpl.rpc.v1.Signer;
+import org.xrpl.rpc.v1.Transaction;
 
 import java.math.BigInteger;
 import java.util.stream.Collectors;
 
-import java.math.BigInteger;
-
 public class ProtocolBufferConversionTest {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
-    // Currency
-
-    @Test
-    public void convertCurrencyTest() {
-        // GIVEN a Currency protocol buffer with a code and a name.
-        Currency currencyProto = FakeXRPProtobufs.currency;
-
-        // WHEN the protocol buffer is converted to a native Java type.
-        XRPCurrency xrpCurrency = XRPCurrency.from(currencyProto);
-
-        // THEN the currency converted as expected.
-        assertThat(xrpCurrency.name()).isEqualTo(currencyProto.getName());
-        assertThat(xrpCurrency.code()).isEqualTo(currencyProto.getCode().toByteArray());
-    }
-
-    // PathElement
-
-    @Test
-    public void convertPathElementTest() {
-        // GIVEN a PathElement protocol buffer with all fields set.
-        Payment.PathElement testPathElementProto = FakeXRPProtobufs.pathElement;
-
-        // WHEN the protocol buffer is converted to a native Java type.
-        XRPPathElement xrpPathElement = XRPPathElement.from(testPathElementProto);
-
-        // THEN the currency converted as expected.
-        assertThat(xrpPathElement.account()).isEqualTo(testPathElementProto.getAccount().getAddress());
-        assertThat(xrpPathElement.currency()).isEqualTo(XRPCurrency.from(testPathElementProto.getCurrency()));
-        assertThat(xrpPathElement.issuer()).isEqualTo(testPathElementProto.getIssuer().getAddress());
-    }
-
-    @Test
-    public void convertPathElementWithNoFieldsTest() {
-        // GIVEN a PathElement protocol buffer with no fields set.
-        Payment.PathElement emptyPathElementProto = Payment.PathElement.newBuilder().build();
-
-        // WHEN the protocol buffer is converted to a native Java type.
-        XRPPathElement xrpPathElement = XRPPathElement.from(emptyPathElementProto);
-
-        // THEN the currency converted as expected.
-        assertThat(xrpPathElement.account()).isEmpty();
-        assertThat(xrpPathElement.currency()).isEqualTo(XRPCurrency.from(Currency.newBuilder().build()));
-        assertThat(xrpPathElement.issuer()).isEmpty();
-    }
-
-    // Path
-
-    @Test
-    public void convertPathWithNoPathsTest() {
-        // GIVEN a set of paths with zero path elements.
-        // WHEN the protocol buffer is converted to a native Java type.
-        XRPPath xrpPath = XRPPath.from(FakeXRPProtobufs.emptyPath);
-
-        // Then there are zero paths in the output.
-        assertThat(xrpPath.pathElements().size()).isZero();
-    }
-
-    @Test
-    public void convertPathWithOnePathTest() {
-        // GIVEN a set of paths with one path element.
-        // WHEN the protocol buffer is converted to a native Java type.
-        XRPPath xrpPath = XRPPath.from(FakeXRPProtobufs.pathWithOneElement);
-
-        // THEN there is one path in the output.
-        assertThat(xrpPath.pathElements().size()).isOne();
-    }
-
-    @Test
-    public void convertPathWithManyPathsTest() {
-        // GIVEN a set of paths with three path elements.
-        // WHEN the protocol buffer is converted to a native Java type.
-        XRPPath xrpPath = XRPPath.from(FakeXRPProtobufs.pathWithThreeElements);
-
-        // THEN there are three paths in the output.
-        assertThat(xrpPath.pathElements().size()).isEqualTo(3);
-    }
-
-    // IssuedCurrency
-
-    @Test
-    public void convertIssuedCurrencyTest() {
-        // GIVEN an issued currency protocol buffer,
-        // WHEN the protocol buffer is converted to a native Java type.
-        XRPIssuedCurrency xrpIssuedCurrency = XRPIssuedCurrency.from(FakeXRPProtobufs.issuedCurrencyAmount);
-
-        // THEN the issued currency converted as expected.
-        assertThat(xrpIssuedCurrency.currency())
-                .isEqualTo(XRPCurrency.from(FakeXRPProtobufs.issuedCurrencyAmount.getCurrency()));
-
-        assertThat(xrpIssuedCurrency.issuer())
-                .isEqualTo(FakeXRPProtobufs.issuedCurrencyAmount.getIssuer().getAddress());
-
-        assertThat(xrpIssuedCurrency.value()).isEqualTo(new BigInteger(FakeXRPProtobufs.issuedCurrencyAmount.getValue()));
-    }
-
-    @Test
-    public void convertIssuedCurrencyWithBadValueTest() {
-        // GIVEN an issued currency protocol buffer with a non numeric value
-        // WHEN the protocol buffer is converted to a native Java type.
-        // THEN a NumberFormatException is thrown.
-        expectedException.expect(NumberFormatException.class);
-        XRPIssuedCurrency.from(FakeXRPProtobufs.invalidIssuedCurrencyAmount);
-    }
-
-    // CurrencyAmount
-
-    @Test
-    public void convertCurrencyAmountWithDropsTest() {
-        // GIVEN a currency amount protocol buffer with an XRP amount.
-        // WHEN the protocol buffer is converted to a native Java type.
-        XRPCurrencyAmount xrpCurrencyAmount = XRPCurrencyAmount.from(FakeXRPProtobufs.dropsCurrencyAmount);
-
-        // THEN the result has drops set and an empty issued currency.
-        assertThat(xrpCurrencyAmount.drops())
-                .isEqualTo(Long.toString(FakeXRPProtobufs.dropsCurrencyAmount.getXrpAmount().getDrops()));
-        assertThat(xrpCurrencyAmount.issuedCurrency()).isNull();
-    }
-
-    @Test
-    public void convertCurrencyAmountWithIssuedCurrencyTest() {
-        // GIVEN a currency amount protocol buffer with an issued currency amount.
-        // WHEN the protocol buffer is converted to a native Java type.
-        XRPCurrencyAmount xrpCurrencyAmount = XRPCurrencyAmount.from(FakeXRPProtobufs.issuedCurrencyCurrencyAmount);
-
-        // THEN the result has an issued currency set and no drops amount.
-        assertThat(xrpCurrencyAmount.drops()).isNull();
-        assertThat(xrpCurrencyAmount.issuedCurrency())
-                .isEqualTo(XRPIssuedCurrency.from(FakeXRPProtobufs.issuedCurrencyCurrencyAmount.getIssuedCurrencyAmount()));
-    }
-
-    @Test
-    public void convertCurrencyAmountWithBadInputsTest() {
-        // GIVEN a currency amount protocol buffer with no amounts.
-        CurrencyAmount emptyCurrencyAmount = CurrencyAmount.newBuilder().build();
-
-        // WHEN the protocol buffer is converted to a native Java type.
-        XRPCurrencyAmount xrpCurrencyAmount = XRPCurrencyAmount.from(emptyCurrencyAmount);
-
-        // THEN the result is null.
-        assertThat(xrpCurrencyAmount).isNull();
-    }
-
-    @Test
-    public void convertCurrencyAmountWithInvalidIssuedCurrencyTest() {
-        // GIVEN a currency amount protocol buffer with an invalid issued currency.
-        // WHEN the protocol buffer is converted to a native Java type.
-        // THEN a NumberFormatException is re-thrown.
-        expectedException.expect(NumberFormatException.class);
-        XRPCurrencyAmount.from(FakeXRPProtobufs.invalidCurrencyAmount);
-    }
-
-    // Payment
-
-    @Test
-    public void convertPaymentWithAllFieldsSetTest() {
-        // GIVEN a payment protocol buffer with all fields set.
-        Payment paymentProto = FakeXRPProtobufs.paymentWithAllFieldsSet;
-
-        // WHEN the protocol buffer is converted to a native Java type.
-        XRPPayment xrpPayment = XRPPayment.from(paymentProto);
-
-        // THEN the result is as expected.
-        assertThat(xrpPayment.amount()).isEqualTo(XRPCurrencyAmount.from(paymentProto.getAmount().getValue()));
-        assertThat(xrpPayment.destination()).isEqualTo(paymentProto.getDestination().getValue().getAddress());
-        assertThat(xrpPayment.destinationTag()).isEqualTo(paymentProto.getDestinationTag().getValue());
-        assertThat(xrpPayment.deliverMin()).isEqualTo(XRPCurrencyAmount.from(paymentProto.getDeliverMin().getValue()));
-        assertThat(xrpPayment.invoiceID()).isEqualTo(paymentProto.getInvoiceId().getValue().toByteArray());
-        assertThat(xrpPayment.paths())
-                .isEqualTo(paymentProto.getPathsList()
-                                        .stream()
-                                        .map(path -> XRPPath.from(path))
-                                        .collect(Collectors.toList()));
-        assertThat(xrpPayment.sendMax()).isEqualTo(XRPCurrencyAmount.from(paymentProto.getSendMax().getValue()));
-    }
-
-    @Test
-    public void convertPaymentWithMandatoryFieldsSetTest() {
-        // GIVEN a payment protocol buffer with only mandatory fields set.
-        Payment paymentProto = FakeXRPProtobufs.paymentWithMandatoryFieldsSet;
-
-        // WHEN the protocol buffer is converted to a native Java type.
-        XRPPayment xrpPayment = XRPPayment.from(paymentProto);
-
-        // THEN the result is as expected.
-        assertThat(xrpPayment.amount()).isEqualTo(XRPCurrencyAmount.from(paymentProto.getAmount().getValue()));
-        assertThat(xrpPayment.destination()).isEqualTo(paymentProto.getDestination().getValue().getAddress());
-        assertThat(xrpPayment.destinationTag()).isNull();
-        assertThat(xrpPayment.destinationTag()).isNull();
-        assertThat(xrpPayment.deliverMin()).isNull();
-        assertThat(xrpPayment.invoiceID()).isNull();
-        assertThat(xrpPayment.paths()).isNull();
-        assertThat(xrpPayment.sendMax()).isNull();
-    }
-
-    @Test
-    public void convertPaymentWithBadAmountFieldTest() {
-        // GIVEN a payment protocol buffer with an invalid amount field.
-        // WHEN the protocol buffer is converted to a native Java type.
-        // THEN a NumberFormatException is re-thrown.
-        expectedException.expect(NumberFormatException.class);
-        XRPPayment.from(FakeXRPProtobufs.invalidPaymentBadAmount);
-    }
-
-    @Test
-    public void convertPaymentWithBadDeliverMinFieldTest() {
-        // GIVEN a payment protocol buffer with an invalid deliverMin field.
-        // WHEN the protocol buffer is converted to a native Java type.
-        // THEN a NumberFormatException is re-thrown.
-        expectedException.expect(NumberFormatException.class);
-        XRPPayment.from(FakeXRPProtobufs.invalidPaymentBadDeliverMin);
-    }
-
-    @Test
-    public void convertPaymentWithBadSendMaxFieldTest() {
-        // GIVEN a payment protocol buffer with an invalid sendMax field.
-        // WHEN the protocol buffer is converted to a native Java type.
-        // THEN a NumberFormatException is re-thrown.
-        expectedException.expect(NumberFormatException.class);
-        XRPPayment.from(FakeXRPProtobufs.invalidPaymentBadSendMax);
-    }
-
-    // Memo
-
-    @Test
-    public void convertMemoWithAllFieldsSetTest() {
-        // GIVEN a memo with all fields set.
-        Memo memoProto = FakeXRPProtobufs.memoWithAllFieldsSet;
-
-        // WHEN the protocol buffer is converted to a native Java type.
-        XRPMemo xrpMemo = XRPMemo.from(memoProto);
-
-        // THEN all fields are present and set correctly.
-        assertThat(xrpMemo.data()).isEqualTo(memoProto.getMemoData().getValue().toByteArray());
-        assertThat(xrpMemo.format()).isEqualTo(memoProto.getMemoFormat().getValue().toByteArray());
-        assertThat(xrpMemo.type()).isEqualTo(memoProto.getMemoType().getValue().toByteArray());
-    }
-
-    @Test
-    public void convertMemoWithNoFieldsSetTest() {
-        // GIVEN a memo with no fields set.
-        Memo memoProto = Memo.newBuilder().build();
-
-        // WHEN the protocol buffer is converted to a native Java type.
-        XRPMemo xrpMemo = XRPMemo.from(memoProto);
-
-        // THEN all fields are null.
-        assertThat(xrpMemo.data()).isNull();
-        assertThat(xrpMemo.format()).isNull();
-        assertThat(xrpMemo.type()).isNull();
-    }
-
-    // Signer
-
-    @Test
-    public void convertSignerWithAllFieldsSetTest() {
-        // GIVEN a Signer protocol buffer with all fields set.
-        Signer signerProto = FakeXRPProtobufs.signerWithAllFieldsSet;
-
-        // WHEN the protocol buffer is converted to a native Java type.
-        XRPSigner xrpSigner = XRPSigner.from(signerProto);
-
-        // THEN all fields are present and converted correctly.
-        assertThat(xrpSigner.account()).isEqualTo(signerProto.getAccount().getValue().getAddress());
-        assertThat(xrpSigner.signingPublicKey())
-                .isEqualTo(signerProto.getSigningPublicKey().getValue().toByteArray());
-        assertThat(xrpSigner.transactionSignature())
-                .isEqualTo(signerProto.getTransactionSignature().getValue().toByteArray());
-    }
-
-    // Transaction
-
-    @Test
-    public void convertPaymentTransactionWithAllCommonFieldsSetTest() {
-        // GIVEN a Transaction protocol buffer with all common fields set.
-        Transaction transactionProto = FakeXRPProtobufs.transactionWithAllFieldsSet;
-
-        // WHEN the protocol buffer is converted to a native Java type.
-        XRPTransaction xrpTransaction = XRPTransaction.from(transactionProto);
-
-        // THEN all fields are present and converted correctly.
-        assertThat(xrpTransaction.account()).isEqualTo(transactionProto.getAccount().getValue().getAddress());
-        assertThat(xrpTransaction.accountTransactionID())
-                .isEqualTo(transactionProto.getAccountTransactionId().getValue().toByteArray());
-        assertThat(xrpTransaction.fee()).isEqualTo(transactionProto.getFee().getDrops());
-        assertThat(xrpTransaction.flags()).isEqualTo(transactionProto.getFlags().getValue());
-        assertThat(xrpTransaction.lastLedgerSequence()).isEqualTo(transactionProto.getLastLedgerSequence().getValue());
-        assertThat(xrpTransaction.memos()).isEqualTo(transactionProto.getMemosList()
-                .stream()
-                .map(memo -> XRPMemo.from(memo))
-                .collect(Collectors.toList()));
-        assertThat(xrpTransaction.sequence()).isEqualTo(transactionProto.getSequence().getValue());
-        assertThat(xrpTransaction.signers()).isEqualTo(transactionProto.getSignersList()
-                .stream()
-                .map(signer -> XRPSigner.from(signer))
-                .collect(Collectors.toList()));
-        assertThat(xrpTransaction.signingPublicKey())
-                .isEqualTo(transactionProto.getSigningPublicKey().getValue().toByteArray());
-        assertThat(xrpTransaction.sourceTag()).isEqualTo(transactionProto.getSourceTag().getValue());
-        assertThat(xrpTransaction.transactionSignature())
-                .isEqualTo(transactionProto.getTransactionSignature().getValue().toByteArray());
-        assertThat(xrpTransaction.type()).isEqualTo(TransactionType.PAYMENT);
-        assertThat(xrpTransaction.paymentFields()).isEqualTo(XRPPayment.from(transactionProto.getPayment()));
-    }
-
-    @Test
-    public void convertPaymentTransactionWithOnlyMandatoryCommonFieldsSetTest() {
-        // GIVEN a Transaction protocol buffer with only mandatory common fields set.
-        Transaction transactionProto = FakeXRPProtobufs.transactionWithOnlyMandatoryCommonFieldsSet;
-
-        // WHEN the protocol buffer is converted to a native Java type.
-        XRPTransaction xrpTransaction = XRPTransaction.from(transactionProto);
-
-        // THEN all fields are present and converted correctly.
-        assertThat(xrpTransaction.account()).isEqualTo(transactionProto.getAccount().getValue().getAddress());
-        assertThat(xrpTransaction.accountTransactionID()).isNull();
-        assertThat(xrpTransaction.fee()).isEqualTo(transactionProto.getFee().getDrops());
-        assertThat(xrpTransaction.flags()).isEqualTo(Common.Flags.newBuilder().build().getValue());
-        assertThat(xrpTransaction.lastLedgerSequence())
-                .isEqualTo(Common.LastLedgerSequence.newBuilder().build().getValue());
-        assertThat(xrpTransaction.memos()).isNull();
-        assertThat(xrpTransaction.sequence()).isEqualTo(transactionProto.getSequence().getValue());
-        assertThat(xrpTransaction.signers()).isNull();
-        assertThat(xrpTransaction.signingPublicKey())
-                .isEqualTo(transactionProto.getSigningPublicKey().getValue().toByteArray());
-        assertThat(xrpTransaction.sourceTag()).isEqualTo(Common.SourceTag.newBuilder().build().getValue());
-        assertThat(xrpTransaction.transactionSignature())
-                .isEqualTo(transactionProto.getTransactionSignature().getValue().toByteArray());
-        assertThat(xrpTransaction.type()).isEqualTo(TransactionType.PAYMENT);
-        assertThat(xrpTransaction.paymentFields()).isEqualTo(XRPPayment.from(transactionProto.getPayment()));
-    }
-
-    @Test
-    public void convertPaymentTransactionWithBadPaymentFieldsTest() {
-        // GIVEN a Transaction protocol buffer with payment fields which are incorrect.
-        Transaction transactionProto = FakeXRPProtobufs.invalidTransactionWithEmptyPaymentFields;
-
-        // WHEN the protocol buffer is converted to a native Java type.
-        XRPTransaction xrpTransaction = XRPTransaction.from(transactionProto);
-
-        // THEN the result is null.
-        assertThat(xrpTransaction).isNull();
-    }
-
-    @Test
-    public void convertTransactionWithUnsupportedTypeTest() {
-        // GIVEN a Transaction protocol buffer with an unsupported transaction type.
-        Transaction transactionProto = FakeXRPProtobufs.invalidTransactionUnsupportedType;
-
-        // WHEN the protocol buffer is converted to a native Java type.
-        XRPTransaction xrpTransaction = XRPTransaction.from(transactionProto);
-
-        // THEN the result is null.
-        assertThat(xrpTransaction).isNull();
-    }
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  // Currency
+
+  @Test
+  public void convertCurrencyTest() {
+    // GIVEN a Currency protocol buffer with a code and a name.
+    Currency currencyProto = FakeXRPProtobufs.currency;
+
+    // WHEN the protocol buffer is converted to a native Java type.
+    XRPCurrency xrpCurrency = XRPCurrency.from(currencyProto);
+
+    // THEN the currency converted as expected.
+    assertThat(xrpCurrency.name()).isEqualTo(currencyProto.getName());
+    assertThat(xrpCurrency.code()).isEqualTo(currencyProto.getCode().toByteArray());
+  }
+
+  // PathElement
+
+  @Test
+  public void convertPathElementTest() {
+    // GIVEN a PathElement protocol buffer with all fields set.
+    PathElement testPathElementProto = FakeXRPProtobufs.pathElement;
+
+    // WHEN the protocol buffer is converted to a native Java type.
+    XRPPathElement xrpPathElement = XRPPathElement.from(testPathElementProto);
+
+    // THEN the currency converted as expected.
+    assertThat(xrpPathElement.account()).isEqualTo(testPathElementProto.getAccount().getAddress());
+    assertThat(xrpPathElement.currency()).isEqualTo(XRPCurrency.from(testPathElementProto.getCurrency()));
+    assertThat(xrpPathElement.issuer()).isEqualTo(testPathElementProto.getIssuer().getAddress());
+  }
+
+  @Test
+  public void convertPathElementWithNoFieldsTest() {
+    // GIVEN a PathElement protocol buffer with no fields set.
+    PathElement emptyPathElementProto = PathElement.newBuilder().build();
+
+    // WHEN the protocol buffer is converted to a native Java type.
+    XRPPathElement xrpPathElement = XRPPathElement.from(emptyPathElementProto);
+
+    // THEN the currency converted as expected.
+    assertThat(xrpPathElement.account()).isEmpty();
+    assertThat(xrpPathElement.currency()).isEqualTo(XRPCurrency.from(Currency.newBuilder().build()));
+    assertThat(xrpPathElement.issuer()).isEmpty();
+  }
+
+  // Path
+
+  @Test
+  public void convertPathWithNoPathsTest() {
+    // GIVEN a set of paths with zero path elements.
+    // WHEN the protocol buffer is converted to a native Java type.
+    XRPPath xrpPath = XRPPath.from(FakeXRPProtobufs.emptyPath);
+
+    // Then there are zero paths in the output.
+    assertThat(xrpPath.pathElements().size()).isZero();
+  }
+
+  @Test
+  public void convertPathWithOnePathTest() {
+    // GIVEN a set of paths with one path element.
+    // WHEN the protocol buffer is converted to a native Java type.
+    XRPPath xrpPath = XRPPath.from(FakeXRPProtobufs.pathWithOneElement);
+
+    // THEN there is one path in the output.
+    assertThat(xrpPath.pathElements().size()).isOne();
+  }
+
+  @Test
+  public void convertPathWithManyPathsTest() {
+    // GIVEN a set of paths with three path elements.
+    // WHEN the protocol buffer is converted to a native Java type.
+    XRPPath xrpPath = XRPPath.from(FakeXRPProtobufs.pathWithThreeElements);
+
+    // THEN there are three paths in the output.
+    assertThat(xrpPath.pathElements().size()).isEqualTo(3);
+  }
+
+  // IssuedCurrency
+
+  @Test
+  public void convertIssuedCurrencyTest() {
+    // GIVEN an issued currency protocol buffer,
+    // WHEN the protocol buffer is converted to a native Java type.
+    XRPIssuedCurrency xrpIssuedCurrency = XRPIssuedCurrency.from(FakeXRPProtobufs.issuedCurrencyAmount);
+
+    // THEN the issued currency converted as expected.
+    assertThat(xrpIssuedCurrency.currency())
+        .isEqualTo(XRPCurrency.from(FakeXRPProtobufs.issuedCurrencyAmount.getCurrency()));
+
+    assertThat(xrpIssuedCurrency.issuer())
+        .isEqualTo(FakeXRPProtobufs.issuedCurrencyAmount.getIssuer().getAddress());
+
+    assertThat(xrpIssuedCurrency.value()).isEqualTo(new BigInteger(FakeXRPProtobufs.issuedCurrencyAmount.getValue()));
+  }
+
+  @Test
+  public void convertIssuedCurrencyWithBadValueTest() {
+    // GIVEN an issued currency protocol buffer with a non numeric value
+    // WHEN the protocol buffer is converted to a native Java type.
+    // THEN a NumberFormatException is thrown.
+    expectedException.expect(NumberFormatException.class);
+    XRPIssuedCurrency.from(FakeXRPProtobufs.invalidIssuedCurrencyAmount);
+  }
+
+  // CurrencyAmount
+
+  @Test
+  public void convertCurrencyAmountWithDropsTest() {
+    // GIVEN a currency amount protocol buffer with an XRP amount.
+    // WHEN the protocol buffer is converted to a native Java type.
+    XRPCurrencyAmount xrpCurrencyAmount = XRPCurrencyAmount.from(FakeXRPProtobufs.dropsCurrencyAmount);
+
+    // THEN the result has drops set and an empty issued currency.
+    assertThat(xrpCurrencyAmount.drops())
+        .isEqualTo(Long.toString(FakeXRPProtobufs.dropsCurrencyAmount.getXrpAmount().getDrops()));
+    assertThat(xrpCurrencyAmount.issuedCurrency()).isNull();
+  }
+
+  @Test
+  public void convertCurrencyAmountWithIssuedCurrencyTest() {
+    // GIVEN a currency amount protocol buffer with an issued currency amount.
+    // WHEN the protocol buffer is converted to a native Java type.
+    XRPCurrencyAmount xrpCurrencyAmount = XRPCurrencyAmount.from(FakeXRPProtobufs.issuedCurrencyCurrencyAmount);
+
+    // THEN the result has an issued currency set and no drops amount.
+    assertThat(xrpCurrencyAmount.drops()).isNull();
+    assertThat(xrpCurrencyAmount.issuedCurrency())
+        .isEqualTo(XRPIssuedCurrency.from(FakeXRPProtobufs.issuedCurrencyCurrencyAmount.getIssuedCurrencyAmount()));
+  }
+
+  @Test
+  public void convertCurrencyAmountWithBadInputsTest() {
+    // GIVEN a currency amount protocol buffer with no amounts.
+    CurrencyAmount emptyCurrencyAmount = CurrencyAmount.newBuilder().build();
+
+    // WHEN the protocol buffer is converted to a native Java type.
+    XRPCurrencyAmount xrpCurrencyAmount = XRPCurrencyAmount.from(emptyCurrencyAmount);
+
+    // THEN the result is null.
+    assertThat(xrpCurrencyAmount).isNull();
+  }
+
+  @Test
+  public void convertCurrencyAmountWithInvalidIssuedCurrencyTest() {
+    // GIVEN a currency amount protocol buffer with an invalid issued currency.
+    // WHEN the protocol buffer is converted to a native Java type.
+    // THEN a NumberFormatException is re-thrown.
+    expectedException.expect(NumberFormatException.class);
+    XRPCurrencyAmount.from(FakeXRPProtobufs.invalidCurrencyAmount);
+  }
+
+  // Payment
+
+  @Test
+  public void convertPaymentWithAllFieldsSetTest() {
+    // GIVEN a payment protocol buffer with all fields set.
+    Payment paymentProto = FakeXRPProtobufs.paymentWithAllFieldsSet;
+
+    // WHEN the protocol buffer is converted to a native Java type.
+    XRPPayment xrpPayment = XRPPayment.from(paymentProto);
+
+    // THEN the result is as expected.
+    assertThat(xrpPayment.amount()).isEqualTo(XRPCurrencyAmount.from(paymentProto.getAmount().getValue()));
+    assertThat(xrpPayment.destination()).isEqualTo(paymentProto.getDestination().getValue().getAddress());
+    assertThat(xrpPayment.destinationTag()).isEqualTo(paymentProto.getDestinationTag().getValue());
+    assertThat(xrpPayment.deliverMin()).isEqualTo(XRPCurrencyAmount.from(paymentProto.getDeliverMin().getValue()));
+    assertThat(xrpPayment.invoiceID()).isEqualTo(paymentProto.getInvoiceId().getValue().toByteArray());
+    assertThat(xrpPayment.paths())
+        .isEqualTo(paymentProto.getPathsList()
+            .stream()
+            .map(path -> XRPPath.from(path))
+            .collect(Collectors.toList()));
+    assertThat(xrpPayment.sendMax()).isEqualTo(XRPCurrencyAmount.from(paymentProto.getSendMax().getValue()));
+  }
+
+  @Test
+  public void convertPaymentWithMandatoryFieldsSetTest() {
+    // GIVEN a payment protocol buffer with only mandatory fields set.
+    Payment paymentProto = FakeXRPProtobufs.paymentWithMandatoryFieldsSet;
+
+    // WHEN the protocol buffer is converted to a native Java type.
+    XRPPayment xrpPayment = XRPPayment.from(paymentProto);
+
+    // THEN the result is as expected.
+    assertThat(xrpPayment.amount()).isEqualTo(XRPCurrencyAmount.from(paymentProto.getAmount().getValue()));
+    assertThat(xrpPayment.destination()).isEqualTo(paymentProto.getDestination().getValue().getAddress());
+    assertThat(xrpPayment.destinationTag()).isNull();
+    assertThat(xrpPayment.destinationTag()).isNull();
+    assertThat(xrpPayment.deliverMin()).isNull();
+    assertThat(xrpPayment.invoiceID()).isNull();
+    assertThat(xrpPayment.paths()).isNull();
+    assertThat(xrpPayment.sendMax()).isNull();
+  }
+
+  @Test
+  public void convertPaymentWithBadAmountFieldTest() {
+    // GIVEN a payment protocol buffer with an invalid amount field.
+    // WHEN the protocol buffer is converted to a native Java type.
+    // THEN a NumberFormatException is re-thrown.
+    expectedException.expect(NumberFormatException.class);
+    XRPPayment.from(FakeXRPProtobufs.invalidPaymentBadAmount);
+  }
+
+  @Test
+  public void convertPaymentWithBadDeliverMinFieldTest() {
+    // GIVEN a payment protocol buffer with an invalid deliverMin field.
+    // WHEN the protocol buffer is converted to a native Java type.
+    // THEN a NumberFormatException is re-thrown.
+    expectedException.expect(NumberFormatException.class);
+    XRPPayment.from(FakeXRPProtobufs.invalidPaymentBadDeliverMin);
+  }
+
+  @Test
+  public void convertPaymentWithBadSendMaxFieldTest() {
+    // GIVEN a payment protocol buffer with an invalid sendMax field.
+    // WHEN the protocol buffer is converted to a native Java type.
+    // THEN a NumberFormatException is re-thrown.
+    expectedException.expect(NumberFormatException.class);
+    XRPPayment.from(FakeXRPProtobufs.invalidPaymentBadSendMax);
+  }
+
+  // Memo
+
+  @Test
+  public void convertMemoWithAllFieldsSetTest() {
+    // GIVEN a memo with all fields set.
+    Memo memoProto = FakeXRPProtobufs.memoWithAllFieldsSet;
+
+    // WHEN the protocol buffer is converted to a native Java type.
+    XRPMemo xrpMemo = XRPMemo.from(memoProto);
+
+    // THEN all fields are present and set correctly.
+    assertThat(xrpMemo.data()).isEqualTo(memoProto.getMemoData().getValue().toByteArray());
+    assertThat(xrpMemo.format()).isEqualTo(memoProto.getMemoFormat().getValue().toByteArray());
+    assertThat(xrpMemo.type()).isEqualTo(memoProto.getMemoType().getValue().toByteArray());
+  }
+
+  @Test
+  public void convertMemoWithNoFieldsSetTest() {
+    // GIVEN a memo with no fields set.
+    Memo memoProto = Memo.newBuilder().build();
+
+    // WHEN the protocol buffer is converted to a native Java type.
+    XRPMemo xrpMemo = XRPMemo.from(memoProto);
+
+    // THEN all fields are null.
+    assertThat(xrpMemo.data()).isNull();
+    assertThat(xrpMemo.format()).isNull();
+    assertThat(xrpMemo.type()).isNull();
+  }
+
+  // Signer
+
+  @Test
+  public void convertSignerWithAllFieldsSetTest() {
+    // GIVEN a Signer protocol buffer with all fields set.
+    Signer signerProto = FakeXRPProtobufs.signerWithAllFieldsSet;
+
+    // WHEN the protocol buffer is converted to a native Java type.
+    XRPSigner xrpSigner = XRPSigner.from(signerProto);
+
+    // THEN all fields are present and converted correctly.
+    assertThat(xrpSigner.account()).isEqualTo(signerProto.getAccount().getValue().getAddress());
+    assertThat(xrpSigner.signingPublicKey())
+        .isEqualTo(signerProto.getSigningPublicKey().getValue().toByteArray());
+    assertThat(xrpSigner.transactionSignature())
+        .isEqualTo(signerProto.getTransactionSignature().getValue().toByteArray());
+  }
+
+  // Transaction
+
+  @Test
+  public void convertPaymentTransactionWithAllCommonFieldsSetTest() {
+    // GIVEN a Transaction protocol buffer with all common fields set.
+    Transaction transactionProto = FakeXRPProtobufs.transactionWithAllFieldsSet;
+
+    // WHEN the protocol buffer is converted to a native Java type.
+    XRPTransaction xrpTransaction = XRPTransaction.from(transactionProto);
+
+    // THEN all fields are present and converted correctly.
+    assertThat(xrpTransaction.account()).isEqualTo(transactionProto.getAccount().getValue().getAddress());
+    assertThat(xrpTransaction.accountTransactionID())
+        .isEqualTo(transactionProto.getAccountTransactionId().getValue().toByteArray());
+    assertThat(xrpTransaction.fee()).isEqualTo(transactionProto.getFee().getDrops());
+    assertThat(xrpTransaction.flags()).isEqualTo(transactionProto.getFlags().getValue());
+    assertThat(xrpTransaction.lastLedgerSequence()).isEqualTo(transactionProto.getLastLedgerSequence().getValue());
+    assertThat(xrpTransaction.memos()).isEqualTo(transactionProto.getMemosList()
+        .stream()
+        .map(memo -> XRPMemo.from(memo))
+        .collect(Collectors.toList()));
+    assertThat(xrpTransaction.sequence()).isEqualTo(transactionProto.getSequence().getValue());
+    assertThat(xrpTransaction.signers()).isEqualTo(transactionProto.getSignersList()
+        .stream()
+        .map(signer -> XRPSigner.from(signer))
+        .collect(Collectors.toList()));
+    assertThat(xrpTransaction.signingPublicKey())
+        .isEqualTo(transactionProto.getSigningPublicKey().getValue().toByteArray());
+    assertThat(xrpTransaction.sourceTag()).isEqualTo(transactionProto.getSourceTag().getValue());
+    assertThat(xrpTransaction.transactionSignature())
+        .isEqualTo(transactionProto.getTransactionSignature().getValue().toByteArray());
+    assertThat(xrpTransaction.type()).isEqualTo(TransactionType.PAYMENT);
+    assertThat(xrpTransaction.paymentFields()).isEqualTo(XRPPayment.from(transactionProto.getPayment()));
+  }
+
+  @Test
+  public void convertPaymentTransactionWithOnlyMandatoryCommonFieldsSetTest() {
+    // GIVEN a Transaction protocol buffer with only mandatory common fields set.
+    Transaction transactionProto = FakeXRPProtobufs.transactionWithOnlyMandatoryCommonFieldsSet;
+
+    // WHEN the protocol buffer is converted to a native Java type.
+    XRPTransaction xrpTransaction = XRPTransaction.from(transactionProto);
+
+    // THEN all fields are present and converted correctly.
+    assertThat(xrpTransaction.account()).isEqualTo(transactionProto.getAccount().getValue().getAddress());
+    assertThat(xrpTransaction.accountTransactionID()).isNull();
+    assertThat(xrpTransaction.fee()).isEqualTo(transactionProto.getFee().getDrops());
+    assertThat(xrpTransaction.flags()).isEqualTo(Flags.newBuilder().build().getValue());
+    assertThat(xrpTransaction.lastLedgerSequence())
+        .isEqualTo(LastLedgerSequence.newBuilder().build().getValue());
+    assertThat(xrpTransaction.memos()).isNull();
+    assertThat(xrpTransaction.sequence()).isEqualTo(transactionProto.getSequence().getValue());
+    assertThat(xrpTransaction.signers()).isNull();
+    assertThat(xrpTransaction.signingPublicKey())
+        .isEqualTo(transactionProto.getSigningPublicKey().getValue().toByteArray());
+    assertThat(xrpTransaction.sourceTag()).isEqualTo(SourceTag.newBuilder().build().getValue());
+    assertThat(xrpTransaction.transactionSignature())
+        .isEqualTo(transactionProto.getTransactionSignature().getValue().toByteArray());
+    assertThat(xrpTransaction.type()).isEqualTo(TransactionType.PAYMENT);
+    assertThat(xrpTransaction.paymentFields()).isEqualTo(XRPPayment.from(transactionProto.getPayment()));
+  }
+
+  @Test
+  public void convertPaymentTransactionWithBadPaymentFieldsTest() {
+    // GIVEN a Transaction protocol buffer with payment fields which are incorrect.
+    Transaction transactionProto = FakeXRPProtobufs.invalidTransactionWithEmptyPaymentFields;
+
+    // WHEN the protocol buffer is converted to a native Java type.
+    XRPTransaction xrpTransaction = XRPTransaction.from(transactionProto);
+
+    // THEN the result is null.
+    assertThat(xrpTransaction).isNull();
+  }
+
+  @Test
+  public void convertTransactionWithUnsupportedTypeTest() {
+    // GIVEN a Transaction protocol buffer with an unsupported transaction type.
+    Transaction transactionProto = FakeXRPProtobufs.invalidTransactionUnsupportedType;
+
+    // WHEN the protocol buffer is converted to a native Java type.
+    XRPTransaction xrpTransaction = XRPTransaction.from(transactionProto);
+
+    // THEN the result is null.
+    assertThat(xrpTransaction).isNull();
+  }
 }

--- a/src/test/java/io/xpring/xrpl/RawTransactionStatusTest.java
+++ b/src/test/java/io/xpring/xrpl/RawTransactionStatusTest.java
@@ -1,58 +1,62 @@
 package io.xpring.xrpl;
 
-import org.junit.Test;
-import org.xrpl.rpc.v1.*;
-import org.xrpl.rpc.v1.Common.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
+import org.xrpl.rpc.v1.Common.Flags;
+import org.xrpl.rpc.v1.GetTransactionResponse;
+import org.xrpl.rpc.v1.Payment;
+import org.xrpl.rpc.v1.Transaction;
+
 
 public class RawTransactionStatusTest {
-    @Test
-    public void testIsFullPaymentNonPayment() {
-        // GIVEN a getTxResponse which is not a payment.
-        Transaction transaction = Transaction.newBuilder().clearPayment().build();
-        GetTransactionResponse getTxResponse = GetTransactionResponse.newBuilder().setTransaction(transaction).build();
+  @Test
+  public void testIsFullPaymentNonPayment() {
+    // GIVEN a getTxResponse which is not a payment.
+    Transaction transaction = Transaction.newBuilder().clearPayment().build();
+    GetTransactionResponse getTxResponse = GetTransactionResponse.newBuilder().setTransaction(transaction).build();
 
-        // WHEN the raw transaction status is wrapped into a RawTransactionStatus object.
-        RawTransactionStatus rawTransactionStatus = new RawTransactionStatus(getTxResponse);
+    // WHEN the raw transaction status is wrapped into a RawTransactionStatus object.
+    RawTransactionStatus rawTransactionStatus = new RawTransactionStatus(getTxResponse);
 
-        // THEN the raw transaction status reports it is not a full payment.
-        assertFalse(rawTransactionStatus.isFullPayment());
-    }
+    // THEN the raw transaction status reports it is not a full payment.
+    assertFalse(rawTransactionStatus.isFullPayment());
+  }
 
-    @Test
-    public void testIsFullPaymentPartialPayment() {
-        // GIVEN a getTxResponse which is a payment with the partial payment flags set.
-        Payment payment = Payment.newBuilder().build();
-        Flags flags = Flags.newBuilder().setValue(RippledFlags.TF_PARTIAL_PAYMENT.value).build();
-        Transaction transaction = Transaction.newBuilder()
-                .setPayment(payment)
-                .setFlags(flags)
-                .build();
-        GetTransactionResponse getTransactionResponse = GetTransactionResponse.newBuilder()
-                .setTransaction(transaction)
-                .build();
+  @Test
+  public void testIsFullPaymentPartialPayment() {
+    // GIVEN a getTxResponse which is a payment with the partial payment flags set.
+    Payment payment = Payment.newBuilder().build();
+    Flags flags = Flags.newBuilder().setValue(RippledFlags.TF_PARTIAL_PAYMENT.value).build();
+    Transaction transaction = Transaction.newBuilder()
+        .setPayment(payment)
+        .setFlags(flags)
+        .build();
+    GetTransactionResponse getTransactionResponse = GetTransactionResponse.newBuilder()
+        .setTransaction(transaction)
+        .build();
 
-        // WHEN the raw transaction status is wrapped into a RawTransactionStatus object.
-        RawTransactionStatus rawTransactionStatus = new RawTransactionStatus(getTransactionResponse);
+    // WHEN the raw transaction status is wrapped into a RawTransactionStatus object.
+    RawTransactionStatus rawTransactionStatus = new RawTransactionStatus(getTransactionResponse);
 
-        // THEN the raw transaction status reports it is not a full payment.
-        assertFalse(rawTransactionStatus.isFullPayment());
-    }
+    // THEN the raw transaction status reports it is not a full payment.
+    assertFalse(rawTransactionStatus.isFullPayment());
+  }
 
-    @Test
-    public void testIsFullPaymentPayment() {
-        // GIVEN a getTxResponse which is a payment.
-        Payment payment = Payment.newBuilder().build();
-        Transaction transaction = Transaction.newBuilder().setPayment(payment).build();
-        GetTransactionResponse getTransactionResponse = GetTransactionResponse.newBuilder()
-                .setTransaction(transaction)
-                .build();
+  @Test
+  public void testIsFullPaymentPayment() {
+    // GIVEN a getTxResponse which is a payment.
+    Payment payment = Payment.newBuilder().build();
+    Transaction transaction = Transaction.newBuilder().setPayment(payment).build();
+    GetTransactionResponse getTransactionResponse = GetTransactionResponse.newBuilder()
+        .setTransaction(transaction)
+        .build();
 
-        // WHEN the raw transaction status is wrapped into a RawTransactionStatus object.
-        RawTransactionStatus rawTransactionStatus = new RawTransactionStatus(getTransactionResponse);
+    // WHEN the raw transaction status is wrapped into a RawTransactionStatus object.
+    RawTransactionStatus rawTransactionStatus = new RawTransactionStatus(getTransactionResponse);
 
-        // THEN the raw transaction status reports it is a full payment.
-        assertTrue(rawTransactionStatus.isFullPayment());
-    }
+    // THEN the raw transaction status reports it is a full payment.
+    assertTrue(rawTransactionStatus.isFullPayment());
+  }
 }

--- a/src/test/java/io/xpring/xrpl/ReliableSubmissionXRPClientTest.java
+++ b/src/test/java/io/xpring/xrpl/ReliableSubmissionXRPClientTest.java
@@ -1,5 +1,7 @@
 package io.xpring.xrpl;
 
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
 import io.xpring.common.Result;
 import io.xpring.common.XRPLNetwork;
 import io.xpring.xrpl.helpers.XRPTestUtils;
@@ -8,6 +10,11 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.xrpl.rpc.v1.Common.LastLedgerSequence;
+import org.xrpl.rpc.v1.GetTransactionResponse;
+import org.xrpl.rpc.v1.Meta;
+import org.xrpl.rpc.v1.Transaction;
+import org.xrpl.rpc.v1.TransactionResult;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -15,231 +22,233 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import org.xrpl.rpc.v1.*;
-
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class ReliableSubmissionXRPClientTest {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
-    private static final String XRPL_ADDRESS = "XVwDxLQ4SN9pEBQagTNHwqpFkPgGppXqrMoTmUcSKdCtcK5";
-    private static final String TRANSACTION_HASH = "DEADBEEF";
-    private static final String WALLET_SEED = "snYP7oArxKepd3GPDcrjMsJYiJeJB";
-    private static final BigInteger SEND_AMOUNT = new BigInteger("20");
+  private static final String XRPL_ADDRESS = "XVwDxLQ4SN9pEBQagTNHwqpFkPgGppXqrMoTmUcSKdCtcK5";
+  private static final String TRANSACTION_HASH = "DEADBEEF";
+  private static final String WALLET_SEED = "snYP7oArxKepd3GPDcrjMsJYiJeJB";
+  private static final BigInteger SEND_AMOUNT = new BigInteger("20");
 
-    private static final int LAST_LEDGER_SEQUENCE = 100;
-    private static final String TRANSACTION_STATUS_CODE = "tesSuccess";
+  private static final int LAST_LEDGER_SEQUENCE = 100;
+  private static final String TRANSACTION_STATUS_CODE = "tesSuccess";
 
-    private static final BigInteger DEFAULT_BALANCE_VALUE = new BigInteger("10");
-    private static final TransactionStatus DEFAULT_TRANSACTION_STATUS_VALUE = TransactionStatus.SUCCEEDED;
-    private static final String DEFAULT_SEND_VALUE = "DEADBEEF";
-    private static final int DEFAULT_LATEST_LEDGER_VALUE = 10;
-    private static final RawTransactionStatus DEFAULT_RAW_TRANSACTION_STATUS_VALUE = new RawTransactionStatus(
-            GetTransactionResponse.newBuilder()
-                    .setValidated(true)
-                    .setTransaction(
-                            Transaction.newBuilder()
-                                    .setLastLedgerSequence(
-                                            Common.LastLedgerSequence.newBuilder()
-                                                    .setValue(LAST_LEDGER_SEQUENCE)
-                                                    .build()
-                                    )
-                                    .build()
-                    )
-                    .setMeta(
-                            Meta.newBuilder().setTransactionResult(
-                                    TransactionResult.newBuilder()
-                                            .setResult(TRANSACTION_STATUS_CODE)
-                                            .build()
-                            )
-                    ).build()
+  private static final BigInteger DEFAULT_BALANCE_VALUE = new BigInteger("10");
+  private static final TransactionStatus DEFAULT_TRANSACTION_STATUS_VALUE = TransactionStatus.SUCCEEDED;
+  private static final String DEFAULT_SEND_VALUE = "DEADBEEF";
+  private static final int DEFAULT_LATEST_LEDGER_VALUE = 10;
+  private static final RawTransactionStatus DEFAULT_RAW_TRANSACTION_STATUS_VALUE = new RawTransactionStatus(
+      GetTransactionResponse.newBuilder()
+          .setValidated(true)
+          .setTransaction(
+              Transaction.newBuilder()
+                  .setLastLedgerSequence(
+                      LastLedgerSequence.newBuilder()
+                          .setValue(LAST_LEDGER_SEQUENCE)
+                          .build()
+                  )
+                  .build()
+          )
+          .setMeta(
+              Meta.newBuilder().setTransactionResult(
+                  TransactionResult.newBuilder()
+                      .setResult(TRANSACTION_STATUS_CODE)
+                      .build()
+              )
+          ).build()
+  );
+  private static final List<XRPTransaction> DEFAULT_PAYMENT_HISTORY_VALUE = XRPTestUtils
+      .transactionHistoryToPaymentsList(FakeXRPProtobufs.paymentOnlyGetAccountTransactionHistoryResponse);
+  private static final boolean DEFAULT_ACCOUNT_EXISTS_VALUE = true;
+
+  @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+  FakeXRPClient fakeXRPClient;
+  ReliableSubmissionXRPClient reliableSubmissionXRPClient;
+  private ScheduledExecutorService scheduledExecutor;
+
+  /**
+   * Set up test parameters.
+   */
+  @Before
+  public void setUp() throws Exception {
+    this.scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
+    this.fakeXRPClient = new FakeXRPClient(
+        XRPLNetwork.TEST,
+        Result.ok(DEFAULT_BALANCE_VALUE),
+        Result.ok(DEFAULT_TRANSACTION_STATUS_VALUE),
+        Result.ok(DEFAULT_SEND_VALUE),
+        Result.ok(DEFAULT_LATEST_LEDGER_VALUE),
+        Result.ok(DEFAULT_RAW_TRANSACTION_STATUS_VALUE),
+        Result.ok(DEFAULT_PAYMENT_HISTORY_VALUE),
+        Result.ok(DEFAULT_ACCOUNT_EXISTS_VALUE)
     );
-    private static final List<XRPTransaction> DEFAULT_PAYMENT_HISTORY_VALUE = XRPTestUtils
-            .transactionHistoryToPaymentsList(FakeXRPProtobufs.paymentOnlyGetAccountTransactionHistoryResponse);
-    private static final boolean DEFAULT_ACCOUNT_EXISTS_VALUE = true;
 
-    FakeXRPClient fakeXRPClient;
-    ReliableSubmissionXRPClient reliableSubmissionXRPClient;
-    private ScheduledExecutorService scheduledExecutor;
+    this.reliableSubmissionXRPClient = new ReliableSubmissionXRPClient(fakeXRPClient);
+  }
 
-    @Before
-    public void setUp() throws Exception {
-        this.scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
-        this.fakeXRPClient = new FakeXRPClient(
-                XRPLNetwork.TEST,
-                Result.ok(DEFAULT_BALANCE_VALUE),
-                Result.ok(DEFAULT_TRANSACTION_STATUS_VALUE),
-                Result.ok(DEFAULT_SEND_VALUE),
-                Result.ok(DEFAULT_LATEST_LEDGER_VALUE),
-                Result.ok(DEFAULT_RAW_TRANSACTION_STATUS_VALUE),
-                Result.ok(DEFAULT_PAYMENT_HISTORY_VALUE),
-                Result.ok(DEFAULT_ACCOUNT_EXISTS_VALUE)
-        );
-
-        this.reliableSubmissionXRPClient = new ReliableSubmissionXRPClient(fakeXRPClient);
-    }
-
-    @Test
-    public void testGetBalance() throws XRPException {
-        // GIVEN a `ReliableSubmissionClient` decorating a FakeXRPClient WHEN a balance is retrieved
-        BigInteger balance = reliableSubmissionXRPClient.getBalance(XRPL_ADDRESS);
+  @Test
+  public void testGetBalance() throws XRPException {
+    // GIVEN a `ReliableSubmissionClient` decorating a FakeXRPClient WHEN a balance is retrieved
+    BigInteger balance = reliableSubmissionXRPClient.getBalance(XRPL_ADDRESS);
 
 
-        // THEN the result is returned unaltered.
-        assertThat(balance).isEqualTo(DEFAULT_BALANCE_VALUE);
-    }
+    // THEN the result is returned unaltered.
+    assertThat(balance).isEqualTo(DEFAULT_BALANCE_VALUE);
+  }
 
-    @Test
-    public void testGetPaymentStatus() throws XRPException {
-        // GIVEN a `ReliableSubmissionClient` decorating a FakeXRPClient WHEN a payment status is retrieved
-        TransactionStatus paymentStatus = reliableSubmissionXRPClient.getPaymentStatus(TRANSACTION_HASH);
+  @Test
+  public void testGetPaymentStatus() throws XRPException {
+    // GIVEN a `ReliableSubmissionClient` decorating a FakeXRPClient WHEN a payment status is retrieved
+    TransactionStatus paymentStatus = reliableSubmissionXRPClient.getPaymentStatus(TRANSACTION_HASH);
 
-        // THEN the result is returned unaltered.
-        assertThat(paymentStatus).isEqualTo(DEFAULT_TRANSACTION_STATUS_VALUE);
-    }
+    // THEN the result is returned unaltered.
+    assertThat(paymentStatus).isEqualTo(DEFAULT_TRANSACTION_STATUS_VALUE);
+  }
 
-    @Test
-    public void testGetLatestValidatedLedgerSequence() throws XRPException {
-        // GIVEN a `ReliableSubmissionClient` decorating a FakeXRPClient WHEN the latest ledger sequence is retrieved
-        int latestSequence = reliableSubmissionXRPClient.getLatestValidatedLedgerSequence();
+  @Test
+  public void testGetLatestValidatedLedgerSequence() throws XRPException {
+    // GIVEN a `ReliableSubmissionClient` decorating a FakeXRPClient WHEN the latest ledger sequence is retrieved
+    int latestSequence = reliableSubmissionXRPClient.getLatestValidatedLedgerSequence();
 
-        // THEN the result is returned unaltered.
-        assertThat(latestSequence).isEqualTo(DEFAULT_LATEST_LEDGER_VALUE);
-    }
+    // THEN the result is returned unaltered.
+    assertThat(latestSequence).isEqualTo(DEFAULT_LATEST_LEDGER_VALUE);
+  }
 
-    @Test
-    public void testGetRawTransactionStatus() throws XRPException {
-        // GIVEN a `ReliableSubmissionClient` decorating a FakeXRPClient WHEN a raw transaction status is retrieved
-        RawTransactionStatus transactionStatus = reliableSubmissionXRPClient.getRawTransactionStatus(TRANSACTION_HASH);
+  @Test
+  public void testGetRawTransactionStatus() throws XRPException {
+    // GIVEN a `ReliableSubmissionClient` decorating a FakeXRPClient WHEN a raw transaction status is retrieved
+    RawTransactionStatus transactionStatus = reliableSubmissionXRPClient.getRawTransactionStatus(TRANSACTION_HASH);
 
-        // THEN the result is returned unaltered.
-        assertThat(transactionStatus).isEqualTo(DEFAULT_RAW_TRANSACTION_STATUS_VALUE);
-    }
+    // THEN the result is returned unaltered.
+    assertThat(transactionStatus).isEqualTo(DEFAULT_RAW_TRANSACTION_STATUS_VALUE);
+  }
 
-    @Test(timeout=10000)
-    public void testSendWithExpiredLedgerSequenceAndUnvalidatedTransaction() throws XRPException {
-        // GIVEN A faked latestLedgerSequence number that will increment past the lastLedgerSequence for a transaction
-        this.fakeXRPClient.rawTransactionStatusResult = Result.ok(new RawTransactionStatus(
-                GetTransactionResponse.newBuilder()
-                        .setValidated(false)
-                        .setTransaction(
-                                Transaction.newBuilder()
-                                        .setLastLedgerSequence(
-                                                Common.LastLedgerSequence.newBuilder()
-                                                        .setValue(LAST_LEDGER_SEQUENCE)
-                                                        .build()
-                                        )
-                                        .build()
-                        )
-                        .setMeta(
-                                Meta.newBuilder().setTransactionResult(
-                                        TransactionResult.newBuilder()
-                                                .setResult(TRANSACTION_STATUS_CODE)
-                                                .build()
-                                )
-                        ).build()
-        ));
+  @Test(timeout = 10000)
+  public void testSendWithExpiredLedgerSequenceAndUnvalidatedTransaction() throws XRPException {
+    // GIVEN A faked latestLedgerSequence number that will increment past the lastLedgerSequence for a transaction
+    this.fakeXRPClient.rawTransactionStatusResult = Result.ok(new RawTransactionStatus(
+        GetTransactionResponse.newBuilder()
+            .setValidated(false)
+            .setTransaction(
+                Transaction.newBuilder()
+                    .setLastLedgerSequence(
+                        LastLedgerSequence.newBuilder()
+                            .setValue(LAST_LEDGER_SEQUENCE)
+                            .build()
+                    )
+                    .build()
+            )
+            .setMeta(
+                Meta.newBuilder().setTransactionResult(
+                    TransactionResult.newBuilder()
+                        .setResult(TRANSACTION_STATUS_CODE)
+                        .build()
+                )
+            ).build()
+    ));
 
-        runAfterOneSecond(() -> {
-            this.fakeXRPClient.latestValidatedLedgerResult = Result.ok(LAST_LEDGER_SEQUENCE + 1);
-        });
+    runAfterOneSecond(() -> {
+      this.fakeXRPClient.latestValidatedLedgerResult = Result.ok(LAST_LEDGER_SEQUENCE + 1);
+    });
 
-        // WHEN a reliable send is submitted THEN the send reaches a consistent state and returns.
-        this.reliableSubmissionXRPClient.send(SEND_AMOUNT, XRPL_ADDRESS, new Wallet(WALLET_SEED));
-    }
+    // WHEN a reliable send is submitted THEN the send reaches a consistent state and returns.
+    this.reliableSubmissionXRPClient.send(SEND_AMOUNT, XRPL_ADDRESS, new Wallet(WALLET_SEED));
+  }
 
-    @Test(timeout=10000)
-    public void testSendWithUnxpiredLedgerSequenceAndValidatedTransaction() throws XRPException {
-        // GIVEN A transaction that will validate in one second
-        final String transactionStatusCode = "tesSuccess";
-        this.fakeXRPClient.rawTransactionStatusResult = Result.ok(new RawTransactionStatus(
-                GetTransactionResponse.newBuilder()
-                        .setValidated(false)
-                        .setTransaction(
-                                Transaction.newBuilder()
-                                        .setLastLedgerSequence(
-                                                Common.LastLedgerSequence.newBuilder()
-                                                        .setValue(LAST_LEDGER_SEQUENCE)
-                                                        .build()
-                                        )
-                                        .build()
-                        )
-                        .setMeta(
-                                Meta.newBuilder().setTransactionResult(
-                                        TransactionResult.newBuilder()
-                                                .setResult(transactionStatusCode)
-                                                .build()
-                                )
-                        ).build()
-        ));
+  @Test(timeout = 10000)
+  public void testSendWithUnxpiredLedgerSequenceAndValidatedTransaction() throws XRPException {
+    // GIVEN A transaction that will validate in one second
+    final String transactionStatusCode = "tesSuccess";
+    this.fakeXRPClient.rawTransactionStatusResult = Result.ok(new RawTransactionStatus(
+        GetTransactionResponse.newBuilder()
+            .setValidated(false)
+            .setTransaction(
+                Transaction.newBuilder()
+                    .setLastLedgerSequence(
+                        LastLedgerSequence.newBuilder()
+                            .setValue(LAST_LEDGER_SEQUENCE)
+                            .build()
+                    )
+                    .build()
+            )
+            .setMeta(
+                Meta.newBuilder().setTransactionResult(
+                    TransactionResult.newBuilder()
+                        .setResult(transactionStatusCode)
+                        .build()
+                )
+            ).build()
+    ));
 
-        runAfterOneSecond(() -> {
-            this.fakeXRPClient.rawTransactionStatusResult = Result.ok(new RawTransactionStatus(
-                    GetTransactionResponse.newBuilder()
-                            .setValidated(true)
-                            .setTransaction(
-                                    Transaction.newBuilder()
-                                            .setLastLedgerSequence(
-                                                    Common.LastLedgerSequence.newBuilder()
-                                                            .setValue(LAST_LEDGER_SEQUENCE)
-                                                            .build()
-                                            )
-                                            .build()
-                            )
-                            .setMeta(
-                                    Meta.newBuilder().setTransactionResult(
-                                            TransactionResult.newBuilder()
-                                                    .setResult(TRANSACTION_STATUS_CODE)
-                                                    .build()
-                                    )
-                            ).build()
-            ));
-        });
+    runAfterOneSecond(() -> {
+      this.fakeXRPClient.rawTransactionStatusResult = Result.ok(new RawTransactionStatus(
+          GetTransactionResponse.newBuilder()
+              .setValidated(true)
+              .setTransaction(
+                  Transaction.newBuilder()
+                      .setLastLedgerSequence(
+                          LastLedgerSequence.newBuilder()
+                              .setValue(LAST_LEDGER_SEQUENCE)
+                              .build()
+                      )
+                      .build()
+              )
+              .setMeta(
+                  Meta.newBuilder().setTransactionResult(
+                      TransactionResult.newBuilder()
+                          .setResult(TRANSACTION_STATUS_CODE)
+                          .build()
+                  )
+              ).build()
+      ));
+    });
 
-        // WHEN a reliable send is submitted THEN the send reaches a consistent state and returns.
-        this.reliableSubmissionXRPClient.send(SEND_AMOUNT, XRPL_ADDRESS, new Wallet(WALLET_SEED));
-    }
+    // WHEN a reliable send is submitted THEN the send reaches a consistent state and returns.
+    this.reliableSubmissionXRPClient.send(SEND_AMOUNT, XRPL_ADDRESS, new Wallet(WALLET_SEED));
+  }
 
-    @Test
-    public void testSendWithNoLastLedgerSequence() throws XRPException {
-        // GIVEN a `ReliableSubmissionXRPClient` decorating a `FakeXRPClient` which will return a transaction that did not have a last ledger sequence attached.
-        this.fakeXRPClient.rawTransactionStatusResult = Result.ok(new RawTransactionStatus(
-                GetTransactionResponse.newBuilder()
-                        .setValidated(false)
-                        .setTransaction(
-                                Transaction.newBuilder()
-                                        .build()
-                        )
-                        .setMeta(
-                                Meta.newBuilder().setTransactionResult(
-                                        TransactionResult.newBuilder()
-                                                .setResult(TRANSACTION_STATUS_CODE)
-                                                .build()
-                                )
-                        ).build()
-        ));
+  @Test
+  public void testSendWithNoLastLedgerSequence() throws XRPException {
+    // GIVEN a `ReliableSubmissionXRPClient` decorating a `FakeXRPClient` which will return a transaction that did not
+    // have a last ledger sequence attached.
+    this.fakeXRPClient.rawTransactionStatusResult = Result.ok(new RawTransactionStatus(
+        GetTransactionResponse.newBuilder()
+            .setValidated(false)
+            .setTransaction(
+                Transaction.newBuilder()
+                    .build()
+            )
+            .setMeta(
+                Meta.newBuilder().setTransactionResult(
+                    TransactionResult.newBuilder()
+                        .setResult(TRANSACTION_STATUS_CODE)
+                        .build()
+                )
+            ).build()
+    ));
 
-        // WHEN a reliable send is submitted THEN an error is thrown.
-        expectedException.expect(Exception.class);
-        this.reliableSubmissionXRPClient.send(SEND_AMOUNT, XRPL_ADDRESS, new Wallet(WALLET_SEED));
-    }
+    // WHEN a reliable send is submitted THEN an error is thrown.
+    expectedException.expect(Exception.class);
+    this.reliableSubmissionXRPClient.send(SEND_AMOUNT, XRPL_ADDRESS, new Wallet(WALLET_SEED));
+  }
 
-    @Test
-    public void testPaymentHistoryWithUnmodifiedResponse() throws XRPException {
-        // GIVEN a `ReliableSubmissionXRPClient` decorating a `FakeXRPClient` WHEN transaction history is retrieved.
-        List<XRPTransaction> returnedValue = this.fakeXRPClient.paymentHistory(XRPL_ADDRESS);
+  @Test
+  public void testPaymentHistoryWithUnmodifiedResponse() throws XRPException {
+    // GIVEN a `ReliableSubmissionXRPClient` decorating a `FakeXRPClient` WHEN transaction history is retrieved.
+    List<XRPTransaction> returnedValue = this.fakeXRPClient.paymentHistory(XRPL_ADDRESS);
 
-        // THEN the result is returned unaltered.
-        assertThat(returnedValue).isEqualTo(this.fakeXRPClient.paymentHistoryResult.getValue());
-    }
+    // THEN the result is returned unaltered.
+    assertThat(returnedValue).isEqualTo(this.fakeXRPClient.paymentHistoryResult.getValue());
+  }
 
-    /**
-     * Run the given work on an separate thread in after one second.
-     *
-     * @param work The work to run.
-     */
-    private void runAfterOneSecond(Runnable work) {
-        scheduledExecutor.schedule(work, 1, TimeUnit.SECONDS);
-    }
+  /**
+   * Run the given work on an separate thread in after one second.
+   *
+   * @param work The work to run.
+   */
+  private void runAfterOneSecond(Runnable work) {
+    scheduledExecutor.schedule(work, 1, TimeUnit.SECONDS);
+  }
 }

--- a/src/test/java/io/xpring/xrpl/RippledFlagsTest.java
+++ b/src/test/java/io/xpring/xrpl/RippledFlagsTest.java
@@ -1,26 +1,26 @@
 package io.xpring.xrpl;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Test;
+
 public class RippledFlagsTest {
-    @Test
-    public void testCheckContainsValue() {
-        // GIVEN a set of flags that contains the tfPartialPayment flag.
-        int flags = RippledFlags.TF_PARTIAL_PAYMENT.value | 1 | 4; // 1 and 4 are arbitrarily chosen numbers.
+  @Test
+  public void testCheckContainsValue() {
+    // GIVEN a set of flags that contains the tfPartialPayment flag.
+    int flags = RippledFlags.TF_PARTIAL_PAYMENT.value | 1 | 4; // 1 and 4 are arbitrarily chosen numbers.
 
-        // WHEN the presence of tfPartialPayment is checked THEN the flag is reported as present.
-        assertTrue(RippledFlags.check(RippledFlags.TF_PARTIAL_PAYMENT, flags));
-    }
+    // WHEN the presence of tfPartialPayment is checked THEN the flag is reported as present.
+    assertTrue(RippledFlags.check(RippledFlags.TF_PARTIAL_PAYMENT, flags));
+  }
 
-    @Test
-    public void testCheckDoesNotContainValue() {
-        // GIVEN a set of flags that does not contain the tfPartialPayment flag.
-        int flags = 1 | 4; // 1 and 4 are arbitrarily chosen numbers.
+  @Test
+  public void testCheckDoesNotContainValue() {
+    // GIVEN a set of flags that does not contain the tfPartialPayment flag.
+    int flags = 1 | 4; // 1 and 4 are arbitrarily chosen numbers.
 
-        // WHEN the presence of tfPartialPayment is checked THEN the flag is reported as not present.
-        assertFalse(RippledFlags.check(RippledFlags.TF_PARTIAL_PAYMENT, flags));
-    }
+    // WHEN the presence of tfPartialPayment is checked THEN the flag is reported as not present.
+    assertFalse(RippledFlags.check(RippledFlags.TF_PARTIAL_PAYMENT, flags));
+  }
 }

--- a/src/test/java/io/xpring/xrpl/SignerTest.java
+++ b/src/test/java/io/xpring/xrpl/SignerTest.java
@@ -1,56 +1,59 @@
 package io.xpring.xrpl;
 
-import org.junit.Test;
-
-import java.math.BigInteger;
-import java.util.Arrays;
-
-import org.xrpl.rpc.v1.*;
-import org.xrpl.rpc.v1.Common.*;
-import org.xrpl.rpc.v1.Common.Account;
-import org.xrpl.rpc.v1.Common.Amount;
-
 import static org.junit.Assert.assertArrayEquals;
 
+import org.junit.Test;
+import org.xrpl.rpc.v1.AccountAddress;
+import org.xrpl.rpc.v1.Common.Account;
+import org.xrpl.rpc.v1.Common.Amount;
+import org.xrpl.rpc.v1.Common.Destination;
+import org.xrpl.rpc.v1.Common.Sequence;
+import org.xrpl.rpc.v1.CurrencyAmount;
+import org.xrpl.rpc.v1.Payment;
+import org.xrpl.rpc.v1.Transaction;
+import org.xrpl.rpc.v1.XRPDropsAmount;
+
 public class SignerTest {
-    @Test
-    public void testSign() throws Exception {
-        // GIVEN a wallet, a transaction and an expected serialized and signed output.
-        Wallet wallet = new Wallet("snYP7oArxKepd3GPDcrjMsJYiJeJB");
+  @Test
+  public void testSign() throws Exception {
+    // GIVEN a wallet, a transaction and an expected serialized and signed output.
+    Wallet wallet = new Wallet("snYP7oArxKepd3GPDcrjMsJYiJeJB");
 
-        int sequenceInt = 1;
-        XRPDropsAmount feeAmount = XRPDropsAmount.newBuilder().setDrops(10).build();
-        XRPDropsAmount sendAmount = XRPDropsAmount.newBuilder().setDrops(1000).build();
-        AccountAddress senderAddress = AccountAddress.newBuilder().setAddress("X7vjQVCddnQ7GCESYnYR3EdpzbcoAMbPw7s2xv8YQs94tv4").build();
-        AccountAddress destinationAddress = AccountAddress.newBuilder().setAddress("XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc").build();
-        CurrencyAmount paymentAmount = CurrencyAmount.newBuilder().setXrpAmount(sendAmount).build();
-        Destination destination = Destination.newBuilder().setValue(destinationAddress).build();
-        Amount amount = Amount.newBuilder().setValue(paymentAmount).build();
-        Account account = Account.newBuilder().setValue(senderAddress).build();
-        Sequence sequence = Sequence.newBuilder().setValue(sequenceInt).build();
+    int sequenceInt = 1;
+    XRPDropsAmount feeAmount = XRPDropsAmount.newBuilder().setDrops(10).build();
+    XRPDropsAmount sendAmount = XRPDropsAmount.newBuilder().setDrops(1000).build();
+    AccountAddress senderAddress =
+        AccountAddress.newBuilder().setAddress("X7vjQVCddnQ7GCESYnYR3EdpzbcoAMbPw7s2xv8YQs94tv4").build();
+    AccountAddress destinationAddress =
+        AccountAddress.newBuilder().setAddress("XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc").build();
+    CurrencyAmount paymentAmount = CurrencyAmount.newBuilder().setXrpAmount(sendAmount).build();
+    Destination destination = Destination.newBuilder().setValue(destinationAddress).build();
+    Amount amount = Amount.newBuilder().setValue(paymentAmount).build();
+    Account account = Account.newBuilder().setValue(senderAddress).build();
+    Sequence sequence = Sequence.newBuilder().setValue(sequenceInt).build();
 
-        Payment payment = Payment.newBuilder().setDestination(destination).setAmount(amount).build();
-        Transaction transaction = Transaction.newBuilder()
-                .setAccount(account)
-                .setFee(feeAmount)
-                .setSequence(sequence)
-                .setPayment(payment)
-                .build();
+    Payment payment = Payment.newBuilder().setDestination(destination).setAmount(amount).build();
+    Transaction transaction = Transaction.newBuilder()
+        .setAccount(account)
+        .setFee(feeAmount)
+        .setSequence(sequence)
+        .setPayment(payment)
+        .build();
 
-        byte [] expected = {
-                18, 0, 0, 36, 0, 0, 0, 1, 32, 27, 0, 0, 0, 0, 97, 64, 0, 0, 0, 0, 0, 3, -24, 104, 64, 0, 0, 0, 0, 0, 0,
-                10, 115, 0, 116, 71, 48, 69, 2, 33, 0, -11, 52, -67, 33, -66, -56, 90, 121, -8, -29, 64, -57, -16, -51,
-                -35, 62, 60, 86, -64, -100, 67, -108, 18, 99, 33, -87, -18, 71, -125, -70, -64, -116, 2, 32, 99, -37,
-                -20, 23, -102, -95, -16, 28, -36, -49, 75, 63, -50, -92, 46, 49, -3, -34, 30, -74, -103, -117, 90, 36,
-                -19, 56, 50, 27, -19, 102, 29, 106, -127, 20, 91, -127, 44, -99, 87, 115, 30, 39, -94, -38, -117, 24,
-                48, 25, 95, -120, -17, 50, -93, -74, -125, 20, -75, -9, 98, 121, -118, 83, -43, 67, -96, 20, -54, -8,
-                -78, -105, -49, -8, -14, -7, 55, -24
-        };
+    byte[] expected = {
+        18, 0, 0, 36, 0, 0, 0, 1, 32, 27, 0, 0, 0, 0, 97, 64, 0, 0, 0, 0, 0, 3, -24, 104, 64, 0, 0, 0, 0, 0, 0,
+        10, 115, 0, 116, 71, 48, 69, 2, 33, 0, -11, 52, -67, 33, -66, -56, 90, 121, -8, -29, 64, -57, -16, -51,
+        -35, 62, 60, 86, -64, -100, 67, -108, 18, 99, 33, -87, -18, 71, -125, -70, -64, -116, 2, 32, 99, -37,
+        -20, 23, -102, -95, -16, 28, -36, -49, 75, 63, -50, -92, 46, 49, -3, -34, 30, -74, -103, -117, 90, 36,
+        -19, 56, 50, 27, -19, 102, 29, 106, -127, 20, 91, -127, 44, -99, 87, 115, 30, 39, -94, -38, -117, 24,
+        48, 25, 95, -120, -17, 50, -93, -74, -125, 20, -75, -9, 98, 121, -118, 83, -43, 67, -96, 20, -54, -8,
+        -78, -105, -49, -8, -14, -7, 55, -24
+    };
 
-        // WHEN the transaction is signed.
-        byte [] signedTransaction = Signer.signTransaction(transaction, wallet);
+    // WHEN the transaction is signed.
+    byte[] signedTransaction = Signer.signTransaction(transaction, wallet);
 
-        // THEN the result is the same as expected.
-        assertArrayEquals(signedTransaction, expected);
-    }
+    // THEN the result is the same as expected.
+    assertArrayEquals(signedTransaction, expected);
+  }
 }

--- a/src/test/java/io/xpring/xrpl/UtilsTest.java
+++ b/src/test/java/io/xpring/xrpl/UtilsTest.java
@@ -1,195 +1,205 @@
 package io.xpring.xrpl;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
 
 /**
  * Unit tests for {@link Utils}.
  */
 public class UtilsTest {
-    @Test
-    public void testIsValidAddressValidClassicAddress() {
-        assertTrue(Utils.isValidAddress("rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"));
-    }
+  @Test
+  public void testIsValidAddressValidClassicAddress() {
+    assertTrue(Utils.isValidAddress("rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"));
+  }
 
-    @Test
-    public void testIsValidAddressValidXAddress() {
-        assertTrue(Utils.isValidAddress("XVLhHMPHU98es4dbozjVtdWzVrDjtV18pX8yuPT7y4xaEHi"));
-    }
+  @Test
+  public void testIsValidAddressValidXAddress() {
+    assertTrue(Utils.isValidAddress("XVLhHMPHU98es4dbozjVtdWzVrDjtV18pX8yuPT7y4xaEHi"));
+  }
 
-    @Test
-    public void testIsValidAddressInvalidAlphabet() {
-        assertFalse(Utils.isValidAddress("1EAG1MwmzkG6gRZcYqcRMfC17eMt8TDTit"));
-    }
+  @Test
+  public void testIsValidAddressInvalidAlphabet() {
+    assertFalse(Utils.isValidAddress("1EAG1MwmzkG6gRZcYqcRMfC17eMt8TDTit"));
+  }
 
-    @Test
-    public void testIsValidAddressInvalidClassicAddressChecksum() {
-        assertFalse(Utils.isValidAddress("rU6K7V3Po4sBBBBBaU29sesqs2qTQJWDw1"));
-    }
+  @Test
+  public void testIsValidAddressInvalidClassicAddressChecksum() {
+    assertFalse(Utils.isValidAddress("rU6K7V3Po4sBBBBBaU29sesqs2qTQJWDw1"));
+  }
 
-    @Test
-    public void testIsValidAddressInvalidCharacters() {
-        assertFalse(Utils.isValidAddress("rU6K7V3Po4sBBBBBaU@#$%qs2qTQJWDw1"));
-    }
+  @Test
+  public void testIsValidAddressInvalidCharacters() {
+    assertFalse(Utils.isValidAddress("rU6K7V3Po4sBBBBBaU@#$%qs2qTQJWDw1"));
+  }
 
-    @Test
-    public void testIsValidAddressTooLong() {
-        assertFalse(Utils.isValidAddress("rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"));
-    }
+  @Test
+  public void testIsValidAddressTooLong() {
+    assertFalse(Utils.isValidAddress("rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"));
+  }
 
-    @Test
-    public void testIsValidAddressTooShort() {
-        assertFalse(Utils.isValidAddress("rU6K7V3Po4s2qTQJWDw1"));
-    }
+  @Test
+  public void testIsValidAddressTooShort() {
+    assertFalse(Utils.isValidAddress("rU6K7V3Po4s2qTQJWDw1"));
+  }
 
-    @Test
-    public void testEncodeMainNetXAddressWithAddressAndTag() {
-        // GIVEN a valid classic address and a tag on MainNet.
-        String address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1";
-        int tag = 12345;
-        ClassicAddress classicAddress = ImmutableClassicAddress.builder().address(address).tag(tag).isTest(false).build();
+  @SuppressWarnings("checkstyle:LocalVariableName")
+  @Test
+  public void testEncodeMainNetXAddressWithAddressAndTag() {
+    // GIVEN a valid classic address and a tag on MainNet.
+    String address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1";
+    int tag = 12345;
+    ClassicAddress classicAddress = ImmutableClassicAddress.builder().address(address).tag(tag).isTest(false).build();
 
-        // WHEN they are encoded to an X-Address.
-        String xAddress = Utils.encodeXAddress(classicAddress);
+    // WHEN they are encoded to an X-Address.
+    String xAddress = Utils.encodeXAddress(classicAddress);
 
-        // THEN the result is as expected.
-        assertEquals(xAddress, "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT");
-    }
+    // THEN the result is as expected.
+    assertEquals(xAddress, "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT");
+  }
 
-    @Test
-    public void testEncodeTestNetXAddressWithAddressAndTag() {
-        // GIVEN a valid classic address and a tag on TestNet.
-        String address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1";
-        int tag = 12345;
-        ClassicAddress classicAddress = ImmutableClassicAddress.builder().address(address).tag(tag).isTest(true).build();
+  @SuppressWarnings("checkstyle:LocalVariableName")
+  @Test
+  public void testEncodeTestNetXAddressWithAddressAndTag() {
+    // GIVEN a valid classic address and a tag on TestNet.
+    String address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1";
+    int tag = 12345;
+    ClassicAddress classicAddress = ImmutableClassicAddress.builder().address(address).tag(tag).isTest(true).build();
 
-        // WHEN they are encoded to an X-Address.
-        String xAddress = Utils.encodeXAddress(classicAddress);
+    // WHEN they are encoded to an X-Address.
+    String xAddress = Utils.encodeXAddress(classicAddress);
 
-        // THEN the result is as expected.
-        assertEquals(xAddress, "TVsBZmcewpEHgajPi1jApLeYnHPJw82v9JNYf7dkGmWphmh");
-    }
+    // THEN the result is as expected.
+    assertEquals(xAddress, "TVsBZmcewpEHgajPi1jApLeYnHPJw82v9JNYf7dkGmWphmh");
+  }
 
-    @Test
-    public void testEncodeXAddressWithAddressOnly() {
-        // GIVEN a valid classic address without a tag.
-        ClassicAddress classicAddress = ImmutableClassicAddress.builder().address("rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1").isTest(false).build();
+  @SuppressWarnings("checkstyle:LocalVariableName")
+  @Test
+  public void testEncodeXAddressWithAddressOnly() {
+    // GIVEN a valid classic address without a tag.
+    ClassicAddress classicAddress =
+        ImmutableClassicAddress.builder().address("rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1").isTest(false).build();
 
-        // WHEN it is encoded to an X-Address.
-        String xAddress = Utils.encodeXAddress(classicAddress);
+    // WHEN it is encoded to an X-Address.
+    String xAddress = Utils.encodeXAddress(classicAddress);
 
-        // THEN the result is as expected.
-        assertEquals(xAddress, "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUFyQVMzRrMGUZpokKH");
-    }
+    // THEN the result is as expected.
+    assertEquals(xAddress, "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUFyQVMzRrMGUZpokKH");
+  }
 
-    @Test
-    public void testEncodeXAddressWithInvalidAddress() {
-        // GIVEN an invalid address.
-        ClassicAddress classicAddress = ImmutableClassicAddress.builder().address("xrp").isTest(false).build();
+  @SuppressWarnings("checkstyle:LocalVariableName")
+  @Test
+  public void testEncodeXAddressWithInvalidAddress() {
+    // GIVEN an invalid address.
+    ClassicAddress classicAddress = ImmutableClassicAddress.builder().address("xrp").isTest(false).build();
 
-        // WHEN it is encoded to an X-Address.
-        String xAddress = Utils.encodeXAddress(classicAddress);
+    // WHEN it is encoded to an X-Address.
+    String xAddress = Utils.encodeXAddress(classicAddress);
 
-        // THEN the result is null.
-        assertNull(xAddress);
-    }
+    // THEN the result is null.
+    assertNull(xAddress);
+  }
 
-    @Test
-    public void testDecodeXAddressWithValidMainNetAddressContainingTag() {
-        // GIVEN an X-Address that encodes an address on mainnet and a tag.
-        String address = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT";
+  @Test
+  public void testDecodeXAddressWithValidMainNetAddressContainingTag() {
+    // GIVEN an X-Address that encodes an address on mainnet and a tag.
+    String address = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT";
 
-        // WHEN it is decoded to an classic address.
-        ClassicAddress classicAddress = Utils.decodeXAddress(address);
+    // WHEN it is decoded to an classic address.
+    ClassicAddress classicAddress = Utils.decodeXAddress(address);
 
-        // Then the decoded address and tag as are expected.
-        assertEquals(classicAddress.address(), "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1");
-        assertEquals(classicAddress.tag().get(), new Integer(12345));
-        assertFalse(classicAddress.isTest());
-    }
+    // Then the decoded address and tag as are expected.
+    assertEquals(classicAddress.address(), "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1");
+    assertEquals(classicAddress.tag().get(), Integer.valueOf(12345));
+    assertFalse(classicAddress.isTest());
+  }
 
-    @Test
-    public void testDecodeXAddressWithValidTestNetAddressContainingTag() {
-        // GIVEN an x-address that encodes an address on a testnet and a tag.
-        String address = "TVsBZmcewpEHgajPi1jApLeYnHPJw82v9JNYf7dkGmWphmh";
+  @Test
+  public void testDecodeXAddressWithValidTestNetAddressContainingTag() {
+    // GIVEN an x-address that encodes an address on a testnet and a tag.
+    String address = "TVsBZmcewpEHgajPi1jApLeYnHPJw82v9JNYf7dkGmWphmh";
 
-        // WHEN it is decoded to an classic address.
-        ClassicAddress classicAddress = Utils.decodeXAddress(address);
+    // WHEN it is decoded to an classic address.
+    ClassicAddress classicAddress = Utils.decodeXAddress(address);
 
-        // Then the decoded address and tag as are expected.
-        assertEquals(classicAddress.address(), "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1");
-        assertEquals(classicAddress.tag().get(), new Integer(12345));
-        assertTrue(classicAddress.isTest());
-    }
+    // Then the decoded address and tag as are expected.
+    assertEquals(classicAddress.address(), "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1");
+    assertEquals(classicAddress.tag().get(), new Integer(12345));
+    assertTrue(classicAddress.isTest());
+  }
 
-    @Test
-    public void testDecodeXAddressWithValidAddressWithoutTag() {
-        // GIVEN an X-Address that encodes an address and no tag.
-        String address = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUFyQVMzRrMGUZpokKH";
+  @Test
+  public void testDecodeXAddressWithValidAddressWithoutTag() {
+    // GIVEN an X-Address that encodes an address and no tag.
+    String address = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUFyQVMzRrMGUZpokKH";
 
-        // WHEN it is decoded to an classic address.
-        ClassicAddress classicAddress = Utils.decodeXAddress(address);
+    // WHEN it is decoded to an classic address.
+    ClassicAddress classicAddress = Utils.decodeXAddress(address);
 
-        // Then the decoded address and tag as are expected.
-        assertEquals(classicAddress.address(), "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1");
-        assertFalse(classicAddress.tag().isPresent());
-        assertFalse(classicAddress.isTest());
-    }
+    // Then the decoded address and tag as are expected.
+    assertEquals(classicAddress.address(), "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1");
+    assertFalse(classicAddress.tag().isPresent());
+    assertFalse(classicAddress.isTest());
+  }
 
-    @Test
-    public void testDecodeXAddressWithInvalidXAddress() {
-        // GIVEN an invalid address.
-        String address = "xrp";
+  @Test
+  public void testDecodeXAddressWithInvalidXAddress() {
+    // GIVEN an invalid address.
+    String address = "xrp";
 
-        // WHEN it is decoded to an classic address.
-        ClassicAddress classicAddress = Utils.decodeXAddress(address);
+    // WHEN it is decoded to an classic address.
+    ClassicAddress classicAddress = Utils.decodeXAddress(address);
 
-        // Then the decoded address is null.
-        assertNull(classicAddress);
-    }
+    // Then the decoded address is null.
+    assertNull(classicAddress);
+  }
 
-    @Test
-    public void testIsValidXAddressWithValidXAddress() {
-        assertTrue(Utils.isValidXAddress("XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT"));
-    }
+  @Test
+  public void testIsValidXAddressWithValidXAddress() {
+    assertTrue(Utils.isValidXAddress("XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT"));
+  }
 
-    @Test
-    public void testIsValidXAddressWithValidClassicAddress() {
-        assertFalse(Utils.isValidXAddress("rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"));
-    }
+  @Test
+  public void testIsValidXAddressWithValidClassicAddress() {
+    assertFalse(Utils.isValidXAddress("rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"));
+  }
 
-    @Test
-    public void testIsValidXAddressWithInvalidAddress() {
-        assertFalse(Utils.isValidXAddress("xrp"));
-    }
+  @Test
+  public void testIsValidXAddressWithInvalidAddress() {
+    assertFalse(Utils.isValidXAddress("xrp"));
+  }
 
-    @Test
-    public void testIsValidClassicAddressWithValidXAddress() {
-        assertFalse(Utils.isValidClassicAddress("XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT"));
-    }
+  @Test
+  public void testIsValidClassicAddressWithValidXAddress() {
+    assertFalse(Utils.isValidClassicAddress("XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT"));
+  }
 
-    @Test
-    public void testIsValidClassicAddressWithValidClassicAddress() {
-        assertTrue(Utils.isValidClassicAddress("rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"));
-    }
+  @Test
+  public void testIsValidClassicAddressWithValidClassicAddress() {
+    assertTrue(Utils.isValidClassicAddress("rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"));
+  }
 
-    @Test
-    public void testIsValidClassicAddressWithInvalidAddress() {
-        assertFalse(Utils.isValidClassicAddress("xrp"));
-    }
+  @Test
+  public void testIsValidClassicAddressWithInvalidAddress() {
+    assertFalse(Utils.isValidClassicAddress("xrp"));
+  }
 
-    @Test
-    public void testToTransactionHashValidTransaction() {
-        String transactionBlob = "120000240000000561400000000000000168400000000000000C73210261BBB9D242440BA38375DAD79B146E559A9DFB99055F7077DA63AE0D643CA0E174473045022100C8BB1CE19DFB1E57CDD60947C5D7F1ACD10851B0F066C28DBAA3592475BC3808022056EEB85CC8CD41F1F1CF635C244943AD43E3CF0CE1E3B7359354AC8A62CF3F488114F8942487EDB0E4FD86190BF8DCB3AF36F608839D83141D10E382F805CD7033CC4582D2458922F0D0ACA6";
-        String expectedHash = "7B9F6E019C2A79857427B4EF968D77D683AC84F5A880830955D7BDF47F120667";
-        String hash = Utils.toTransactionHash(transactionBlob);
-        assertEquals(hash, expectedHash);
-    }
+  @SuppressWarnings("checkstyle:LineLength")
+  @Test
+  public void testToTransactionHashValidTransaction() {
+    String transactionBlob =
+        "120000240000000561400000000000000168400000000000000C73210261BBB9D242440BA38375DAD79B146E559A9DFB99055F7077DA63AE0D643CA0E174473045022100C8BB1CE19DFB1E57CDD60947C5D7F1ACD10851B0F066C28DBAA3592475BC3808022056EEB85CC8CD41F1F1CF635C244943AD43E3CF0CE1E3B7359354AC8A62CF3F488114F8942487EDB0E4FD86190BF8DCB3AF36F608839D83141D10E382F805CD7033CC4582D2458922F0D0ACA6";
+    String expectedHash = "7B9F6E019C2A79857427B4EF968D77D683AC84F5A880830955D7BDF47F120667";
+    String hash = Utils.toTransactionHash(transactionBlob);
+    assertEquals(hash, expectedHash);
+  }
 
-    @Test
-    public void testToTransactionHashInvalidTransaction() {
-        String hash = Utils.toTransactionHash("xrp");
-        assertNull(hash, null);
-    }
+  @Test
+  public void testToTransactionHashInvalidTransaction() {
+    String hash = Utils.toTransactionHash("xrp");
+    assertNull(hash, null);
+  }
 }

--- a/src/test/java/io/xpring/xrpl/WalletTest.java
+++ b/src/test/java/io/xpring/xrpl/WalletTest.java
@@ -1,194 +1,200 @@
 package io.xpring.xrpl;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static org.junit.Assert.*;
-
 public class WalletTest {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
-    @Test
-    public void testGenerateMainNetWalletFromSeed() throws XRPException {
-        Wallet wallet = new Wallet("snYP7oArxKepd3GPDcrjMsJYiJeJB");
-        assertEquals(wallet.getAddress(), "XVnJMYQFqA8EAijpKh5EdjEY5JqyxykMKKSbrUX8uchF6U8");
-    }
+  @Test
+  public void testGenerateMainNetWalletFromSeed() throws XRPException {
+    Wallet wallet = new Wallet("snYP7oArxKepd3GPDcrjMsJYiJeJB");
+    assertEquals(wallet.getAddress(), "XVnJMYQFqA8EAijpKh5EdjEY5JqyxykMKKSbrUX8uchF6U8");
+  }
 
-    @Test
-    public void testGenerateTestNetWalletFromSeed() throws XRPException {
-        Wallet wallet = new Wallet("snYP7oArxKepd3GPDcrjMsJYiJeJB", true);
-        assertEquals(wallet.getAddress(), "T7zFmeZo6uLHP4Vd21TpXjrTBk487ZQPGVQsJ1mKWGCD5rq");
-    }
+  @Test
+  public void testGenerateTestNetWalletFromSeed() throws XRPException {
+    Wallet wallet = new Wallet("snYP7oArxKepd3GPDcrjMsJYiJeJB", true);
+    assertEquals(wallet.getAddress(), "T7zFmeZo6uLHP4Vd21TpXjrTBk487ZQPGVQsJ1mKWGCD5rq");
+  }
 
-    @Test
-    public void testGenerateWalletFromInvalidSeed() throws XRPException {
-        expectedException.expect(XRPException.class);
-        new Wallet("xrp");
-    }
+  @Test
+  public void testGenerateWalletFromInvalidSeed() throws XRPException {
+    expectedException.expect(XRPException.class);
+    new Wallet("xrp");
+  }
 
-    @Test
-    public void testGenerateRandomWallet() throws XRPException {
-        WalletGenerationResult generationResult = Wallet.generateRandomWallet();
+  @Test
+  public void testGenerateRandomWallet() throws XRPException {
+    WalletGenerationResult generationResult = Wallet.generateRandomWallet();
 
-        assertNotNull(generationResult.getWallet());
-        assertNotNull(generationResult.getMnemonic());
-        assertNotNull(generationResult.getDerivationPath());
+    assertNotNull(generationResult.getWallet());
+    assertNotNull(generationResult.getMnemonic());
+    assertNotNull(generationResult.getDerivationPath());
 
-        Wallet recreatedWallet = new Wallet(generationResult.getMnemonic(), generationResult.getDerivationPath());
+    Wallet recreatedWallet = new Wallet(generationResult.getMnemonic(), generationResult.getDerivationPath());
 
-        assertEquals(generationResult.getWallet().getAddress(), recreatedWallet.getAddress());
-        assertEquals(generationResult.getWallet().getPublicKey(), recreatedWallet.getPublicKey());
-        assertEquals(generationResult.getWallet().getPrivateKey(), recreatedWallet.getPrivateKey());
-    }
+    assertEquals(generationResult.getWallet().getAddress(), recreatedWallet.getAddress());
+    assertEquals(generationResult.getWallet().getPublicKey(), recreatedWallet.getPublicKey());
+    assertEquals(generationResult.getWallet().getPrivateKey(), recreatedWallet.getPrivateKey());
+  }
 
-    @Test
-    public void testGenerateWalletFromMnemonicNoDerivationPath() throws XRPException {
-        String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-        Wallet wallet = new Wallet(mnemonic, null);
+  @Test
+  public void testGenerateWalletFromMnemonicNoDerivationPath() throws XRPException {
+    String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    Wallet wallet = new Wallet(mnemonic, null);
 
-        assertEquals(wallet.getPublicKey(), "031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE");
-        assertEquals(wallet.getPrivateKey(), "0090802A50AA84EFB6CDB225F17C27616EA94048C179142FECF03F4712A07EA7A4");
-        assertEquals(wallet.getAddress(), "XVMFQQBMhdouRqhPMuawgBMN1AVFTofPAdRsXG5RkPtUPNQ");
-    }
+    assertEquals(wallet.getPublicKey(), "031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE");
+    assertEquals(wallet.getPrivateKey(), "0090802A50AA84EFB6CDB225F17C27616EA94048C179142FECF03F4712A07EA7A4");
+    assertEquals(wallet.getAddress(), "XVMFQQBMhdouRqhPMuawgBMN1AVFTofPAdRsXG5RkPtUPNQ");
+  }
 
-    @Test
-    public void testGenerateMainNetWalletFromMnemonicDerivationPath0() throws XRPException {
-        String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-        String derivationPath = "m/44'/144'/0'/0/0";
-        Wallet wallet = new Wallet(mnemonic, derivationPath);
+  @Test
+  public void testGenerateMainNetWalletFromMnemonicDerivationPath0() throws XRPException {
+    String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    String derivationPath = "m/44'/144'/0'/0/0";
+    Wallet wallet = new Wallet(mnemonic, derivationPath);
 
-        assertEquals(wallet.getPublicKey(), "031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE");
-        assertEquals(wallet.getPrivateKey(), "0090802A50AA84EFB6CDB225F17C27616EA94048C179142FECF03F4712A07EA7A4");
-        assertEquals(wallet.getAddress(), "XVMFQQBMhdouRqhPMuawgBMN1AVFTofPAdRsXG5RkPtUPNQ");
-    }
+    assertEquals(wallet.getPublicKey(), "031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE");
+    assertEquals(wallet.getPrivateKey(), "0090802A50AA84EFB6CDB225F17C27616EA94048C179142FECF03F4712A07EA7A4");
+    assertEquals(wallet.getAddress(), "XVMFQQBMhdouRqhPMuawgBMN1AVFTofPAdRsXG5RkPtUPNQ");
+  }
 
-    @Test
-    public void testGenerateTestNetWalletFromMnemonicDerivationPath0() throws XRPException {
-        String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-        String derivationPath = "m/44'/144'/0'/0/0";
-        Wallet wallet = new Wallet(mnemonic, derivationPath, true);
+  @Test
+  public void testGenerateTestNetWalletFromMnemonicDerivationPath0() throws XRPException {
+    String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    String derivationPath = "m/44'/144'/0'/0/0";
+    Wallet wallet = new Wallet(mnemonic, derivationPath, true);
 
-        assertEquals(wallet.getPublicKey(), "031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE");
-        assertEquals(wallet.getPrivateKey(), "0090802A50AA84EFB6CDB225F17C27616EA94048C179142FECF03F4712A07EA7A4");
-        assertEquals(wallet.getAddress(), "TVHLFWLKvbMv1LFzd6FA2Bf9MPpcy4mRto4VFAAxLuNpvdW");
-    }
+    assertEquals(wallet.getPublicKey(), "031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE");
+    assertEquals(wallet.getPrivateKey(), "0090802A50AA84EFB6CDB225F17C27616EA94048C179142FECF03F4712A07EA7A4");
+    assertEquals(wallet.getAddress(), "TVHLFWLKvbMv1LFzd6FA2Bf9MPpcy4mRto4VFAAxLuNpvdW");
+  }
 
-    @Test
-    public void testGenerateWalletFromMnemonicDerivationPath1() throws XRPException {
-        String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-        String derivationPath = "m/44'/144'/0'/0/1";
-        Wallet wallet = new Wallet(mnemonic, derivationPath);
+  @Test
+  public void testGenerateWalletFromMnemonicDerivationPath1() throws XRPException {
+    String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    String derivationPath = "m/44'/144'/0'/0/1";
+    Wallet wallet = new Wallet(mnemonic, derivationPath);
 
-        assertEquals(wallet.getPublicKey(), "038BF420B5271ADA2D7479358FF98A29954CF18DC25155184AEAD05796DA737E89");
-        assertEquals(wallet.getPrivateKey(), "000974B4CFE004A2E6C4364CBF3510A36A352796728D0861F6B555ED7E54A70389");
-        assertEquals(wallet.getAddress(), "X7uRz9jfzHUFEjZTZ7rMVzFuTGZTHWcmkKjvGkNqVbfMhca");
-    }
+    assertEquals(wallet.getPublicKey(), "038BF420B5271ADA2D7479358FF98A29954CF18DC25155184AEAD05796DA737E89");
+    assertEquals(wallet.getPrivateKey(), "000974B4CFE004A2E6C4364CBF3510A36A352796728D0861F6B555ED7E54A70389");
+    assertEquals(wallet.getAddress(), "X7uRz9jfzHUFEjZTZ7rMVzFuTGZTHWcmkKjvGkNqVbfMhca");
+  }
 
-    @Test
-    public void testGenerateWalletFromMnemonicInvalidDerivationPath() throws XRPException {
-        expectedException.expect(XRPException.class);
-        String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-        String derivationPath = "invalid_path";
-        new Wallet(mnemonic, derivationPath);
-    }
+  @Test
+  public void testGenerateWalletFromMnemonicInvalidDerivationPath() throws XRPException {
+    expectedException.expect(XRPException.class);
+    String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    String derivationPath = "invalid_path";
+    new Wallet(mnemonic, derivationPath);
+  }
 
-    @Test
-    public void testGenerateWalletFromMnemonicInvalidMnemonic() throws XRPException {
-        expectedException.expect(XRPException.class);
-        String mnemonic = "xrp xrp xrp xrp xrp xrp xrp xrp xrp xrp xrp xrp";
-        String derivationPath = "m/44'/144'/0'/0/1";
-        new Wallet(mnemonic, derivationPath);
-    }
+  @Test
+  public void testGenerateWalletFromMnemonicInvalidMnemonic() throws XRPException {
+    expectedException.expect(XRPException.class);
+    String mnemonic = "xrp xrp xrp xrp xrp xrp xrp xrp xrp xrp xrp xrp";
+    String derivationPath = "m/44'/144'/0'/0/1";
+    new Wallet(mnemonic, derivationPath);
+  }
 
-    @Test
-    public void testGenerateWalletFromKeys() throws XRPException {
-        // GIVEN a set of well formed keys.
-        String publicKey = "031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE";
-        String privateKey = "0090802A50AA84EFB6CDB225F17C27616EA94048C179142FECF03F4712A07EA7A4";
+  @Test
+  public void testGenerateWalletFromKeys() throws XRPException {
+    // GIVEN a set of well formed keys.
+    String publicKey = "031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE";
+    String privateKey = "0090802A50AA84EFB6CDB225F17C27616EA94048C179142FECF03F4712A07EA7A4";
 
-        // WHEN a wallet is generated THEN it is constructed successfully.
-        assertNotNull(Wallet.walletFromKeys(publicKey, privateKey, false));
-    }
+    // WHEN a wallet is generated THEN it is constructed successfully.
+    assertNotNull(Wallet.walletFromKeys(publicKey, privateKey, false));
+  }
 
-    @Test
-    public void testSign() throws XRPException {
-        String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-        String derivationPath = "m/44'/144'/0'/0/0";
-        Wallet wallet = new Wallet(mnemonic, derivationPath);
+  @Test
+  @SuppressWarnings("checkstyle:LineLength")
+  public void testSign() throws XRPException {
+    String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    String derivationPath = "m/44'/144'/0'/0/0";
+    Wallet wallet = new Wallet(mnemonic, derivationPath);
 
-        String result = wallet.sign("74657374206d657373616765");
-        assertEquals(result, "3045022100E10177E86739A9C38B485B6AA04BF2B9AA00E79189A1132E7172B70F400ED1170220566BD64AA3F01DDE8D99DFFF0523D165E7DD2B9891ABDA1944E2F3A52CCCB83A");
-    }
+    String result = wallet.sign("74657374206d657373616765");
+    assertEquals(result, "3045022100E10177E86739A9C38B485B6AA04BF2B9AA00E79189A1132E7172B70F400ED1170220566BD64AA3F01DDE8D99DFFF0523D165E7DD2B9891ABDA1944E2F3A52CCCB83A");
+  }
 
-    @Test
-    public void testSignInvalidHex() throws XRPException {
-        expectedException.expect(XRPException.class);
-        String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-        String derivationPath = "m/44'/144'/0'/0/0";
-        Wallet wallet = new Wallet(mnemonic, derivationPath);
+  @Test
+  public void testSignInvalidHex() throws XRPException {
+    expectedException.expect(XRPException.class);
+    String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    String derivationPath = "m/44'/144'/0'/0/0";
+    Wallet wallet = new Wallet(mnemonic, derivationPath);
 
-        wallet.sign("xrp");
-    }
+    wallet.sign("xrp");
+  }
 
-    @Test
-    public void testVerify() throws XRPException {
-        String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-        String derivationPath = "m/44'/144'/0'/0/0";
-        Wallet wallet = new Wallet(mnemonic, derivationPath);
+  @Test
+  @SuppressWarnings("checkstyle:LineLength")
+  public void testVerify() throws XRPException {
+    String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    String derivationPath = "m/44'/144'/0'/0/0";
+    Wallet wallet = new Wallet(mnemonic, derivationPath);
 
-        String message = "74657374206d657373616765";
-        String signature = "3045022100E10177E86739A9C38B485B6AA04BF2B9AA00E79189A1132E7172B70F400ED1170220566BD64AA3F01DDE8D99DFFF0523D165E7DD2B9891ABDA1944E2F3A52CCCB83A";
+    String message = "74657374206d657373616765";
+    String signature = "3045022100E10177E86739A9C38B485B6AA04BF2B9AA00E79189A1132E7172B70F400ED1170220566BD64AA3F01DDE8D99DFFF0523D165E7DD2B9891ABDA1944E2F3A52CCCB83A";
 
-        assertTrue(wallet.verify(message, signature));
-    }
+    assertTrue(wallet.verify(message, signature));
+  }
 
-    @Test
-    public void testVerifyInvalidSignature() throws XRPException {
-        String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-        String derivationPath = "m/44'/144'/0'/0/0";
-        Wallet wallet = new Wallet(mnemonic, derivationPath);
+  @Test
+  public void testVerifyInvalidSignature() throws XRPException {
+    String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    String derivationPath = "m/44'/144'/0'/0/0";
+    Wallet wallet = new Wallet(mnemonic, derivationPath);
 
-        String message = "74657374206d657373616765";
-        String signature = "DEADBEEF";
+    String message = "74657374206d657373616765";
+    String signature = "DEADBEEF";
 
-        assertFalse(wallet.verify(message, signature));
-    }
+    assertFalse(wallet.verify(message, signature));
+  }
 
-    @Test
-    public void testVerifyBadMessage() throws XRPException {
-        String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-        String derivationPath = "m/44'/144'/0'/0/0";
-        Wallet wallet = new Wallet(mnemonic, derivationPath);
+  @Test
+  @SuppressWarnings("checkstyle:LineLength")
+  public void testVerifyBadMessage() throws XRPException {
+    String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    String derivationPath = "m/44'/144'/0'/0/0";
+    Wallet wallet = new Wallet(mnemonic, derivationPath);
 
-        String message = "xrp";
-        String signature = "3045022100E10177E86739A9C38B485B6AA04BF2B9AA00E79189A1132E7172B70F400ED1170220566BD64AA3F01DDE8D99DFFF0523D165E7DD2B9891ABDA1944E2F3A52CCCB83A";
+    String message = "xrp";
+    String signature = "3045022100E10177E86739A9C38B485B6AA04BF2B9AA00E79189A1132E7172B70F400ED1170220566BD64AA3F01DDE8D99DFFF0523D165E7DD2B9891ABDA1944E2F3A52CCCB83A";
 
-        assertFalse(wallet.verify(message, signature));
-    }
+    assertFalse(wallet.verify(message, signature));
+  }
 
-    @Test
-    public void testSignAndVerifyEmptyString() throws XRPException {
-        String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-        String derivationPath = "m/44'/144'/0'/0/0";
-        Wallet wallet = new Wallet(mnemonic, derivationPath);
+  @Test
+  public void testSignAndVerifyEmptyString() throws XRPException {
+    String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    String derivationPath = "m/44'/144'/0'/0/0";
+    Wallet wallet = new Wallet(mnemonic, derivationPath);
 
-        String message = "";
-        String signature = wallet.sign(message);
+    String message = "";
+    String signature = wallet.sign(message);
 
-        assertTrue(wallet.verify(message, signature));
-    }
+    assertTrue(wallet.verify(message, signature));
+  }
 
-    @Test
-    public void testVerifyEmptyStringBadSignature() throws XRPException {
-        String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-        String derivationPath = "m/44'/144'/0'/0/0";
-        Wallet wallet = new Wallet(mnemonic, derivationPath);
+  @Test
+  public void testVerifyEmptyStringBadSignature() throws XRPException {
+    String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    String derivationPath = "m/44'/144'/0'/0/0";
+    Wallet wallet = new Wallet(mnemonic, derivationPath);
 
-        String message = "";
-        String signature = "DEADBEEF";
+    String message = "";
+    String signature = "DEADBEEF";
 
-        assertFalse(wallet.verify(message, signature));
-    }
+    assertFalse(wallet.verify(message, signature));
+  }
 }

--- a/src/test/java/io/xpring/xrpl/XRPClientIntegrationTests.java
+++ b/src/test/java/io/xpring/xrpl/XRPClientIntegrationTests.java
@@ -13,63 +13,75 @@ import java.util.List;
 /**
  * Integration tests for Xpring4J.
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class XRPClientIntegrationTests {
-    /** The rippled XRPClient under test. */
-    private XRPClient xrpClient;
+  /**
+   * The rippled XRPClient under test.
+   */
+  private XRPClient xrpClient;
 
-    /** The gRPC URL */
-    private String GRPC_URL = "test.xrp.xpring.io:50051";
+  /**
+   * The gRPC URL.
+   */
+  private static final String GRPC_URL = "test.xrp.xpring.io:50051";
 
-    /** An address on the XRP Ledger. */
-    private static final String XRPL_ADDRESS = "XVwDxLQ4SN9pEBQagTNHwqpFkPgGppXqrMoTmUcSKdCtcK5";
+  /**
+   * An address on the XRP Ledger.
+   */
+  private static final String XRPL_ADDRESS = "XVwDxLQ4SN9pEBQagTNHwqpFkPgGppXqrMoTmUcSKdCtcK5";
 
-    /** The seed for a wallet with funds on the XRP Ledger test net. */
-    private static final String WALLET_SEED = "snYP7oArxKepd3GPDcrjMsJYiJeJB";
+  /**
+   * The seed for a wallet with funds on the XRP Ledger test net.
+   */
+  private static final String WALLET_SEED = "snYP7oArxKepd3GPDcrjMsJYiJeJB";
 
-    /** Drops of XRP to send. */
-    private static final BigInteger AMOUNT = new BigInteger("1");
+  /**
+   * Drops of XRP to send.
+   */
+  private static final BigInteger AMOUNT = new BigInteger("1");
 
-    @Before
-    public void setUp() throws Exception {
-        this.xrpClient = new XRPClient(GRPC_URL, XRPLNetwork.TEST);
-    }
+  @Before
+  public void setUp() throws Exception {
+    this.xrpClient = new XRPClient(GRPC_URL, XRPLNetwork.TEST);
+  }
 
-    @Test
-    public void getBalanceTest() throws XRPException {
-        BigInteger balance = xrpClient.getBalance(XRPL_ADDRESS);
-        assertThat(balance).isGreaterThan(BigInteger.ONE).withFailMessage("Balance should have been positive");
-    }
+  @Test
+  public void getBalanceTest() throws XRPException {
+    BigInteger balance = xrpClient.getBalance(XRPL_ADDRESS);
+    assertThat(balance).isGreaterThan(BigInteger.ONE).withFailMessage("Balance should have been positive");
+  }
 
-    @Test
-    public void getPaymentStatusTest() throws XRPException {
-        // GIVEN a hash of a payment transaction.
-        Wallet wallet = new Wallet(WALLET_SEED);
-        String transactionHash = xrpClient.send(AMOUNT, XRPL_ADDRESS, wallet);
+  @Test
+  public void getPaymentStatusTest() throws XRPException {
+    // GIVEN a hash of a payment transaction.
+    Wallet wallet = new Wallet(WALLET_SEED);
+    String transactionHash = xrpClient.send(AMOUNT, XRPL_ADDRESS, wallet);
 
-        // WHEN the transaction status is retrieved.
-        TransactionStatus transactionStatus = xrpClient.getPaymentStatus(transactionHash);
+    // WHEN the transaction status is retrieved.
+    TransactionStatus transactionStatus = xrpClient.getPaymentStatus(transactionHash);
 
-        // THEN the status is 'succeeded'.
-        assertThat(transactionStatus).isEqualTo(TransactionStatus.SUCCEEDED);
-    }
+    // THEN the status is 'succeeded'.
+    assertThat(transactionStatus).isEqualTo(TransactionStatus.SUCCEEDED);
+  }
 
-    @Test
-    public void sendXRPTest() throws XRPException {
-        Wallet wallet = new Wallet(WALLET_SEED);
+  @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+  @Test
+  public void sendXRPTest() throws XRPException {
+    Wallet wallet = new Wallet(WALLET_SEED);
 
-        String transactionHash = xrpClient.send(AMOUNT, XRPL_ADDRESS, wallet);
-        assertThat(transactionHash).isNotNull();
-    }
+    String transactionHash = xrpClient.send(AMOUNT, XRPL_ADDRESS, wallet);
+    assertThat(transactionHash).isNotNull();
+  }
 
-    @Test
-    public void accountExistsTest() throws XRPException {
-        boolean exists = xrpClient.accountExists(XRPL_ADDRESS);
-        assertThat(exists).isEqualTo(true);
-    }
+  @Test
+  public void accountExistsTest() throws XRPException {
+    boolean exists = xrpClient.accountExists(XRPL_ADDRESS);
+    assertThat(exists).isEqualTo(true);
+  }
 
-    @Test
-    public void paymentHistoryTest() throws XRPException {
-        List<XRPTransaction> paymentHistory = xrpClient.paymentHistory(XRPL_ADDRESS);
-        assertThat(paymentHistory.size()).isGreaterThan(0);
-    }
+  @Test
+  public void paymentHistoryTest() throws XRPException {
+    List<XRPTransaction> paymentHistory = xrpClient.paymentHistory(XRPL_ADDRESS);
+    assertThat(paymentHistory.size()).isGreaterThan(0);
+  }
 }

--- a/src/test/java/io/xpring/xrpl/fakes/FakeWallet.java
+++ b/src/test/java/io/xpring/xrpl/fakes/FakeWallet.java
@@ -2,56 +2,57 @@ package io.xpring.xrpl.fakes;
 
 import io.xpring.xrpl.Wallet;
 import io.xpring.xrpl.XRPException;
-import io.xpring.xrpl.javascript.JavaScriptWallet;
 import io.xpring.xrpl.javascript.JavaScriptWalletFactory;
 
 /**
  * A fake {@link Wallet} which always produces the given signature.
  */
 public class FakeWallet extends Wallet {
-    /**
-    * A public key to default to.
-    */
-    public static final String DEFAULT_PUBLIC_KEY = "031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE";
+  /**
+   * A public key to default to.
+   */
+  public static final String DEFAULT_PUBLIC_KEY = "031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE";
 
-    /**
-     * A private key to default to.
-     */
-    public static final String DEFAULT_PRIVATE_KEY = "0090802A50AA84EFB6CDB225F17C27616EA94048C179142FECF03F4712A07EA7A4";
+  /**
+   * A private key to default to.
+   */
+  public static final String DEFAULT_PRIVATE_KEY = "0090802A50AA84EFB6CDB225F17C27616EA94048C179142FECF03F4712A07EA7A4";
 
-    /** The signature that this wallet will always produce. */
-    private String signature;
+  /**
+   * The signature that this wallet will always produce.
+   */
+  private String signature;
 
-    /**
-     * Initialize a wallet which will always produce the same signature when asked to sign inputs.
-     *
-     * The wallet will use DEFAULT_PUBLIC_KEY and DEFAULT_PRIVATE_KEY as a set of keys.
-     *
-     * @param signature The signature this wallet will produce.
-     */
-    public FakeWallet(String signature) throws XRPException {
-        this(signature, DEFAULT_PUBLIC_KEY, DEFAULT_PRIVATE_KEY);
-    }
+  /**
+   * Initialize a wallet which will always produce the same signature when asked to sign inputs.
+   * <p>
+   * The wallet will use DEFAULT_PUBLIC_KEY and DEFAULT_PRIVATE_KEY as a set of keys.
+   * </p>
+   * @param signature The signature this wallet will produce.
+   */
+  public FakeWallet(String signature) throws XRPException {
+    this(signature, DEFAULT_PUBLIC_KEY, DEFAULT_PRIVATE_KEY);
+  }
 
-    /**
-     * Initialize a wallet which will always produce the same signature when asked to sign inputs.
-     *
-     * @param signature The signature this wallet will produce.
-     * @param publicKey A hex encoded string representing a public key.
-     * @param privateKey A hex encoded string representing a private key.
-     */
-    public FakeWallet(String signature, String publicKey, String privateKey) throws XRPException {
-        super(JavaScriptWalletFactory.get().walletFromKeys(publicKey, privateKey, true));
-        this.signature = signature;
-    }
+  /**
+   * Initialize a wallet which will always produce the same signature when asked to sign inputs.
+   *
+   * @param signature  The signature this wallet will produce.
+   * @param publicKey  A hex encoded string representing a public key.
+   * @param privateKey A hex encoded string representing a private key.
+   */
+  public FakeWallet(String signature, String publicKey, String privateKey) throws XRPException {
+    super(JavaScriptWalletFactory.get().walletFromKeys(publicKey, privateKey, true));
+    this.signature = signature;
+  }
 
-    /**
-     * Return a fake signature for any input.
-     *
-     * @param hex The hex to sign.
-     */
-    @Override
-    public String sign(String hex) {
-        return this.signature;
-    }
+  /**
+   * Return a fake signature for any input.
+   *
+   * @param hex The hex to sign.
+   */
+  @Override
+  public String sign(String hex) {
+    return this.signature;
+  }
 }

--- a/src/test/java/io/xpring/xrpl/helpers/XRPTestUtils.java
+++ b/src/test/java/io/xpring/xrpl/helpers/XRPTestUtils.java
@@ -11,35 +11,36 @@ import java.util.List;
 /**
  * Convenience class for utility functions used in test cases for XRPClient infrastructure.
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class XRPTestUtils {
-    /**
-     * Converts a GetAccountTransactionHistoryResponse protocol buffer object into a list of XRPTransaction objects,
-     * filtered only for PAYMENT type transactions.
-     *
-     * @param transactionHistoryResponse protocol buffer object containing an array of GetTransactionResponse objects
-     */
-    public static List<XRPTransaction> transactionHistoryToPaymentsList(
-            GetAccountTransactionHistoryResponse transactionHistoryResponse) {
-        List<GetTransactionResponse> getTransactionResponses = transactionHistoryResponse.getTransactionsList();
+  /**
+   * Converts a GetAccountTransactionHistoryResponse protocol buffer object into a list of XRPTransaction objects,
+   * filtered only for PAYMENT type transactions.
+   *
+   * @param transactionHistoryResponse protocol buffer object containing an array of GetTransactionResponse objects
+   */
+  public static List<XRPTransaction> transactionHistoryToPaymentsList(
+      GetAccountTransactionHistoryResponse transactionHistoryResponse) {
+    List<GetTransactionResponse> getTransactionResponses = transactionHistoryResponse.getTransactionsList();
 
-        // Filter transactions to payments only and convert them to XRPTransactions.
-        // If a payment transaction fails conversion, throw an error.
-        List<XRPTransaction> payments = new ArrayList<XRPTransaction>();
-        for (GetTransactionResponse transactionResponse : getTransactionResponses) {
-            Transaction transaction = transactionResponse.getTransaction();
-            switch (transaction.getTransactionDataCase()) {
-                case PAYMENT: {
-                    XRPTransaction xrpTransaction = XRPTransaction.from(transaction);
-                    if (xrpTransaction != null) {
-                        payments.add(xrpTransaction);
-                    }
-                    break;
-                }
-                default: {
-                    // Intentionally do nothing, non-payment type transactions are ignored.
-                }
-            }
+    // Filter transactions to payments only and convert them to XRPTransactions.
+    // If a payment transaction fails conversion, throw an error.
+    List<XRPTransaction> payments = new ArrayList<XRPTransaction>();
+    for (GetTransactionResponse transactionResponse : getTransactionResponses) {
+      Transaction transaction = transactionResponse.getTransaction();
+      switch (transaction.getTransactionDataCase()) {
+        case PAYMENT: {
+          XRPTransaction xrpTransaction = XRPTransaction.from(transaction);
+          if (xrpTransaction != null) {
+            payments.add(xrpTransaction);
+          }
+          break;
         }
-        return payments;
+        default: {
+          // Intentionally do nothing, non-payment type transactions are ignored.
+        }
+      }
     }
+    return payments;
+  }
 }


### PR DESCRIPTION
## High Level Overview of Change

We had a CheckStyle config that didn't work locally and didn't complain or verify itself. Enable that. 

Fix resulting lint errors. 

### Context of Change

I'm sorry for the long PR. There's no good way to do this in pieces. Changes introduced in code are recommended by the linter and are not changing functionality. Reviewers likely want to look at:
- `pom.xml`
- `CONTRIBUTING.md`

The configuration is:
- Run lint checks on `verify` build cycle phase (thus developers can happily run `mvn compile` or `mvn test` locally without lint errors)
- Run lint in a strict configuration that will error on warnings and errors
- CI runs `mvn install` which includes the `verify` build phase and thus runs lint

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Before: Ugly code
After: Pretty code, automatically enforced by a small computer program 

## Test Plan

CI proves that lint errors are resolved and that tests continue to pass. 
