### PR TITLE
Adds `validated` and `ledgerIndex` fields to `XRPTransaction`

### DIFF
--- a/src/main/java/io/xpring/xrpl/model/XRPTransaction.java
+++ b/src/main/java/io/xpring/xrpl/model/XRPTransaction.java
@@ -163,6 +163,21 @@ public interface XRPTransaction {
   Optional<String> deliveredAmount();
 
   /**
+   * A boolean indicating whether this transaction was found on a validated ledger, and not an open or closed ledger.
+   *
+   * @return A boolean indicating whether or not this transactionw as found on a validated ledger.
+   * @see "https://xrpl.org/ledgers.html#open-closed-and-validated-ledgers"
+   */
+  boolean validated();
+
+  /**
+   * The index of the ledger on which this transaction was found.
+   *
+   * @return An integer indicating the ledger index of the ledger on which this transaction was found.
+   */
+  int ledgerIndex();
+
+  /**
    * Constructs an {@link XRPTransaction} from a {@link GetTransactionResponse}.
    *
    * @param getTransactionResponse a {@link GetTransactionResponse} (protobuf object) whose field values will be used
@@ -261,6 +276,10 @@ public interface XRPTransaction {
       }
     }
 
+    final boolean validated = getTransactionResponse.getValidated();
+
+    final int ledgerIndex = getTransactionResponse.getLedgerIndex();
+
     return XRPTransaction.builder()
         .hash(hash)
         .account(account)
@@ -278,6 +297,8 @@ public interface XRPTransaction {
         .paymentFields(paymentFields)
         .timestamp(timestamp)
         .deliveredAmount(deliveredAmount)
+        .validated(validated)
+        .ledgerIndex(ledgerIndex)
         .build();
   }
 }

--- a/src/test/java/io/xpring/xrpl/FakeXRPProtobufs.java
+++ b/src/test/java/io/xpring/xrpl/FakeXRPProtobufs.java
@@ -142,6 +142,9 @@ public class FakeXRPProtobufs {
     }
   }
 
+  static boolean testIsValidated = true;
+  static int testLedgerIndex = 1000;
+
   // VALID OBJECTS ===============================================================
 
   // Currency proto
@@ -376,6 +379,8 @@ public class FakeXRPProtobufs {
                                                                   .setDate(dateProto)
                                                                   .setMeta(metaProtoXRP)
                                                                   .setHash(testTransactionHash)
+                                                                  .setValidated(testIsValidated)
+                                                                  .setLedgerIndex(testLedgerIndex)
                                                                   .build();
 
   static GetTransactionResponse getTransactionResponsePaymentMandatoryFields =

--- a/src/test/java/io/xpring/xrpl/ProtocolBufferConversionTest.java
+++ b/src/test/java/io/xpring/xrpl/ProtocolBufferConversionTest.java
@@ -338,6 +338,8 @@ public class ProtocolBufferConversionTest {
     assertThat(xrpTransaction.paymentFields()).isEqualTo(XRPPayment.from(transactionProto.getPayment()));
     assertThat(xrpTransaction.timestamp().get()).isEqualTo(FakeXRPProtobufs.expectedTimestamp);
     assertThat(xrpTransaction.deliveredAmount().get()).isEqualTo(Long.toString(FakeXRPProtobufs.testDeliveredDrops));
+    assertThat(xrpTransaction.validated()).isEqualTo(FakeXRPProtobufs.testIsValidated);
+    assertThat(xrpTransaction.ledgerIndex()).isEqualTo(FakeXRPProtobufs.testLedgerIndex);
   }
 
   @Test


### PR DESCRIPTION
## High Level Overview of Change
This PR adds the `validated` and `ledgerIndex` fields to the `XRPTransaction` object. 
These fields come from a `GetTransactionResponse` protobuf object, which is returned by a call to `getTransaction`. 

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
This change is made in preparation for implementing a `getTransaction` method in the SDKs. The original implementation of the `XRPTransaction` class in the SDK only included the fields present in the `Transaction` protocol buffer object (which is wrapped by a `GetTransactionResponse` also containing other metadata about the transaction's outcome.) Certain of these other metadata fields have been added as-needed to the `XRPTransaction` object, and this PR takes care of the remaining fields available in `GetTransactionResponse`.

Our current approach is to combine the distinct `GetTransactionResponse` and `Transaction` protocol buffer objects into one type (`XRPTransaction`) since the metadata about the transaction's outcome is of equal importance to the specific transaction data, and while the type distinction makes sense in the context of authoring rippled, it would add unnecessary complexity in the SDK. 

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] New feature (non-breaking change which adds functionality)

## Before / After
Two additional fields available on an `XRPTransaction` object.
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
Added new test values to fake protobuf objects for conversion tests.
CI passes.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->


## Future Tasks
<!--
For future tasks related to PR.
-->
Update Swift SDK with the same changes.