### PR TITLE
Idiomatically Case `PayIDExceptionType` and `PayIDException`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- A new class, `PayIdException`, replaces the functionality in `PayIDException` with an idiomatically cased name.
+- A new enum, `PayIdExceptionType`, replaces the functionality in `PayIDExceptionType` with an idiomatically cased name.
+
+### Deprecated
+- `PayIDException` is deprecated. Please use the idiomatically cased `PayIdException` class instead.
+- `PayIDExceptionType` is deprecated. Please use the idiomatically cased `PayIdExceptionType` enum instead.
+
 ## 5.1.0 - May 6, 2020
 
 ### Added

--- a/src/main/java/io/xpring/payid/PayIDException.java
+++ b/src/main/java/io/xpring/payid/PayIDException.java
@@ -1,5 +1,11 @@
 package io.xpring.payid;
 
+/**
+ * Represents an exception thrown from PayID Components.
+ *
+ * @deprecated Please use the idiomatically cased `PayIdException` class instead.
+ */
+@Deprecated
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class PayIDException extends Exception {
   /**

--- a/src/main/java/io/xpring/payid/PayIDExceptionType.java
+++ b/src/main/java/io/xpring/payid/PayIDExceptionType.java
@@ -2,7 +2,10 @@ package io.xpring.payid;
 
 /**
  * Types of {@link PayIDException}s.
+ *
+ * @deprecated Please use the idiomatically cased `PayIdExceptionType` enum instead.
  */
+@Deprecated
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public enum PayIDExceptionType {
     INVALID_PAYMENT_POINTER,

--- a/src/main/java/io/xpring/payid/idiomatic/PayIdException.java
+++ b/src/main/java/io/xpring/payid/idiomatic/PayIdException.java
@@ -1,0 +1,38 @@
+package io.xpring.payid.idiomatic;
+
+/**
+ * Represents an exception thrown from PayID Components.
+ */
+public class PayIdException extends Exception {
+  /**
+   * Static exception for when a classic address is passed to an X-Address API.
+   */
+  public static PayIdException invalidPaymentPointerException =
+      new PayIdException(PayIdExceptionType.INVALID_PAYMENT_POINTER, "Invalid Payment Pointer");
+
+  /**
+   * The type of exception.
+   */
+  private PayIdExceptionType type;
+
+  /**
+   * Create a new exception.
+   *
+   * @param type    The type of exception.
+   * @param message The message to to include in the exception
+   */
+  public PayIdException(PayIdExceptionType type, String message) {
+    super(message);
+
+    this.type = type;
+  }
+
+  /**
+   * The exception type of this {@link PayIdException}.
+   *
+   * @return A {@link PayIdExceptionType} representing the exception type.
+   */
+  public PayIdExceptionType getType() {
+    return this.type;
+  }
+}

--- a/src/main/java/io/xpring/payid/idiomatic/PayIdExceptionType.java
+++ b/src/main/java/io/xpring/payid/idiomatic/PayIdExceptionType.java
@@ -1,0 +1,12 @@
+package io.xpring.payid.idiomatic;
+
+/**
+ * Types of {@link PayIdException}s.
+ */
+public enum PayIdExceptionType {
+    INVALID_PAYMENT_POINTER,
+    MAPPING_NOT_FOUND,
+    UNEXPECTED_RESPONSE,
+    UNIMPLEMENTED,
+    UNKNOWN;
+}


### PR DESCRIPTION
## High Level Overview of Change

Begin recasing PayID components to be idiomatically cased. 

### Context of Change

Java prefers `Id` to `ID`. This recases the first several classes. 

Because Java only allows one public class per file and MacOS is case insensitive, we can't have these files live side by side. As such, a new package, `idiomatic` is created. We'll migrate things there, free up the original namespace and then migrate them back to avoid breaking clients.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Extra classes added

## Test Plan

CI