### PR TITLE
Enforce Ledger Specifiers as to not use Open Ledgers

### DIFF
--- a/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
+++ b/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
@@ -238,8 +238,8 @@ public class DefaultXRPClient implements XRPClientDecorator {
     ClassicAddress classicAddress = Utils.decodeXAddress(address);
 
     AccountAddress account = AccountAddress.newBuilder().setAddress(classicAddress.address()).build();
-    //LedgerSpecifier ledgerSpecifier = LedgerSpecifier.newBuilder()
-//                                                  .setShortcut(LedgerSpecifier.Shortcut.SHORTCUT_VALIDATED).build();
+    // LedgerSpecifier ledgerSpecifier = LedgerSpecifier.newBuilder()
+    //                                               .setShortcut(LedgerSpecifier.Shortcut.SHORTCUT_VALIDATED).build();
     GetAccountTransactionHistoryRequest request = GetAccountTransactionHistoryRequest.newBuilder()
                                                                                 .setAccount(account)
                                                                                 //.setLedgerSpecifier(ledgerSpecifier)

--- a/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
+++ b/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
@@ -322,8 +322,10 @@ public class DefaultXRPClient implements XRPClientDecorator {
 
   private AccountRoot getAccountData(String xrplAccountAddress) {
     AccountAddress account = AccountAddress.newBuilder().setAddress(xrplAccountAddress).build();
+
     LedgerSpecifier ledgerSpecifier = LedgerSpecifier.newBuilder()
                                                       .setShortcut(LedgerSpecifier.Shortcut.SHORTCUT_VALIDATED).build();
+
     GetAccountInfoRequest request = GetAccountInfoRequest.newBuilder()
                                                           .setAccount(account).setLedger(ledgerSpecifier).build();
 

--- a/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
+++ b/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
@@ -238,11 +238,11 @@ public class DefaultXRPClient implements XRPClientDecorator {
     ClassicAddress classicAddress = Utils.decodeXAddress(address);
 
     AccountAddress account = AccountAddress.newBuilder().setAddress(classicAddress.address()).build();
-    // LedgerSpecifier ledgerSpecifier = LedgerSpecifier.newBuilder()
-    //                                               .setShortcut(LedgerSpecifier.Shortcut.SHORTCUT_VALIDATED).build();
+    LedgerSpecifier ledgerSpecifier = LedgerSpecifier.newBuilder()
+                                                   .setShortcut(LedgerSpecifier.Shortcut.SHORTCUT_VALIDATED).build();
     GetAccountTransactionHistoryRequest request = GetAccountTransactionHistoryRequest.newBuilder()
                                                                                 .setAccount(account)
-                                                                                //.setLedgerSpecifier(ledgerSpecifier)
+                                                                                .setLedgerSpecifier(ledgerSpecifier)
                                                                                 .build();
     GetAccountTransactionHistoryResponse transactionHistory = stub.getAccountTransactionHistory(request);
 

--- a/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
+++ b/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
@@ -24,7 +24,6 @@ import org.xrpl.rpc.v1.GetFeeRequest;
 import org.xrpl.rpc.v1.GetFeeResponse;
 import org.xrpl.rpc.v1.GetTransactionRequest;
 import org.xrpl.rpc.v1.GetTransactionResponse;
-import org.xrpl.rpc.v1.LedgerRange;
 import org.xrpl.rpc.v1.LedgerSpecifier;
 import org.xrpl.rpc.v1.Payment;
 import org.xrpl.rpc.v1.SubmitTransactionRequest;
@@ -240,11 +239,11 @@ public class DefaultXRPClient implements XRPClientDecorator {
 
     AccountAddress account = AccountAddress.newBuilder().setAddress(classicAddress.address()).build();
     //LedgerSpecifier ledgerSpecifier = LedgerSpecifier.newBuilder()
-    //                                                  .setShortcut(LedgerSpecifier.Shortcut.SHORTCUT_VALIDATED).build();
+//                                                  .setShortcut(LedgerSpecifier.Shortcut.SHORTCUT_VALIDATED).build();
     GetAccountTransactionHistoryRequest request = GetAccountTransactionHistoryRequest.newBuilder()
-                                                                                    .setAccount(account)
-                                                                                    //.setLedgerSpecifier(ledgerSpecifier)
-                                                                                    .build();
+                                                                                .setAccount(account)
+                                                                                //.setLedgerSpecifier(ledgerSpecifier)
+                                                                                .build();
     GetAccountTransactionHistoryResponse transactionHistory = stub.getAccountTransactionHistory(request);
 
     List<GetTransactionResponse> getTransactionResponses = transactionHistory.getTransactionsList();

--- a/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
+++ b/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
@@ -239,11 +239,11 @@ public class DefaultXRPClient implements XRPClientDecorator {
     ClassicAddress classicAddress = Utils.decodeXAddress(address);
 
     AccountAddress account = AccountAddress.newBuilder().setAddress(classicAddress.address()).build();
-    LedgerSpecifier ledgerSpecifier = LedgerSpecifier.newBuilder()
-                                                      .setShortcut(LedgerSpecifier.Shortcut.SHORTCUT_VALIDATED).build();
+    //LedgerSpecifier ledgerSpecifier = LedgerSpecifier.newBuilder()
+    //                                                  .setShortcut(LedgerSpecifier.Shortcut.SHORTCUT_VALIDATED).build();
     GetAccountTransactionHistoryRequest request = GetAccountTransactionHistoryRequest.newBuilder()
                                                                                     .setAccount(account)
-                                                                                    .setLedgerSpecifier(ledgerSpecifier)
+                                                                                    //.setLedgerSpecifier(ledgerSpecifier)
                                                                                     .build();
     GetAccountTransactionHistoryResponse transactionHistory = stub.getAccountTransactionHistory(request);
 
@@ -307,11 +307,8 @@ public class DefaultXRPClient implements XRPClientDecorator {
 
     byte[] transactionHashBytes = Utils.hexStringToByteArray(transactionHash);
     ByteString transactionHashByteString = ByteString.copyFrom(transactionHashBytes);
-    // Note, if ledger_index_min is non-zero and ledger_index_max is 0, the
-    // software will use the max validated ledger in place of ledger_index_max
-    LedgerRange ledgerRange = LedgerRange.newBuilder().setLedgerIndexMin(1).setLedgerIndexMax(0).build();
     GetTransactionRequest request = GetTransactionRequest.newBuilder()
-                                              .setHash(transactionHashByteString).setLedgerRange(ledgerRange).build();
+                                              .setHash(transactionHashByteString).build();
 
     GetTransactionResponse response = this.stub.getTransaction(request);
 

--- a/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
+++ b/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
@@ -238,11 +238,8 @@ public class DefaultXRPClient implements XRPClientDecorator {
     ClassicAddress classicAddress = Utils.decodeXAddress(address);
 
     AccountAddress account = AccountAddress.newBuilder().setAddress(classicAddress.address()).build();
-    LedgerSpecifier ledgerSpecifier = LedgerSpecifier.newBuilder()
-                                                   .setShortcut(LedgerSpecifier.Shortcut.SHORTCUT_VALIDATED).build();
     GetAccountTransactionHistoryRequest request = GetAccountTransactionHistoryRequest.newBuilder()
                                                                                 .setAccount(account)
-                                                                                .setLedgerSpecifier(ledgerSpecifier)
                                                                                 .build();
     GetAccountTransactionHistoryResponse transactionHistory = stub.getAccountTransactionHistory(request);
 


### PR DESCRIPTION
## High Level Overview of Change
Tyler S noticed in [this PR](https://github.com/xpring-eng/Xpring-JS/pull/423) that currently, when requesting account information we are not setting the ledger specifier to validated ledgers only. This means all the balances and other account information we return can include unconfirmed values. This could lead to issues where a user thinks they have received a payment when in reality that payment could be fraudulent.

NOTE: 
Setting a `LedgerSpecifer` to `Shortcut.VALIDATED` in the `GetAccountTransactionHistoryRequest` was causing integration tests to fail.  After communicating with CJ Cobb about the rippled gRPC implementation I learned (paraphrased from CJ's responses):
- `Shortcut.VALIDATED` refers to the single most recently validated ledger held by a rippled node. 
- For account info, `Shortcut.VALIDATED` should be specified. Otherwise, it will use the current ledger (potentially open or closed but not validated), which would give back a balance (amongst other info) that is not yet validated.
- For account transaction history (the rippled JSON API equivalent is account_tx), that rpc *only ever returns validated data.*  You do not need to set a ledger specifier in this case, and doing so likely causes only a partial transaction history to be returned.
- To get info on a transaction that has not yet been validated, you have to call GetTransaction (the JSON equivalent is tx).  In this case, you can only specify an (optional) ledger range, and that is only used in error handling: if the transaction is present, that rpc returns the transaction, regardless of what you pass as the ledger range. If it's not present, the response will specify whether the entire range you specified was searched.  The idea is that you can know what ledgers the server did search, since servers can have gaps in the ledger history, which could lead to false negatives.
- Finally, the behavior of rippled gRPC calls is designed to mimic the JSON API as closely as possible, which has better documentation.

Analogue in JS: https://github.com/xpring-eng/Xpring-JS/pull/423 (I will submit a revised PR for `xpring-js` that doesn't set a ledger specifier for full transaction history)
Analogue in Swift: https://github.com/xpring-eng/XpringKit/pull/204

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After
No more unconfirmed transactions impacting the user's balance or other account information.
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
CI passes
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->


## Future Tasks
<!--
For future tasks related to PR.
-->