### PR TITLE
Fix bug in X-Address Encoding

### DIFF
--- a/src/main/java/io/xpring/xrpl/javascript/JavaScriptUtils.java
+++ b/src/main/java/io/xpring/xrpl/javascript/JavaScriptUtils.java
@@ -49,13 +49,18 @@ public class JavaScriptUtils {
    * @return A new X-Address if inputs were valid, otherwise null.
    * @see <a href="https://xrpaddress.info/">https://xrpaddress.info/</a>
    */
+  @SuppressWarnings("checkstyle:LocalVariableName")
   public String encodeXAddress(ClassicAddress classicAddress) {
     Objects.requireNonNull(classicAddress);
 
     Value encodeXAddressFunction = javaScriptUtils.getMember("encodeXAddress");
 
     if (classicAddress.tag().isPresent()) {
-      Value xAddress = encodeXAddressFunction.execute(classicAddress.address(), classicAddress.tag().get(), classicAddress.isTest());
+      Value xAddress = encodeXAddressFunction.execute(
+          classicAddress.address(),
+          classicAddress.tag().get(),
+          classicAddress.isTest()
+      );
       return xAddress.asString();
     } else {
       Value undefined = JavaScriptLoader.getContext().eval("js", "undefined");

--- a/src/main/java/io/xpring/xrpl/javascript/JavaScriptUtils.java
+++ b/src/main/java/io/xpring/xrpl/javascript/JavaScriptUtils.java
@@ -54,14 +54,14 @@ public class JavaScriptUtils {
 
     Value encodeXAddressFunction = javaScriptUtils.getMember("encodeXAddress");
 
-    Value result = classicAddress.tag().isPresent()
-        ? encodeXAddressFunction.execute(classicAddress.address(), classicAddress.tag().isPresent(), classicAddress.isTest())
-        : encodeXAddressFunction.execute(
-            classicAddress.address(),
-            JavaScriptLoader.getContext().eval("js", "undefined"),
-            classicAddress.isTest()
-          );
-    return result.asString();
+    if (classicAddress.tag().isPresent()) {
+      Value xAddress = encodeXAddressFunction.execute(classicAddress.address(), classicAddress.tag().get(), classicAddress.isTest());
+      return xAddress.asString();
+    } else {
+      Value undefined = JavaScriptLoader.getContext().eval("js", "undefined");
+      Value xAddress = encodeXAddressFunction.execute(classicAddress.address(), undefined, classicAddress.isTest());
+      return xAddress.asString();
+    }
   }
 
   /**

--- a/src/main/java/io/xpring/xrpl/javascript/JavaScriptUtils.java
+++ b/src/main/java/io/xpring/xrpl/javascript/JavaScriptUtils.java
@@ -53,9 +53,14 @@ public class JavaScriptUtils {
     Objects.requireNonNull(classicAddress);
 
     Value encodeXAddressFunction = javaScriptUtils.getMember("encodeXAddress");
+
     Value result = classicAddress.tag().isPresent()
-        ? encodeXAddressFunction.execute(classicAddress.address(), classicAddress.tag().get(), classicAddress.isTest())
-        : encodeXAddressFunction.execute(classicAddress.address(), classicAddress.isTest());
+        ? encodeXAddressFunction.execute(classicAddress.address(), classicAddress.tag().isPresent(), classicAddress.isTest())
+        : encodeXAddressFunction.execute(
+            classicAddress.address(),
+            JavaScriptLoader.getContext().eval("js", "undefined"),
+            classicAddress.isTest()
+          );
     return result.asString();
   }
 

--- a/src/test/java/io/xpring/xrpl/UtilsTest.java
+++ b/src/test/java/io/xpring/xrpl/UtilsTest.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import java.util.Optional;
+
 /**
  * Unit tests for {@link Utils}.
  */
@@ -88,6 +90,22 @@ public class UtilsTest {
 
     // THEN the result is as expected.
     assertEquals(xAddress, "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUFyQVMzRrMGUZpokKH");
+  }
+
+  @Test
+  public void testEncodeXAddressWithAddressOnlyOnTestnet() {
+    // GIVEN a valid classic address without a tag on testnet.
+    ClassicAddress classicAddress = ImmutableClassicAddress.builder()
+        .address("rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1")
+        .tag(Optional.empty())
+        .isTest(true)
+        .build();
+
+    // WHEN it is encoded to an X-Address.
+    String xAddress = Utils.encodeXAddress(classicAddress);
+
+    // THEN the result is as expected.
+    assertEquals(xAddress, "TVsBZmcewpEHgajPi1jApLeYnHPJw8VrMCKS5g28oDXYiVA");
   }
 
   @SuppressWarnings("checkstyle:LocalVariableName")

--- a/src/test/java/io/xpring/xrpl/UtilsTest.java
+++ b/src/test/java/io/xpring/xrpl/UtilsTest.java
@@ -92,6 +92,7 @@ public class UtilsTest {
     assertEquals(xAddress, "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUFyQVMzRrMGUZpokKH");
   }
 
+  @SuppressWarnings("checkstyle:LocalVariableName")
   @Test
   public void testEncodeXAddressWithAddressOnlyOnTestnet() {
     // GIVEN a valid classic address without a tag on testnet.


### PR DESCRIPTION
## High Level Overview of Change

Fix bug where encoding addresses without tags returned incorrect results. 

### Context of Change

The signature of `encodeXAddress` in JavaScript is `address: string, tag: number, isTest: bool`. Without a tag, we were passing `address: string, isTest: bool` which was yielding bad results. 


### Type of Change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Added a new test case and ensured it failed. Corrected code and ensured it passed. 

## Test Plan

CI