### PR TITLE
Fix semantics of methods for current open ledger and last validated ledger

### DIFF
--- a/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
+++ b/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
@@ -7,7 +7,24 @@ import io.grpc.StatusRuntimeException;
 import io.xpring.xrpl.model.XRPTransaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xrpl.rpc.v1.*;
+import org.xrpl.rpc.v1.AccountAddress;
+import org.xrpl.rpc.v1.AccountRoot;
+import org.xrpl.rpc.v1.CurrencyAmount;
+import org.xrpl.rpc.v1.GetAccountInfoRequest;
+import org.xrpl.rpc.v1.GetAccountInfoResponse;
+import org.xrpl.rpc.v1.GetAccountTransactionHistoryRequest;
+import org.xrpl.rpc.v1.GetAccountTransactionHistoryResponse;
+import org.xrpl.rpc.v1.GetFeeRequest;
+import org.xrpl.rpc.v1.GetFeeResponse;
+import org.xrpl.rpc.v1.GetTransactionRequest;
+import org.xrpl.rpc.v1.GetTransactionResponse;
+import org.xrpl.rpc.v1.LedgerSpecifier;
+import org.xrpl.rpc.v1.Payment;
+import org.xrpl.rpc.v1.SubmitTransactionRequest;
+import org.xrpl.rpc.v1.SubmitTransactionResponse;
+import org.xrpl.rpc.v1.Transaction;
+import org.xrpl.rpc.v1.XRPDropsAmount;
+import org.xrpl.rpc.v1.XRPLedgerAPIServiceGrpc;
 import org.xrpl.rpc.v1.Common.Account;
 import org.xrpl.rpc.v1.Common.Amount;
 import org.xrpl.rpc.v1.Common.Destination;
@@ -281,15 +298,15 @@ public class DefaultXRPClient implements XRPClientDecorator {
 
   /**
    * Retrieve the latest validated ledger sequence on the XRP Ledger.
-   *
+   * <p>
    * Note: This call will throw if the given account does not exist on the ledger at the current time. It is the
    * *caller's responsibility* to ensure this invariant is met.
-   *
+   * </p><p>
    * Note: The input address *must* be in a classic address form. Inputs are not checked to this internal method.
-   *
+   * </p><p>
    * TODO(keefertaylor): The above requirements are onerous, difficult to reason about and the logic of this method is
    * brittle. Replace this method's implementation when rippled supports a `ledger` RPC via gRPC.
-   *
+   * </p>
    * @param address An address that exists at the current time. The address is unchecked and must be a classic address.
    * @return The index of the latest validated ledger.
    * @throws XRPException If there was a problem communicating with the XRP Ledger.
@@ -300,8 +317,13 @@ public class DefaultXRPClient implements XRPClientDecorator {
     // query the account info for an account which will exist, using a shortcut for the latest validated ledger. The
     // response will contain the ledger the information was retrieved at.
     AccountAddress accountAddress = AccountAddress.newBuilder().setAddress(address).build();
-    LedgerSpecifier ledgerSpecifier = LedgerSpecifier.newBuilder().setShortcut(LedgerSpecifier.Shortcut.SHORTCUT_VALIDATED).build();
-    GetAccountInfoRequest getAccountInfoRequest = GetAccountInfoRequest.newBuilder().setAccount(accountAddress).setLedger(ledgerSpecifier).build();
+    LedgerSpecifier ledgerSpecifier = LedgerSpecifier.newBuilder()
+        .setShortcut(LedgerSpecifier.Shortcut.SHORTCUT_VALIDATED)
+        .build();
+    GetAccountInfoRequest getAccountInfoRequest = GetAccountInfoRequest.newBuilder()
+        .setAccount(accountAddress)
+        .setLedger(ledgerSpecifier)
+        .build();
 
     GetAccountInfoResponse getAccountInfoResponse = this.stub.getAccountInfo(getAccountInfoRequest);
 

--- a/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
+++ b/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
@@ -7,30 +7,13 @@ import io.grpc.StatusRuntimeException;
 import io.xpring.xrpl.model.XRPTransaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xrpl.rpc.v1.AccountAddress;
-import org.xrpl.rpc.v1.AccountRoot;
+import org.xrpl.rpc.v1.*;
 import org.xrpl.rpc.v1.Common.Account;
 import org.xrpl.rpc.v1.Common.Amount;
 import org.xrpl.rpc.v1.Common.Destination;
 import org.xrpl.rpc.v1.Common.DestinationTag;
 import org.xrpl.rpc.v1.Common.LastLedgerSequence;
 import org.xrpl.rpc.v1.Common.SigningPublicKey;
-import org.xrpl.rpc.v1.CurrencyAmount;
-import org.xrpl.rpc.v1.GetAccountInfoRequest;
-import org.xrpl.rpc.v1.GetAccountInfoResponse;
-import org.xrpl.rpc.v1.GetAccountTransactionHistoryRequest;
-import org.xrpl.rpc.v1.GetAccountTransactionHistoryResponse;
-import org.xrpl.rpc.v1.GetFeeRequest;
-import org.xrpl.rpc.v1.GetFeeResponse;
-import org.xrpl.rpc.v1.GetTransactionRequest;
-import org.xrpl.rpc.v1.GetTransactionResponse;
-import org.xrpl.rpc.v1.LedgerSpecifier;
-import org.xrpl.rpc.v1.Payment;
-import org.xrpl.rpc.v1.SubmitTransactionRequest;
-import org.xrpl.rpc.v1.SubmitTransactionResponse;
-import org.xrpl.rpc.v1.Transaction;
-import org.xrpl.rpc.v1.XRPDropsAmount;
-import org.xrpl.rpc.v1.XRPLedgerAPIServiceGrpc;
 import org.xrpl.rpc.v1.XRPLedgerAPIServiceGrpc.XRPLedgerAPIServiceBlockingStub;
 
 import java.math.BigInteger;
@@ -162,7 +145,7 @@ public class DefaultXRPClient implements XRPClientDecorator {
 
     AccountRoot accountData = this.getAccountData(sourceClassicAddress.address());
     XRPDropsAmount fee = this.getMinimumFee();
-    int lastValidatedLedgerSequence = this.getLatestValidatedLedgerSequence();
+    int openLedgerSequence = this.getOpenLedgerSequence();
 
     AccountAddress destinationAccountAddress = AccountAddress.newBuilder()
         .setAddress(destinationClassicAddress.address())
@@ -189,7 +172,7 @@ public class DefaultXRPClient implements XRPClientDecorator {
     Payment payment = paymentBuilder.build();
 
     byte[] signingPublicKeyBytes = Utils.hexStringToByteArray(sourceWallet.getPublicKey());
-    int lastLedgerSequenceInt = lastValidatedLedgerSequence + MAX_LEDGER_VERSION_OFFSET;
+    int lastLedgerSequenceInt = openLedgerSequence + MAX_LEDGER_VERSION_OFFSET;
 
     Account sourceAccount = Account.newBuilder().setValue(sourceAccountAddress).build();
     LastLedgerSequence lastLedgerSequence = LastLedgerSequence.newBuilder().setValue(lastLedgerSequenceInt).build();
@@ -292,9 +275,37 @@ public class DefaultXRPClient implements XRPClientDecorator {
     }
   }
 
-  @Override
-  public int getLatestValidatedLedgerSequence() throws XRPException {
+  public int getOpenLedgerSequence() throws XRPException {
     return this.getFeeResponse().getLedgerCurrentIndex();
+  }
+
+  /**
+   * Retrieve the latest validated ledger sequence on the XRP Ledger.
+   *
+   * Note: This call will throw if the given account does not exist on the ledger at the current time. It is the
+   * *caller's responsibility* to ensure this invariant is met.
+   *
+   * Note: The input address *must* be in a classic address form. Inputs are not checked to this internal method.
+   *
+   * TODO(keefertaylor): The above requirements are onerous, difficult to reason about and the logic of this method is
+   * brittle. Replace this method's implementation when rippled supports a `ledger` RPC via gRPC.
+   *
+   * @param address An address that exists at the current time. The address is unchecked and must be a classic address.
+   * @return The index of the latest validated ledger.
+   * @throws XRPException If there was a problem communicating with the XRP Ledger.
+   */
+  @Override
+  public int getLatestValidatedLedgerSequence(String address) throws XRPException {
+    // rippled doesn't support a gRPC call that tells us the latest validated ledger sequence. To get around this,
+    // query the account info for an account which will exist, using a shortcut for the latest validated ledger. The
+    // response will contain the ledger the information was retrieved at.
+    AccountAddress accountAddress = AccountAddress.newBuilder().setAddress(address).build();
+    LedgerSpecifier ledgerSpecifier = LedgerSpecifier.newBuilder().setShortcut(LedgerSpecifier.Shortcut.SHORTCUT_VALIDATED).build();
+    GetAccountInfoRequest getAccountInfoRequest = GetAccountInfoRequest.newBuilder().setAccount(accountAddress).setLedger(ledgerSpecifier).build();
+
+    GetAccountInfoResponse getAccountInfoResponse = this.stub.getAccountInfo(getAccountInfoRequest);
+
+    return getAccountInfoResponse.getLedgerIndex();
   }
 
   @Override

--- a/src/main/java/io/xpring/xrpl/ReliableSubmissionXRPClient.java
+++ b/src/main/java/io/xpring/xrpl/ReliableSubmissionXRPClient.java
@@ -43,14 +43,30 @@ public class ReliableSubmissionXRPClient implements XRPClientDecorator {
         );
       }
 
+      // Decode the sending address to a classic address for use in determining the last ledger sequence.
+      // An invariant of `getLatestValidatedLedgerSequence` is that the given input address (1) exists when the method
+      // is called and (2) is in a classic address form.
+      //
+      // The sending address should always exist, except in the case where it is deleted. A deletion would supersede the
+      // transaction in flight, either by:
+      // 1) Consuming the nonce sequence number of the transaction, which would effectively cancel the transaction
+      // 2) Occur after the transaction has settled which is an unlikely enough case that we ignore it.
+      //
+      // This logic is brittle and should be replaced when we have an RPC that can give us this data.
+      ClassicAddress classicAddress = Utils.decodeXAddress(sourceWallet.getAddress());
+      if (classicAddress == null) {
+        throw new XRPException(XRPExceptionType.UNKNOWN, "The source wallet reported an address which could not be decoded to a classic address");
+      }
+      String sourceClassicAddress = classicAddress.address();
+
       // Retrieve the latest ledger index.
-      int latestLedgerSequence = this.getLatestValidatedLedgerSequence();
+      int latestLedgerSequence = this.getLatestValidatedLedgerSequence(sourceClassicAddress);
 
       // Poll until the transaction is validated, or until the lastLedgerSequence has been passed.
       while (latestLedgerSequence <= lastLedgerSequence && !transactionStatus.getValidated()) {
         Thread.sleep(ledgerCloseTime);
 
-        latestLedgerSequence = this.getLatestValidatedLedgerSequence();
+        latestLedgerSequence = this.getLatestValidatedLedgerSequence(sourceClassicAddress);
         transactionStatus = this.getRawTransactionStatus(transactionHash);
       }
 
@@ -64,8 +80,8 @@ public class ReliableSubmissionXRPClient implements XRPClientDecorator {
   }
 
   @Override
-  public int getLatestValidatedLedgerSequence() throws XRPException {
-    return this.decoratedClient.getLatestValidatedLedgerSequence();
+  public int getLatestValidatedLedgerSequence(String address) throws XRPException {
+    return this.decoratedClient.getLatestValidatedLedgerSequence(address);
   }
 
   @Override

--- a/src/main/java/io/xpring/xrpl/ReliableSubmissionXRPClient.java
+++ b/src/main/java/io/xpring/xrpl/ReliableSubmissionXRPClient.java
@@ -55,7 +55,10 @@ public class ReliableSubmissionXRPClient implements XRPClientDecorator {
       // This logic is brittle and should be replaced when we have an RPC that can give us this data.
       ClassicAddress classicAddress = Utils.decodeXAddress(sourceWallet.getAddress());
       if (classicAddress == null) {
-        throw new XRPException(XRPExceptionType.UNKNOWN, "The source wallet reported an address which could not be decoded to a classic address");
+        throw new XRPException(
+            XRPExceptionType.UNKNOWN,
+            "The source wallet reported an address which could not be decoded to a classic address"
+        );
       }
       String sourceClassicAddress = classicAddress.address();
 

--- a/src/main/java/io/xpring/xrpl/XRPClientDecorator.java
+++ b/src/main/java/io/xpring/xrpl/XRPClientDecorator.java
@@ -50,15 +50,15 @@ interface XRPClientDecorator {
 
   /**
    * Retrieve the latest validated ledger sequence on the XRP Ledger.
-   *
+   * <p>
    * Note: This call will throw if the given account does not exist on the ledger at the current time. It is the
    * *caller's responsibility* to ensure this invariant is met.
-   *
+   * </p><p>
    * Note: The input address *must* be in a classic address form. Inputs are not checked to this internal method.
-   *
+   * </p><p>
    * TODO(keefertaylor): The above requirements are onerous, difficult to reason about and the logic of this method is
    * brittle. Replace this method's implementation when rippled supports a `ledger` RPC via gRPC.
-   *
+   * </p>
    * @param address An address that exists at the current time. The address is unchecked and must be a classic address.
    * @return The index of the latest validated ledger.
    * @throws XRPException If there was a problem communicating with the XRP Ledger.

--- a/src/main/java/io/xpring/xrpl/XRPClientDecorator.java
+++ b/src/main/java/io/xpring/xrpl/XRPClientDecorator.java
@@ -9,7 +9,7 @@ import java.util.List;
  * An common interface shared between XRPClient and the internal hierarchy of decorators.
  */
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
-public interface XRPClientDecorator {
+interface XRPClientDecorator {
   /**
    * Get the balance of the specified account on the XRP Ledger.
    *
@@ -51,10 +51,19 @@ public interface XRPClientDecorator {
   /**
    * Retrieve the latest validated ledger sequence on the XRP Ledger.
    *
-   * @return A long representing the sequence of the most recently validated ledger.
-   * @throws XRPException If the given inputs were invalid.
+   * Note: This call will throw if the given account does not exist on the ledger at the current time. It is the
+   * *caller's responsibility* to ensure this invariant is met.
+   *
+   * Note: The input address *must* be in a classic address form. Inputs are not checked to this internal method.
+   *
+   * TODO(keefertaylor): The above requirements are onerous, difficult to reason about and the logic of this method is
+   * brittle. Replace this method's implementation when rippled supports a `ledger` RPC via gRPC.
+   *
+   * @param address An address that exists at the current time. The address is unchecked and must be a classic address.
+   * @return The index of the latest validated ledger.
+   * @throws XRPException If there was a problem communicating with the XRP Ledger.
    */
-  int getLatestValidatedLedgerSequence() throws XRPException;
+  int getLatestValidatedLedgerSequence(String address) throws XRPException;
 
   /**
    * Retrieve the raw transaction status for the given transaction hash.

--- a/src/test/java/io/xpring/xrpl/FakeXRPClient.java
+++ b/src/test/java/io/xpring/xrpl/FakeXRPClient.java
@@ -91,7 +91,7 @@ public class FakeXRPClient implements XRPClientDecorator, XRPClientInterface {
   }
 
   @Override
-  public int getLatestValidatedLedgerSequence() throws XRPException {
+  public int getLatestValidatedLedgerSequence(String address) throws XRPException {
     if (this.latestValidatedLedgerResult.isError()) {
       throw this.latestValidatedLedgerResult.getError();
     } else {

--- a/src/test/java/io/xpring/xrpl/ReliableSubmissionXRPClientTest.java
+++ b/src/test/java/io/xpring/xrpl/ReliableSubmissionXRPClientTest.java
@@ -110,7 +110,7 @@ public class ReliableSubmissionXRPClientTest {
   @Test
   public void testGetLatestValidatedLedgerSequence() throws XRPException {
     // GIVEN a `ReliableSubmissionClient` decorating a FakeXRPClient WHEN the latest ledger sequence is retrieved
-    int latestSequence = reliableSubmissionXRPClient.getLatestValidatedLedgerSequence();
+    int latestSequence = reliableSubmissionXRPClient.getLatestValidatedLedgerSequence(XRPL_ADDRESS);
 
     // THEN the result is returned unaltered.
     assertThat(latestSequence).isEqualTo(DEFAULT_LATEST_LEDGER_VALUE);


### PR DESCRIPTION
## High Level Overview of Change

The current implementation of `getLatestValidatedLedgerSequence` returns the latest *open* ledger sequence. 

Fix this method's name and re-implement `getLatestValidatedLedgerSequence`.

Analogue in Swift: https://github.com/xpring-eng/XpringKit/pull/216

### Context of Change

There are a number of assumptions required to get `getLatestValidatedLedgerSequence` working. Namely, an address that is guaranteed to exist needs to be provided. 

I've worked with @carlhua  and @cjcobb23  on the rippled team and we are convinced that this implementation will never fail to return the latest validated ledger sequence when called from our reliable submission logic. 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Reliable submission bug is fixed. 

## Test Plan

CI