### PR TITLE
Adds `xrpToDrops` and `dropsToXrp` to XRP/Utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `xrpToDrops` and `dropsToXrp` conversion utilities added to `io.xpring.xrpl.Utils`
 
 ## 5.0.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/io/xpring/xrpl/Utils.java
+++ b/src/main/java/io/xpring/xrpl/Utils.java
@@ -126,9 +126,9 @@ public class Utils {
    *
    * @param drops An amount of xrp expressed in units of drops.
    * @return A String representing the drops amount in units of xrp.
-   * @throws Exception if drops is in an invalid format.
+   * @throws IllegalArgumentException if drops is in an invalid format.
    */
-  public static String dropsToXrp(String drops) throws Exception {
+  public static String dropsToXrp(String drops) throws IllegalArgumentException {
     if (drops == null) {
       return null;
     }
@@ -137,10 +137,10 @@ public class Utils {
 
     Matcher dropsMatcher = dropsPattern.matcher(drops);
     if (!dropsMatcher.matches()) {
-      throw new Exception(String.format(
+      throw new IllegalArgumentException(String.format(
               "dropsToXrp: invalid value %s, should be a number matching %s.", drops, dropsRegex));
     } else if (drops.equals(".")) {
-      throw new Exception(String.format(
+      throw new IllegalArgumentException(String.format(
               "dropsToXrp: invalid value %s, should be a BigNumber or string-encoded number.", drops));
     }
 
@@ -156,7 +156,7 @@ public class Utils {
     // This should never happen; the value has already been validated above.
     // This just ensures BigDecimal did not do something unexpected.
     if (!dropsMatcher.matches()) {
-      throw new Exception(String.format(
+      throw new IllegalArgumentException(String.format(
               "dropsToXrp: failed sanity check - value %s does not match %s.", drops, dropsRegex));
     }
 
@@ -168,9 +168,9 @@ public class Utils {
    *
    * @param xrp An amount of xrp expressed in units of xrp.
    * @return A String representing an amount of xrp expressed in units of drops.
-   * @throws Exception if xrp is in invalid format.
+   * @throws IllegalArgumentException if xrp is in invalid format.
    */
-  public static String xrpToDrops(String xrp) throws Exception {
+  public static String xrpToDrops(String xrp) throws IllegalArgumentException {
     if (xrp == null) {
       return null;
     }
@@ -179,10 +179,10 @@ public class Utils {
 
     Matcher xrpMatcher = xrpPattern.matcher(xrp);
     if (!xrpMatcher.matches()) {
-      throw new Exception(String.format(
+      throw new IllegalArgumentException(String.format(
               "xrpToDrops: invalid value, %s should be a number matching %s.", xrp, xrpRegex));
     } else if (xrp.equals(".")) {
-      throw new Exception(String.format(
+      throw new IllegalArgumentException(String.format(
               "xrpToDrops: invalid value, %s should be a BigDecimal or string-encoded number.", xrp));
     }
 
@@ -195,13 +195,13 @@ public class Utils {
     // validated above. This just ensures BigDecimal did not do
     // something unexpected.
     if (!xrpMatcher.matches()) {
-      throw new Exception(String.format(
+      throw new IllegalArgumentException(String.format(
               "xrpToDrops: failed sanity check - value %s does not match %s.", xrp, xrpRegex));
     }
 
     String[] components = xrp.split("[.]");
     if (components.length > 2) {
-      throw new Exception(String.format(
+      throw new IllegalArgumentException(String.format(
               "xrpToDrops: failed sanity check - value %s has too many decimal points.", xrp));
     }
     String fraction = "0";
@@ -209,7 +209,7 @@ public class Utils {
       fraction = components[1];
     }
     if (fraction.length() > 6) {
-      throw new Exception(String.format("xrpToDrops: value %s has too many decimal places.", xrp));
+      throw new IllegalArgumentException(String.format("xrpToDrops: value %s has too many decimal places.", xrp));
     }
     return new BigDecimal(xrp)
             .multiply(new BigDecimal(1000000.0))

--- a/src/main/java/io/xpring/xrpl/Utils.java
+++ b/src/main/java/io/xpring/xrpl/Utils.java
@@ -128,7 +128,7 @@ public class Utils {
    * @return A String representing the drops amount in units of XRP.
    * @throws IllegalArgumentException if drops is in an invalid format.
    */
-  public static String dropsToXrp(String drops) throws IllegalArgumentException {
+  public static String dropsToXrp(String drops) throws XRPException {
     Preconditions.checkNotNull(drops);
 
     String dropsRegex = "^-?[0-9]*['.']?[0-9]*$";
@@ -136,10 +136,10 @@ public class Utils {
     Matcher dropsMatcher = dropsPattern.matcher(drops);
 
     if (!dropsMatcher.matches()) {
-      throw new IllegalArgumentException(String.format(
+      throw new XRPException(XRPExceptionType.INVALID_INPUTS, String.format(
               "dropsToXrp: invalid value %s, should be a string-encoded number matching %s.", drops, dropsRegex));
     } else if (drops.equals(".")) {
-      throw new IllegalArgumentException(String.format(
+      throw new XRPException(XRPExceptionType.INVALID_INPUTS, String.format(
               "dropsToXrp: invalid value %s, should be a string-encoded number.", drops));
     }
 
@@ -149,17 +149,17 @@ public class Utils {
     try {
       drops = new BigDecimal(drops).toBigIntegerExact().toString(10);
     } catch (ArithmeticException exception) {     // drops are only whole units
-      throw new IllegalArgumentException(String.format("dropsToXrp: value %s must be a whole number.", drops));
+      throw new XRPException(XRPExceptionType.INVALID_INPUTS, String.format("dropsToXrp: value %s must be a whole number.", drops));
     }
 
     // This should never happen; the value has already been validated above.
     // This just ensures BigDecimal did not do something unexpected.
     if (!dropsMatcher.matches()) {
-      throw new IllegalArgumentException(String.format(
+      throw new XRPException(XRPExceptionType.INVALID_INPUTS, String.format(
               "dropsToXrp: failed sanity check - value %s does not match %s.", drops, dropsRegex));
     }
-
-    return new BigDecimal(drops).divide(new BigDecimal(1000000.0)).toPlainString();
+    Integer dropsPerXrp = 1000000;
+    return new BigDecimal(drops).divide(new BigDecimal(dropsPerXrp)).toPlainString();
   }
 
   /**
@@ -169,7 +169,7 @@ public class Utils {
    * @return A String representing an amount of XRP expressed in units of drops.
    * @throws IllegalArgumentException if xrp is in invalid format.
    */
-  public static String xrpToDrops(String xrp) throws IllegalArgumentException {
+  public static String xrpToDrops(String xrp) throws XRPException {
     Preconditions.checkNotNull(xrp);
 
     String xrpRegex = "^-?[0-9]*['.']?[0-9]*$";
@@ -177,10 +177,10 @@ public class Utils {
     Matcher xrpMatcher = xrpPattern.matcher(xrp);
 
     if (!xrpMatcher.matches()) {
-      throw new IllegalArgumentException(String.format(
+      throw new XRPException(XRPExceptionType.INVALID_INPUTS, String.format(
               "xrpToDrops: invalid value, %s should be a number matching %s.", xrp, xrpRegex));
     } else if (xrp.equals(".")) {
-      throw new IllegalArgumentException(String.format(
+      throw new XRPException(XRPExceptionType.INVALID_INPUTS, String.format(
               "xrpToDrops: invalid value, %s should be a string-encoded number.", xrp));
     }
 
@@ -191,13 +191,13 @@ public class Utils {
     // This should never happen; the value has already been validated above.
     // This just ensures BigDecimal did not do something unexpected.
     if (!xrpMatcher.matches()) {
-      throw new IllegalArgumentException(String.format(
+      throw new XRPException(XRPExceptionType.INVALID_INPUTS, String.format(
               "xrpToDrops: failed sanity check - value %s does not match %s.", xrp, xrpRegex));
     }
 
     String[] components = xrp.split("[.]");
     if (components.length > 2) {
-      throw new IllegalArgumentException(String.format(
+      throw new XRPException(XRPExceptionType.INVALID_INPUTS, String.format(
               "xrpToDrops: failed sanity check - value %s has too many decimal points.", xrp));
     }
     String fraction = "0";
@@ -205,7 +205,7 @@ public class Utils {
       fraction = components[1];
     }
     if (fraction.length() > 6) {
-      throw new IllegalArgumentException(String.format("xrpToDrops: value %s has too many decimal places.", xrp));
+      throw new XRPException(XRPExceptionType.INVALID_INPUTS, String.format("xrpToDrops: value %s has too many decimal places.", xrp));
     }
     return new BigDecimal(xrp)
             .multiply(new BigDecimal(1000000.0))

--- a/src/main/java/io/xpring/xrpl/Utils.java
+++ b/src/main/java/io/xpring/xrpl/Utils.java
@@ -136,7 +136,7 @@ public class Utils {
     if (!dropsMatcher.matches()) {
       throw new Exception(String.format(
               "dropsToXrp: invalid value %s, should be a number matching %s.", drops, dropsRegex));
-    } else if (drops == ".") {
+    } else if (drops.equals(".")) {
       throw new Exception(String.format(
               "dropsToXrp: invalid value %s, should be a BigNumber or string-encoded number.", drops));
     }
@@ -178,7 +178,7 @@ public class Utils {
     if (!xrpMatcher.matches()) {
       throw new Exception(String.format(
               "xrpToDrops: invalid value, %s should be a number matching %s.", xrp, xrpRegex));
-    } else if (xrp == ".") {
+    } else if (xrp.equals(".")) {
       throw new Exception(String.format(
               "xrpToDrops: invalid value, %s should be a BigDecimal or string-encoded number.", xrp));
     }

--- a/src/main/java/io/xpring/xrpl/Utils.java
+++ b/src/main/java/io/xpring/xrpl/Utils.java
@@ -207,8 +207,9 @@ public class Utils {
     if (fraction.length() > 6) {
       throw new XRPException(XRPExceptionType.INVALID_INPUTS, String.format("xrpToDrops: value %s has too many decimal places.", xrp));
     }
+    Integer dropsPerXrp = 1000000;
     return new BigDecimal(xrp)
-            .multiply(new BigDecimal(1000000.0))
+            .multiply(new BigDecimal(dropsPerXrp))
             .toBigInteger()
             .toString(10);
   }

--- a/src/main/java/io/xpring/xrpl/Utils.java
+++ b/src/main/java/io/xpring/xrpl/Utils.java
@@ -129,6 +129,9 @@ public class Utils {
    * @throws Exception if drops is in an invalid format.
    */
   public static String dropsToXrp(String drops) throws Exception {
+    if (drops == null) {
+      return null;
+    }
     String dropsRegex = "^-?[0-9]*['.']?[0-9]*$";
     Pattern dropsPattern = Pattern.compile(dropsRegex);
 
@@ -171,6 +174,9 @@ public class Utils {
    * @throws Exception if xrp is in invalid format.
    */
   public static String xrpToDrops(String xrp) throws Exception {
+    if (xrp == null) {
+      return null;
+    }
     String xrpRegex = "^-?[0-9]*['.']?[0-9]*$";
     Pattern xrpPattern = Pattern.compile(xrpRegex);
 

--- a/src/main/java/io/xpring/xrpl/Utils.java
+++ b/src/main/java/io/xpring/xrpl/Utils.java
@@ -149,7 +149,9 @@ public class Utils {
     try {
       drops = new BigDecimal(drops).toBigIntegerExact().toString(10);
     } catch (ArithmeticException exception) {     // drops are only whole units
-      throw new XRPException(XRPExceptionType.INVALID_INPUTS, String.format("dropsToXrp: value %s must be a whole number.", drops));
+      throw new XRPException(XRPExceptionType.INVALID_INPUTS,
+              String.format("dropsToXrp: value %s must be a whole number.", drops)
+      );
     }
 
     // This should never happen; the value has already been validated above.
@@ -205,7 +207,9 @@ public class Utils {
       fraction = components[1];
     }
     if (fraction.length() > 6) {
-      throw new XRPException(XRPExceptionType.INVALID_INPUTS, String.format("xrpToDrops: value %s has too many decimal places.", xrp));
+      throw new XRPException(XRPExceptionType.INVALID_INPUTS,
+              String.format("xrpToDrops: value %s has too many decimal places.", xrp)
+      );
     }
     Integer dropsPerXrp = 1000000;
     return new BigDecimal(xrp)

--- a/src/main/java/io/xpring/xrpl/Utils.java
+++ b/src/main/java/io/xpring/xrpl/Utils.java
@@ -1,9 +1,9 @@
 package io.xpring.xrpl;
 
+import com.google.common.base.Preconditions;
 import io.xpring.xrpl.javascript.JavaScriptLoaderException;
 import io.xpring.xrpl.javascript.JavaScriptUtils;
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -122,20 +122,19 @@ public class Utils {
   }
 
   /**
-   * Convert from units in drops to xrp.
+   * Convert from units in drops to XRP.
    *
-   * @param drops An amount of xrp expressed in units of drops.
-   * @return A String representing the drops amount in units of xrp.
+   * @param drops An amount of XRP expressed in units of drops.
+   * @return A String representing the drops amount in units of XRP.
    * @throws IllegalArgumentException if drops is in an invalid format.
    */
   public static String dropsToXrp(String drops) throws IllegalArgumentException {
-    if (drops == null) {
-      return null;
-    }
+    Preconditions.checkNotNull(drops);
+
     String dropsRegex = "^-?[0-9]*['.']?[0-9]*$";
     Pattern dropsPattern = Pattern.compile(dropsRegex);
-
     Matcher dropsMatcher = dropsPattern.matcher(drops);
+
     if (!dropsMatcher.matches()) {
       throw new IllegalArgumentException(String.format(
               "dropsToXrp: invalid value %s, should be a number matching %s.", drops, dropsRegex));
@@ -164,20 +163,19 @@ public class Utils {
   }
 
   /**
-   * Convert from units in xrp to drops.
+   * Convert from units in XRP to drops.
    *
-   * @param xrp An amount of xrp expressed in units of xrp.
-   * @return A String representing an amount of xrp expressed in units of drops.
+   * @param xrp An amount of XRP expressed in units of XRP.
+   * @return A String representing an amount of XRP expressed in units of drops.
    * @throws IllegalArgumentException if xrp is in invalid format.
    */
   public static String xrpToDrops(String xrp) throws IllegalArgumentException {
-    if (xrp == null) {
-      return null;
-    }
+    Preconditions.checkNotNull(xrp);
+
     String xrpRegex = "^-?[0-9]*['.']?[0-9]*$";
     Pattern xrpPattern = Pattern.compile(xrpRegex);
-
     Matcher xrpMatcher = xrpPattern.matcher(xrp);
+
     if (!xrpMatcher.matches()) {
       throw new IllegalArgumentException(String.format(
               "xrpToDrops: invalid value, %s should be a number matching %s.", xrp, xrpRegex));
@@ -191,9 +189,8 @@ public class Utils {
     // Important: use toPlainString() to avoid exponential notation, e.g. '1e-7'.
     xrp = new BigDecimal(xrp).stripTrailingZeros().toPlainString();
 
-    // This should never happen; the value has already been
-    // validated above. This just ensures BigDecimal did not do
-    // something unexpected.
+    // This should never happen; the value has already been validated above.
+    // This just ensures BigDecimal did not do something unexpected.
     if (!xrpMatcher.matches()) {
       throw new IllegalArgumentException(String.format(
               "xrpToDrops: failed sanity check - value %s does not match %s.", xrp, xrpRegex));

--- a/src/main/java/io/xpring/xrpl/Utils.java
+++ b/src/main/java/io/xpring/xrpl/Utils.java
@@ -144,20 +144,17 @@ public class Utils {
               "dropsToXrp: invalid value %s, should be a BigNumber or string-encoded number.", drops));
     }
 
-    // Converting to BigInteger and then back to string should remove any
-    // decimal point followed by zeros, e.g. '1.00', which is the only valid decimal
-    // representation of drops, which must be whole numbers.
+    // Converting with toBigIntegerExact() will throw an ArithmeticException if there is a fractional remainder.
+    // Drops values can be expressed as a decimal (i.e. 2.00) but still must be whole numbers.
     // Important: specify base 10 to avoid exponential notation, e.g. '1e-7'
-    drops = new BigDecimal(drops).toBigIntegerExact().toString(10);
-
-    // drops are only whole units
-    if (drops.contains(".")) {
-      throw new Exception(String.format("dropsToXrp: value %s has too many decimal places.", drops));
+    try {
+      drops = new BigDecimal(drops).toBigIntegerExact().toString(10);
+    } catch (ArithmeticException exception) {     // drops are only whole units
+      throw new IllegalArgumentException(String.format("dropsToXrp: value %s must be a whole number.", drops));
     }
 
-    // This should never happen; the value has already been
-    // validated above. This just ensures BigNumber did not do
-    // something unexpected.
+    // This should never happen; the value has already been validated above.
+    // This just ensures BigDecimal did not do something unexpected.
     if (!dropsMatcher.matches()) {
       throw new Exception(String.format(
               "dropsToXrp: failed sanity check - value %s does not match %s.", drops, dropsRegex));

--- a/src/main/java/io/xpring/xrpl/Utils.java
+++ b/src/main/java/io/xpring/xrpl/Utils.java
@@ -137,10 +137,10 @@ public class Utils {
 
     if (!dropsMatcher.matches()) {
       throw new IllegalArgumentException(String.format(
-              "dropsToXrp: invalid value %s, should be a number matching %s.", drops, dropsRegex));
+              "dropsToXrp: invalid value %s, should be a string-encoded number matching %s.", drops, dropsRegex));
     } else if (drops.equals(".")) {
       throw new IllegalArgumentException(String.format(
-              "dropsToXrp: invalid value %s, should be a BigNumber or string-encoded number.", drops));
+              "dropsToXrp: invalid value %s, should be a string-encoded number.", drops));
     }
 
     // Converting with toBigIntegerExact() will throw an ArithmeticException if there is a fractional remainder.
@@ -181,11 +181,10 @@ public class Utils {
               "xrpToDrops: invalid value, %s should be a number matching %s.", xrp, xrpRegex));
     } else if (xrp.equals(".")) {
       throw new IllegalArgumentException(String.format(
-              "xrpToDrops: invalid value, %s should be a BigDecimal or string-encoded number.", xrp));
+              "xrpToDrops: invalid value, %s should be a string-encoded number.", xrp));
     }
 
-    // Converting to BigDecimal and then back to string should remove any
-    // decimal point followed by zeros, e.g. '1.00'.
+    // Remove any trailing zeroes and convert back to String.
     // Important: use toPlainString() to avoid exponential notation, e.g. '1e-7'.
     xrp = new BigDecimal(xrp).stripTrailingZeros().toPlainString();
 

--- a/src/main/java/io/xpring/xrpl/Utils.java
+++ b/src/main/java/io/xpring/xrpl/Utils.java
@@ -126,7 +126,7 @@ public class Utils {
    *
    * @param drops An amount of XRP expressed in units of drops.
    * @return A String representing the drops amount in units of XRP.
-   * @throws IllegalArgumentException if drops is in an invalid format.
+   * @throws XRPException if drops is in an invalid format.
    */
   public static String dropsToXrp(String drops) throws XRPException {
     Preconditions.checkNotNull(drops);
@@ -169,7 +169,7 @@ public class Utils {
    *
    * @param xrp An amount of XRP expressed in units of XRP.
    * @return A String representing an amount of XRP expressed in units of drops.
-   * @throws IllegalArgumentException if xrp is in invalid format.
+   * @throws XRPException if xrp is in invalid format.
    */
   public static String xrpToDrops(String xrp) throws XRPException {
     Preconditions.checkNotNull(xrp);

--- a/src/test/java/io/xpring/xrpl/UtilsTest.java
+++ b/src/test/java/io/xpring/xrpl/UtilsTest.java
@@ -208,7 +208,7 @@ public class UtilsTest {
 
   // xrpToDrops and dropsToXrp tests =====================================================
   @Test
-  public void dropsToXrpWorksWithTypicalAmount() throws IllegalArgumentException {
+  public void dropsToXrpWorksWithTypicalAmount() throws XRPException {
     // GIVEN a typical, valid drops value, WHEN converted to xrp
     String xrp = dropsToXrp("2000000");
 
@@ -217,7 +217,7 @@ public class UtilsTest {
   }
 
   @Test
-  public void dropsToXrpWorksWithFractions() throws IllegalArgumentException {
+  public void dropsToXrpWorksWithFractions() throws XRPException {
     // GIVEN drops amounts that convert to fractional xrp amounts
     // WHEN converted to xrp THEN the conversion is as expected
     String xrp = dropsToXrp("3456789");
@@ -237,7 +237,7 @@ public class UtilsTest {
   }
 
   @Test
-  public void dropsToXrpWorksWithZero() throws IllegalArgumentException {
+  public void dropsToXrpWorksWithZero() throws XRPException {
     // GIVEN several equivalent representations of zero
     // WHEN converted to xrp, THEN the result is zero
     String xrp = dropsToXrp("0");
@@ -255,7 +255,7 @@ public class UtilsTest {
   }
 
   @Test
-  public void dropsToXrpWorksWithNegativeValues() throws IllegalArgumentException {
+  public void dropsToXrpWorksWithNegativeValues() throws XRPException {
     // GIVEN a negative drops amount
     // WHEN converted to xrp
     String xrp = dropsToXrp("-2000000");
@@ -265,7 +265,7 @@ public class UtilsTest {
   }
 
   @Test
-  public void dropsToXrpWorksWithValueEndingWithDecimalPoint() throws IllegalArgumentException {
+  public void dropsToXrpWorksWithValueEndingWithDecimalPoint() throws XRPException {
     // GIVEN a positive or negative drops amount that ends with a decimal point
     // WHEN converted to xrp THEN the conversion is successful and correct
     String xrp = dropsToXrp("2000000.");
@@ -277,25 +277,25 @@ public class UtilsTest {
 
   @Test
   public void dropsToXrpThrowsWithAnAmountWithTooManyDecimalPlaces() {
-    assertThrows("has too many decimal places", IllegalArgumentException.class, () -> dropsToXrp("1.2"));
-    assertThrows("has too many decimal places", IllegalArgumentException.class, () -> dropsToXrp("0.10"));
+    assertThrows("has too many decimal places", XRPException.class, () -> dropsToXrp("1.2"));
+    assertThrows("has too many decimal places", XRPException.class, () -> dropsToXrp("0.10"));
   }
 
   @Test
   public void dropsToXrpThrowsWithAnInvalidValue() {
     // GIVEN invalid drops values, WHEN converted to xrp, THEN an exception is thrown
-    assertThrows("invalid value", IllegalArgumentException.class, () -> dropsToXrp("FOO"));
-    assertThrows("invalid value", IllegalArgumentException.class, () -> dropsToXrp("1e-7"));
-    assertThrows("invalid value", IllegalArgumentException.class, () -> dropsToXrp("2,0"));
-    assertThrows("invalid value", IllegalArgumentException.class, () -> dropsToXrp("."));
+    assertThrows("invalid value", XRPException.class, () -> dropsToXrp("FOO"));
+    assertThrows("invalid value", XRPException.class, () -> dropsToXrp("1e-7"));
+    assertThrows("invalid value", XRPException.class, () -> dropsToXrp("2,0"));
+    assertThrows("invalid value", XRPException.class, () -> dropsToXrp("."));
   }
 
   @Test
   public void dropsToXrpThrowsWithAnAmountMoreThanOneDecimalPoint() {
     // GIVEN invalid drops values that contain more than one decimal point
     // WHEN converted to xrp THEN an exception is thrown
-    assertThrows("invalid value", IllegalArgumentException.class, () -> dropsToXrp("1.0.0"));
-    assertThrows("invalid value", IllegalArgumentException.class, () -> dropsToXrp("..."));
+    assertThrows("invalid value", XRPException.class, () -> dropsToXrp("1.0.0"));
+    assertThrows("invalid value", XRPException.class, () -> dropsToXrp("..."));
   }
 
   @Test
@@ -306,7 +306,7 @@ public class UtilsTest {
   }
 
   @Test
-  public void xrpToDropsWorksWithATypicalAmount() throws IllegalArgumentException {
+  public void xrpToDropsWorksWithATypicalAmount() throws XRPException {
     // GIVEN an xrp amount that is typical and valid
     // WHEN converted to drops
     String drops = xrpToDrops("2");
@@ -316,7 +316,7 @@ public class UtilsTest {
   }
 
   @Test
-  public void xrpToDropsWorksWithFractions() throws IllegalArgumentException {
+  public void xrpToDropsWorksWithFractions() throws XRPException {
     // GIVEN xrp amounts that are fractional
     // WHEN converted to drops THEN the conversions are successful and correct
     String drops = xrpToDrops("3.456789");
@@ -330,7 +330,7 @@ public class UtilsTest {
   }
 
   @Test
-  public void xrpToDropsWorksWithZero() throws IllegalArgumentException {
+  public void xrpToDropsWorksWithZero() throws XRPException {
     // GIVEN xrp amounts that are various equivalent representations of zero
     // WHEN converted to drops THEN the conversions are equal to zero
     String drops = xrpToDrops("0");
@@ -344,7 +344,7 @@ public class UtilsTest {
   }
 
   @Test
-  public void xrpToDropsWorksWithNegativeValues() throws IllegalArgumentException {
+  public void xrpToDropsWorksWithNegativeValues() throws XRPException {
     // GIVEN a negative xrp amount
     // WHEN converted to drops THEN the conversion is also negative
     String drops = xrpToDrops("-2");
@@ -352,7 +352,7 @@ public class UtilsTest {
   }
 
   @Test
-  public void xrpToDropsWorksWithAValueEndingWithADecimalPoint() throws IllegalArgumentException {
+  public void xrpToDropsWorksWithAValueEndingWithADecimalPoint() throws XRPException {
     // GIVEN an xrp amount that ends with a decimal point
     // WHEN converted to drops THEN the conversion is correct and successful
     String drops = xrpToDrops("2.");
@@ -365,26 +365,26 @@ public class UtilsTest {
   public void xrpToDropsThrowsWithAnAmountWithTooManyDecimalPlaces() {
     // GIVEN an xrp amount with too many decimal places
     // WHEN converted to a drops amount THEN an exception is thrown
-    assertThrows("has too many decimal places", IllegalArgumentException.class, () -> xrpToDrops("1.1234567"));
-    assertThrows("has too many decimal places", IllegalArgumentException.class, () -> xrpToDrops("0.0000001"));
+    assertThrows("has too many decimal places", XRPException.class, () -> xrpToDrops("1.1234567"));
+    assertThrows("has too many decimal places", XRPException.class, () -> xrpToDrops("0.0000001"));
   }
 
   @Test
   public void xrpToDropsThrowsWithAnInvalidValue() {
     // GIVEN xrp amounts represented as various invalid values
     // WHEN converted to drops THEN an exception is thrown
-    assertThrows("invalid value", IllegalArgumentException.class, () -> xrpToDrops("FOO"));
-    assertThrows("invalid value", IllegalArgumentException.class, () -> xrpToDrops("1e-7"));
-    assertThrows("invalid value", IllegalArgumentException.class, () -> xrpToDrops("2,0"));
-    assertThrows("invalid value", IllegalArgumentException.class, () -> xrpToDrops("."));
+    assertThrows("invalid value", XRPException.class, () -> xrpToDrops("FOO"));
+    assertThrows("invalid value", XRPException.class, () -> xrpToDrops("1e-7"));
+    assertThrows("invalid value", XRPException.class, () -> xrpToDrops("2,0"));
+    assertThrows("invalid value", XRPException.class, () -> xrpToDrops("."));
   }
 
   @Test
   public void xrpToDropsThrowsWithAnAmountMoreThanOneDecimalPoint() {
     // GIVEN an xrp amount with more than one decimal point, or all decimal points
     // WHEN converted to drops THEN an exception is thrown
-    assertThrows("invalid value", IllegalArgumentException.class, () -> xrpToDrops("1.0.0"));
-    assertThrows("invalid value", IllegalArgumentException.class, () -> xrpToDrops("..."));
+    assertThrows("invalid value", XRPException.class, () -> xrpToDrops("1.0.0"));
+    assertThrows("invalid value", XRPException.class, () -> xrpToDrops("..."));
   }
 
   @Test

--- a/src/test/java/io/xpring/xrpl/UtilsTest.java
+++ b/src/test/java/io/xpring/xrpl/UtilsTest.java
@@ -1,9 +1,12 @@
 package io.xpring.xrpl;
 
+import static io.xpring.xrpl.Utils.dropsToXrp;
+import static io.xpring.xrpl.Utils.xrpToDrops;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThrows;
 
 import org.junit.Test;
 
@@ -201,5 +204,179 @@ public class UtilsTest {
   public void testToTransactionHashInvalidTransaction() {
     String hash = Utils.toTransactionHash("xrp");
     assertNull(hash, null);
+  }
+
+  // xrpToDrops and dropsToXrp tests =====================================================
+  @Test
+  public void dropsToXrpWorksWithTypicalAmount() throws Exception {
+    // GIVEN a typical, valid drops value, WHEN converted to xrp
+    String xrp = dropsToXrp("2000000");
+
+    // THEN the conversion is as expected
+    assertEquals("2 million drops equals 2 XRP", "2", xrp);
+  }
+
+  @Test
+  public void dropsToXrpWorksWithFractions() throws Exception {
+    // GIVEN drops amounts that convert to fractional xrp amounts
+    // WHEN converted to xrp THEN the conversion is as expected
+    String xrp = dropsToXrp("3456789");
+    assertEquals("3,456,789 drops equals 3.456789 XRP","3.456789", xrp);
+
+    xrp = dropsToXrp("3400000");
+    assertEquals("3,400,000 drops equals 3.4 XRP", "3.4", xrp);
+
+    xrp = dropsToXrp("1");
+    assertEquals("1 drop equals 0.000001 XRP", "0.000001", xrp);
+
+    xrp = dropsToXrp("1.0");
+    assertEquals("1.0 drops equals 0.000001 XRP", "0.000001", xrp);
+
+    xrp = dropsToXrp("1.00");
+    assertEquals("1.00 drops equals 0.000001 XRP", "0.000001", xrp);
+  }
+
+  @Test
+  public void dropsToXrpWorksWithZero() throws Exception {
+    // GIVEN several equivalent representations of zero
+    // WHEN converted to xrp, THEN the result is zero
+    String xrp = dropsToXrp("0");
+    assertEquals("0 drops equals 0 XRP", "0", xrp);
+
+    // negative zero is equivalent to zero
+    xrp = dropsToXrp("-0");
+    assertEquals("-0 drops equals 0 XRP", "0", xrp);
+
+    xrp = dropsToXrp("0.00");
+    assertEquals("0.00 drops equals 0 XRP", "0", xrp);
+
+    xrp = dropsToXrp("000000000");
+    assertEquals("000000000 drops equals 0 XRP", "0", xrp);
+  }
+
+  @Test
+  public void dropsToXrpWorksWithNegativeValues() throws Exception {
+    // GIVEN a negative drops amount
+    // WHEN converted to xrp
+    String xrp = dropsToXrp("-2000000");
+
+    // THEN the conversion is also negative
+    assertEquals("-2 million drops equals -2 XRP", "-2", xrp);
+  }
+
+  @Test
+  public void dropsToXrpWorksWithValueEndingWithDecimalPoint() throws Exception {
+    // GIVEN a positive or negative drops amount that ends with a decimal point
+    // WHEN converted to xrp THEN the conversion is successful and correct
+    String xrp = dropsToXrp("2000000.");
+    assertEquals("2000000. drops equals 2 XRP", "2", xrp);
+
+    xrp = dropsToXrp("-2000000.");
+    assertEquals("-2000000. drops equals -2 XRP", "-2", xrp);
+  }
+
+  @Test
+  public void dropsToXrpThrowsWithAnAmountWithTooManyDecimalPlaces() {
+    assertThrows("has too many decimal places", Exception.class, () -> dropsToXrp("1.2"));
+    assertThrows("has too many decimal places", Exception.class, () -> dropsToXrp("0.10"));
+  }
+
+  @Test
+  public void dropsToXrpThrowsWithAnInvalidValue() {
+    // GIVEN invalid drops values, WHEN converted to xrp, THEN an error is thrown
+    assertThrows("invalid value", Exception.class, () -> dropsToXrp("FOO"));
+    assertThrows("invalid value", Exception.class, () -> dropsToXrp("1e-7"));
+    assertThrows("invalid value", Exception.class, () -> dropsToXrp("2,0"));
+    assertThrows("invalid value", Exception.class, () -> dropsToXrp("."));
+  }
+
+  @Test
+  public void dropsToXrpThrowsWithAnAmountMoreThanOneDecimalPoint() {
+    // GIVEN invalid drops values that contain more than one decimal point
+    // WHEN converted to xrp THEN an error is thrown
+    assertThrows("invalid value", Exception.class, () -> dropsToXrp("1.0.0"));
+    assertThrows("invalid value", Exception.class, () -> dropsToXrp("..."));
+  }
+
+  @Test
+  public void xrpToDropsWorksWithATypicalAmount() throws Exception {
+    // GIVEN an xrp amount that is typical and valid
+    // WHEN converted to drops
+    String drops = xrpToDrops("2");
+
+    // THEN the conversion is successful and correct
+    assertEquals("2 XRP equals 2 million drops", "2000000", drops);
+  }
+
+  @Test
+  public void xrpToDropsWorksWithFractions() throws Exception {
+    // GIVEN xrp amounts that are fractional
+    // WHEN converted to drops THEN the conversions are successful and correct
+    String drops = xrpToDrops("3.456789");
+    assertEquals("3.456789 XRP equals 3,456,789 drops", "3456789", drops);
+    drops = xrpToDrops("3.400000");
+    assertEquals("3.400000 XRP equals 3,400,000 drops", "3400000", drops);
+    drops = xrpToDrops("0.000001");
+    assertEquals("0.000001 XRP equals 1 drop", "1", drops);
+    drops = xrpToDrops("0.0000010");
+    assertEquals("0.0000010 XRP equals 1 drop", "1", drops);
+  }
+
+  @Test
+  public void xrpToDropsWorksWithZero() throws Exception {
+    // GIVEN xrp amounts that are various equivalent representations of zero
+    // WHEN converted to drops THEN the conversions are equal to zero
+    String drops = xrpToDrops("0");
+    assertEquals("0 XRP equals 0 drops", "0", drops);
+    drops = xrpToDrops("-0"); // negative zero is equivalent to zero
+    assertEquals("-0 XRP equals 0 drops", "0", drops);
+    drops = xrpToDrops("0.000000");
+    assertEquals("0.000000 XRP equals 0 drops", "0", drops);
+    drops = xrpToDrops("0.0000000");
+    assertEquals( "0.0000000 XRP equals 0 drops", "0", drops);
+  }
+
+  @Test
+  public void xrpToDropsWorksWithNegativeValues() throws Exception {
+    // GIVEN a negative xrp amount
+    // WHEN converted to drops THEN the conversion is also negative
+    String drops = xrpToDrops("-2");
+    assertEquals("-2 XRP equals -2 million drops", "-2000000", drops);
+  }
+
+  @Test
+  public void xrpToDropsWorksWithAValueEndingWithADecimalPoint() throws Exception {
+    // GIVEN an xrp amount that ends with a decimal point
+    // WHEN converted to drops THEN the conversion is correct and successful
+    String drops = xrpToDrops("2.");
+    assertEquals("2. XRP equals 2000000 drops", "2000000", drops);
+    drops = xrpToDrops("-2.");
+    assertEquals( "-2. XRP equals -2000000 drops", "-2000000", drops);
+  }
+
+  @Test
+  public void xrpToDropsThrowsWithAnAmountWithTooManyDecimalPlaces() {
+    // GIVEN an xrp amount with too many decimal places
+    // WHEN converted to a drops amount THEN an error is thrown
+    assertThrows("has too many decimal places", Exception.class, () -> xrpToDrops("1.1234567"));
+    assertThrows("has too many decimal places", Exception.class, () -> xrpToDrops("0.0000001"));
+  }
+
+  @Test
+  public void xrpToDropsThrowsWithAnInvalidValue() {
+    // GIVEN xrp amounts represented as various invalid values
+    // WHEN converted to drops THEN an error is thrown
+    assertThrows("invalid value", Exception.class, () -> xrpToDrops("FOO"));
+    assertThrows("invalid value", Exception.class, () -> xrpToDrops("1e-7"));
+    assertThrows("invalid value", Exception.class, () -> xrpToDrops("2,0"));
+    assertThrows("invalid value", Exception.class, () -> xrpToDrops("."));
+  }
+
+  @Test
+  public void xrpToDropsThrowsWithAnAmountMoreThanOneDecimalPoint() {
+    // GIVEN an xrp amount with more than one decimal point, or all decimal points
+    // WHEN converted to drops THEN an error is thrown
+    assertThrows("invalid value", Exception.class, () -> xrpToDrops("1.0.0"));
+    assertThrows("invalid value", Exception.class, () -> xrpToDrops("..."));
   }
 }

--- a/src/test/java/io/xpring/xrpl/UtilsTest.java
+++ b/src/test/java/io/xpring/xrpl/UtilsTest.java
@@ -208,7 +208,7 @@ public class UtilsTest {
 
   // xrpToDrops and dropsToXrp tests =====================================================
   @Test
-  public void dropsToXrpWorksWithTypicalAmount() throws Exception {
+  public void dropsToXrpWorksWithTypicalAmount() throws IllegalArgumentException {
     // GIVEN a typical, valid drops value, WHEN converted to xrp
     String xrp = dropsToXrp("2000000");
 
@@ -217,7 +217,7 @@ public class UtilsTest {
   }
 
   @Test
-  public void dropsToXrpWorksWithFractions() throws Exception {
+  public void dropsToXrpWorksWithFractions() throws IllegalArgumentException {
     // GIVEN drops amounts that convert to fractional xrp amounts
     // WHEN converted to xrp THEN the conversion is as expected
     String xrp = dropsToXrp("3456789");
@@ -237,7 +237,7 @@ public class UtilsTest {
   }
 
   @Test
-  public void dropsToXrpWorksWithZero() throws Exception {
+  public void dropsToXrpWorksWithZero() throws IllegalArgumentException {
     // GIVEN several equivalent representations of zero
     // WHEN converted to xrp, THEN the result is zero
     String xrp = dropsToXrp("0");
@@ -255,7 +255,7 @@ public class UtilsTest {
   }
 
   @Test
-  public void dropsToXrpWorksWithNegativeValues() throws Exception {
+  public void dropsToXrpWorksWithNegativeValues() throws IllegalArgumentException {
     // GIVEN a negative drops amount
     // WHEN converted to xrp
     String xrp = dropsToXrp("-2000000");
@@ -265,7 +265,7 @@ public class UtilsTest {
   }
 
   @Test
-  public void dropsToXrpWorksWithValueEndingWithDecimalPoint() throws Exception {
+  public void dropsToXrpWorksWithValueEndingWithDecimalPoint() throws IllegalArgumentException {
     // GIVEN a positive or negative drops amount that ends with a decimal point
     // WHEN converted to xrp THEN the conversion is successful and correct
     String xrp = dropsToXrp("2000000.");
@@ -277,29 +277,29 @@ public class UtilsTest {
 
   @Test
   public void dropsToXrpThrowsWithAnAmountWithTooManyDecimalPlaces() {
-    assertThrows("has too many decimal places", Exception.class, () -> dropsToXrp("1.2"));
-    assertThrows("has too many decimal places", Exception.class, () -> dropsToXrp("0.10"));
+    assertThrows("has too many decimal places", IllegalArgumentException.class, () -> dropsToXrp("1.2"));
+    assertThrows("has too many decimal places", IllegalArgumentException.class, () -> dropsToXrp("0.10"));
   }
 
   @Test
   public void dropsToXrpThrowsWithAnInvalidValue() {
     // GIVEN invalid drops values, WHEN converted to xrp, THEN an error is thrown
-    assertThrows("invalid value", Exception.class, () -> dropsToXrp("FOO"));
-    assertThrows("invalid value", Exception.class, () -> dropsToXrp("1e-7"));
-    assertThrows("invalid value", Exception.class, () -> dropsToXrp("2,0"));
-    assertThrows("invalid value", Exception.class, () -> dropsToXrp("."));
+    assertThrows("invalid value", IllegalArgumentException.class, () -> dropsToXrp("FOO"));
+    assertThrows("invalid value", IllegalArgumentException.class, () -> dropsToXrp("1e-7"));
+    assertThrows("invalid value", IllegalArgumentException.class, () -> dropsToXrp("2,0"));
+    assertThrows("invalid value", IllegalArgumentException.class, () -> dropsToXrp("."));
   }
 
   @Test
   public void dropsToXrpThrowsWithAnAmountMoreThanOneDecimalPoint() {
     // GIVEN invalid drops values that contain more than one decimal point
     // WHEN converted to xrp THEN an error is thrown
-    assertThrows("invalid value", Exception.class, () -> dropsToXrp("1.0.0"));
-    assertThrows("invalid value", Exception.class, () -> dropsToXrp("..."));
+    assertThrows("invalid value", IllegalArgumentException.class, () -> dropsToXrp("1.0.0"));
+    assertThrows("invalid value", IllegalArgumentException.class, () -> dropsToXrp("..."));
   }
 
   @Test
-  public void xrpToDropsWorksWithATypicalAmount() throws Exception {
+  public void xrpToDropsWorksWithATypicalAmount() throws IllegalArgumentException {
     // GIVEN an xrp amount that is typical and valid
     // WHEN converted to drops
     String drops = xrpToDrops("2");
@@ -309,7 +309,7 @@ public class UtilsTest {
   }
 
   @Test
-  public void xrpToDropsWorksWithFractions() throws Exception {
+  public void xrpToDropsWorksWithFractions() throws IllegalArgumentException {
     // GIVEN xrp amounts that are fractional
     // WHEN converted to drops THEN the conversions are successful and correct
     String drops = xrpToDrops("3.456789");
@@ -323,7 +323,7 @@ public class UtilsTest {
   }
 
   @Test
-  public void xrpToDropsWorksWithZero() throws Exception {
+  public void xrpToDropsWorksWithZero() throws IllegalArgumentException {
     // GIVEN xrp amounts that are various equivalent representations of zero
     // WHEN converted to drops THEN the conversions are equal to zero
     String drops = xrpToDrops("0");
@@ -337,7 +337,7 @@ public class UtilsTest {
   }
 
   @Test
-  public void xrpToDropsWorksWithNegativeValues() throws Exception {
+  public void xrpToDropsWorksWithNegativeValues() throws IllegalArgumentException {
     // GIVEN a negative xrp amount
     // WHEN converted to drops THEN the conversion is also negative
     String drops = xrpToDrops("-2");
@@ -345,7 +345,7 @@ public class UtilsTest {
   }
 
   @Test
-  public void xrpToDropsWorksWithAValueEndingWithADecimalPoint() throws Exception {
+  public void xrpToDropsWorksWithAValueEndingWithADecimalPoint() throws IllegalArgumentException {
     // GIVEN an xrp amount that ends with a decimal point
     // WHEN converted to drops THEN the conversion is correct and successful
     String drops = xrpToDrops("2.");
@@ -358,25 +358,25 @@ public class UtilsTest {
   public void xrpToDropsThrowsWithAnAmountWithTooManyDecimalPlaces() {
     // GIVEN an xrp amount with too many decimal places
     // WHEN converted to a drops amount THEN an error is thrown
-    assertThrows("has too many decimal places", Exception.class, () -> xrpToDrops("1.1234567"));
-    assertThrows("has too many decimal places", Exception.class, () -> xrpToDrops("0.0000001"));
+    assertThrows("has too many decimal places", IllegalArgumentException.class, () -> xrpToDrops("1.1234567"));
+    assertThrows("has too many decimal places", IllegalArgumentException.class, () -> xrpToDrops("0.0000001"));
   }
 
   @Test
   public void xrpToDropsThrowsWithAnInvalidValue() {
     // GIVEN xrp amounts represented as various invalid values
     // WHEN converted to drops THEN an error is thrown
-    assertThrows("invalid value", Exception.class, () -> xrpToDrops("FOO"));
-    assertThrows("invalid value", Exception.class, () -> xrpToDrops("1e-7"));
-    assertThrows("invalid value", Exception.class, () -> xrpToDrops("2,0"));
-    assertThrows("invalid value", Exception.class, () -> xrpToDrops("."));
+    assertThrows("invalid value", IllegalArgumentException.class, () -> xrpToDrops("FOO"));
+    assertThrows("invalid value", IllegalArgumentException.class, () -> xrpToDrops("1e-7"));
+    assertThrows("invalid value", IllegalArgumentException.class, () -> xrpToDrops("2,0"));
+    assertThrows("invalid value", IllegalArgumentException.class, () -> xrpToDrops("."));
   }
 
   @Test
   public void xrpToDropsThrowsWithAnAmountMoreThanOneDecimalPoint() {
     // GIVEN an xrp amount with more than one decimal point, or all decimal points
     // WHEN converted to drops THEN an error is thrown
-    assertThrows("invalid value", Exception.class, () -> xrpToDrops("1.0.0"));
-    assertThrows("invalid value", Exception.class, () -> xrpToDrops("..."));
+    assertThrows("invalid value", IllegalArgumentException.class, () -> xrpToDrops("1.0.0"));
+    assertThrows("invalid value", IllegalArgumentException.class, () -> xrpToDrops("..."));
   }
 }

--- a/src/test/java/io/xpring/xrpl/UtilsTest.java
+++ b/src/test/java/io/xpring/xrpl/UtilsTest.java
@@ -283,7 +283,7 @@ public class UtilsTest {
 
   @Test
   public void dropsToXrpThrowsWithAnInvalidValue() {
-    // GIVEN invalid drops values, WHEN converted to xrp, THEN an error is thrown
+    // GIVEN invalid drops values, WHEN converted to xrp, THEN an exception is thrown
     assertThrows("invalid value", IllegalArgumentException.class, () -> dropsToXrp("FOO"));
     assertThrows("invalid value", IllegalArgumentException.class, () -> dropsToXrp("1e-7"));
     assertThrows("invalid value", IllegalArgumentException.class, () -> dropsToXrp("2,0"));
@@ -293,9 +293,16 @@ public class UtilsTest {
   @Test
   public void dropsToXrpThrowsWithAnAmountMoreThanOneDecimalPoint() {
     // GIVEN invalid drops values that contain more than one decimal point
-    // WHEN converted to xrp THEN an error is thrown
+    // WHEN converted to xrp THEN an exception is thrown
     assertThrows("invalid value", IllegalArgumentException.class, () -> dropsToXrp("1.0.0"));
     assertThrows("invalid value", IllegalArgumentException.class, () -> dropsToXrp("..."));
+  }
+
+  @Test
+  public void dropsToXrpThrowsWithNullArgument() {
+    // GIVEN a null drops value, WHEN converted to XRP,
+    // THEN an exception is thrown
+    assertThrows("null argument", NullPointerException.class, () -> dropsToXrp(null));
   }
 
   @Test
@@ -357,7 +364,7 @@ public class UtilsTest {
   @Test
   public void xrpToDropsThrowsWithAnAmountWithTooManyDecimalPlaces() {
     // GIVEN an xrp amount with too many decimal places
-    // WHEN converted to a drops amount THEN an error is thrown
+    // WHEN converted to a drops amount THEN an exception is thrown
     assertThrows("has too many decimal places", IllegalArgumentException.class, () -> xrpToDrops("1.1234567"));
     assertThrows("has too many decimal places", IllegalArgumentException.class, () -> xrpToDrops("0.0000001"));
   }
@@ -365,7 +372,7 @@ public class UtilsTest {
   @Test
   public void xrpToDropsThrowsWithAnInvalidValue() {
     // GIVEN xrp amounts represented as various invalid values
-    // WHEN converted to drops THEN an error is thrown
+    // WHEN converted to drops THEN an exception is thrown
     assertThrows("invalid value", IllegalArgumentException.class, () -> xrpToDrops("FOO"));
     assertThrows("invalid value", IllegalArgumentException.class, () -> xrpToDrops("1e-7"));
     assertThrows("invalid value", IllegalArgumentException.class, () -> xrpToDrops("2,0"));
@@ -375,8 +382,15 @@ public class UtilsTest {
   @Test
   public void xrpToDropsThrowsWithAnAmountMoreThanOneDecimalPoint() {
     // GIVEN an xrp amount with more than one decimal point, or all decimal points
-    // WHEN converted to drops THEN an error is thrown
+    // WHEN converted to drops THEN an exception is thrown
     assertThrows("invalid value", IllegalArgumentException.class, () -> xrpToDrops("1.0.0"));
     assertThrows("invalid value", IllegalArgumentException.class, () -> xrpToDrops("..."));
+  }
+
+  @Test
+  public void xrpToDropsThrowsWithNullArgument() {
+    // GIVEN a null xrp value, WHEN converted to drops,
+    // THEN an exception is thrown
+    assertThrows("null argument", NullPointerException.class, () -> xrpToDrops(null));
   }
 }


### PR DESCRIPTION
## High Level Overview of Change
This PR adds the utility functions `xrpToDrops` and `dropsToXrp` to `XRP/xrp-utils.ts`.  These utility methods originally existed in `ripple-lib`, which is a robust and well-tested implementation that can handle either string or numeric values.  Their implementation here is a direct translation into Java.  Note, however, that the Java methods can currently only handle String arguments. Test cases are also based on the cases included in `ripple-lib` and added to `xrpl/helpers/UtilsTest`.
 
The logic in the conversions begins with a regex to determine whether the argument is a well-formed number, and includes additional checks such as (in `dropsToXrp`) that any drops amount submitted as a decimal is actually a whole number (i.e. 5.00, 0.0 etc.) and (in `xrpToDrops`) that any xrp amount submitted as a decimal doesn't contain more than 6 numbers after the decimal, as the 7th and beyond would represent a fractional amount in drops - not allowed.

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
Since this is such a common conversion, a robust implementation should be part of the SDKs. 

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->
- [x] New feature (non-breaking change which adds functionality)

## Before / After
`xrpToDrops` and `dropsToXrp` can now be imported from `xpring4j` `Utils` class
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
New test cases pulled from `ripple-lib` to explore all conversion logic.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->


## Future Tasks
<!--
For future tasks related to PR.
-->
Implement the same functionality in Swift SDK: https://app.asana.com/0/0/1173726982085828/f