### PR TITLE
Rename Additional PayID Objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- A new class, `AbstractPayId`, replaces the functionality in `AbstractPayID` with an idiomatically cased name.
+- A new interface, `PayId`, replaces the functionality in `PayID` with an idiomatically cased name.
+- A new interface, `PayIdComponents`, replaces the functionality in `PayIDComponents` with an idiomatically cased name.
+
+### Deprecated
+- `AbstractPayID` is deprecated. Please use the idiomatically cased `AbstractPayId` class instead.
+- `PayId` is deprecated. Please use the idiomatically cased `PayID` interface instead.
+- `PayIdComponents` is deprecated. Please use the idiomatically cased `PayIDComponents` interface instead.
+
 ## 5.1.1 - 2020-05-15
 
 This release contains minor deprecations of names of methods and classes to make this library more idiomatic with the wider Java ecosystem.

--- a/src/main/java/io/xpring/payid/PayID.java
+++ b/src/main/java/io/xpring/payid/PayID.java
@@ -16,6 +16,7 @@ import java.util.StringTokenizer;
  *
  * @deprecated Please use the idiomatically named `PayId` interface instead.
  */
+@Deprecated
 public interface PayID {
 
   String PAYID_SCHEME = "payid:";

--- a/src/main/java/io/xpring/payid/PayIDComponents.java
+++ b/src/main/java/io/xpring/payid/PayIDComponents.java
@@ -4,8 +4,11 @@ import org.immutables.value.Value;
 
 /**
  * Represents components of a PayID.
+ *
+ * @deprecated Please use the idiomatically named `PayIdComponents` interface instead.
  */
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+@Deprecated
 @Value.Immutable
 public interface PayIDComponents {
   /**

--- a/src/main/java/io/xpring/payid/idiomatic/AbstractPayId.java
+++ b/src/main/java/io/xpring/payid/idiomatic/AbstractPayId.java
@@ -1,4 +1,4 @@
-package io.xpring.payid;
+package io.xpring.payid.idiomatic;
 
 import static java.lang.String.format;
 
@@ -10,13 +10,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * An abstract implementation of {@link PayID} for use by Immutables.
- *
- * @deprecated Please use the idiomatically named `AbstractPayId` class instead.
+ * An abstract implementation of {@link PayId} for use by Immutables.
  */
-@Deprecated
 @Value.Immutable
-abstract class AbstractPayID implements PayID {
+abstract class AbstractPayId implements PayId {
 
   private static final String ALPHA = "a-zA-Z";
   private static final String DIGIT = "0-9";
@@ -78,12 +75,12 @@ abstract class AbstractPayID implements PayID {
   }
 
   /**
-   * Validate a PayID per the rules defined in the PayID RFC.
+   * Validate a Pay ID per the rules defined in the PayID RFC.
    *
-   * @return A normalized and valid {@link AbstractPayID}.
+   * @return A normalized and valid {@link AbstractPayId}.
    */
   @Check
-  AbstractPayID validate() {
+  AbstractPayId validate() {
 
     // Verify Account
     Preconditions.checkArgument(
@@ -100,6 +97,6 @@ abstract class AbstractPayID implements PayID {
 
   @Override
   public String toString() {
-    return PAYID_SCHEME + account() + "$" + host();
+    return PAY_ID_SCHEME + account() + "$" + host();
   }
 }

--- a/src/main/java/io/xpring/payid/idiomatic/PayId.java
+++ b/src/main/java/io/xpring/payid/idiomatic/PayId.java
@@ -1,6 +1,6 @@
-package io.xpring.payid;
+package io.xpring.payid.idiomatic;
 
-import static io.xpring.payid.AbstractPayID.upperCasePercentEncoded;
+import static io.xpring.payid.idiomatic.AbstractPayId.upperCasePercentEncoded;
 import static java.lang.String.format;
 
 import com.google.common.base.Preconditions;
@@ -13,19 +13,17 @@ import java.util.StringTokenizer;
  * A standardized identifier for payment accounts.
  *
  * @see "https://github.com/xpring-eng/rfcs/blob/master/TBD.md"
- *
- * @deprecated Please use the idiomatically named `PayId` interface instead.
  */
-public interface PayID {
+public interface PayId {
 
-  String PAYID_SCHEME = "payid:";
+  String PAY_ID_SCHEME = "payid:";
 
-  static ImmutablePayID.Builder builder() {
-    return ImmutablePayID.builder();
+  static ImmutablePayId.Builder builder() {
+    return ImmutablePayId.builder();
   }
 
   /**
-   * <p>Parses a PayId URI string into a @{code PayId}, applying normalization rules defined in the PayID RFC.</p>
+   * <p>Parses a PayId URI string into a @{code PayId}, applying normalization rules defined in the Pay ID RFC.</p>
    *
    * <p>Normalization includes the following:
    *
@@ -36,38 +34,38 @@ public interface PayID {
    *   <li>For any hex-encoded String, upper-case the Hexadecimal letters (e.g., 'f' to 'F')</li>
    * </ul>
    *
-   * @param value text of a complete PayID.
+   * @param value text of a complete Pay ID.
    *
-   * @return A valid {@link PayID}.
+   * @return A valid {@link PayId}.
    *
    * @throws NullPointerException     if {@code value} is null.
-   * @throws IllegalArgumentException if {@code value} cannot be properly parsed or has invalid characters per the PayID
-   *                                  RFC.
+   * @throws IllegalArgumentException if {@code value} cannot be properly parsed or has invalid characters per the Pay
+   *                                  ID RFC.
    */
-  static PayID of(String value) {
-    Objects.requireNonNull(value, "PayID must not be null");
-    if (value.toLowerCase(Locale.ENGLISH).startsWith(PAYID_SCHEME)) {
+  static PayId of(String value) {
+    Objects.requireNonNull(value, "Pay ID must not be null");
+    if (value.toLowerCase(Locale.ENGLISH).startsWith(PAY_ID_SCHEME)) {
       value = value.substring(6);
     } else {
-      throw new IllegalArgumentException(format("PayID `%s` must start with the 'payid:' scheme", value));
+      throw new IllegalArgumentException(format("Pay ID `%s` must start with the 'payid:' scheme", value));
     }
 
     if (!value.contains("$")) {
-      throw new IllegalArgumentException(format("PayID `%s` must contain a $", value));
+      throw new IllegalArgumentException(format("Pay ID `%s` must contain a $", value));
     } else {
       Preconditions
-        .checkArgument(value.length() > 6, format("PayID `%s` must specify a valid account and host", value));
+        .checkArgument(value.length() > 6, format("Pay ID `%s` must specify a valid account and host", value));
     }
 
     // Ensure no more than a single dollar-sign ($) without using a library.
     // See https://stackoverflow.com/a/35242882
     int numDollarSigns = new StringTokenizer(" " + value + " ", "$").countTokens() - 1;
     Preconditions.checkArgument(numDollarSigns == 1,
-        format("PayID `%s` may only contain a single dollar-sign. All other dollar-signs must be percent-encoded.",
+        format("Pay ID `%s` may only contain a single dollar-sign. All other dollar-signs must be percent-encoded.",
           value));
     Preconditions.checkArgument(!value.startsWith("%"),
-        format("PayID `%s` MUST start with either an 'unreserved' or 'sub-selims' character rules. "
-          + "A PayID may not start with a percent-encoded value.", value));
+        format("Pay ID `%s` MUST start with either an 'unreserved' or 'sub-selims' character rules. "
+          + "A Pay ID may not start with a percent-encoded value.", value));
 
     final String[] parts = value.split("\\$");
 
@@ -82,7 +80,7 @@ public interface PayID {
     account = upperCasePercentEncoded(account);
     host = upperCasePercentEncoded(host);
 
-    final ImmutablePayID.Builder builder = builder();
+    final ImmutablePayId.Builder builder = builder();
     if (account.length() > 0) {
       builder.account(account);
     }

--- a/src/main/java/io/xpring/payid/idiomatic/PayIdComponents.java
+++ b/src/main/java/io/xpring/payid/idiomatic/PayIdComponents.java
@@ -1,0 +1,20 @@
+package io.xpring.payid.idiomatic;
+
+import org.immutables.value.Value;
+
+/**
+ * Represents components of a Pay ID.
+ */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+@Value.Immutable
+public interface PayIdComponents {
+  /**
+   * The host component of the Pay ID.
+   */
+  String host();
+
+  /**
+   * The path component of the Pay ID. Starts with a leading '/'.
+   */
+  String path();
+}


### PR DESCRIPTION
## High Level Overview of Change
Re-case some PayID model objections to be idiomatically.

Follow on to https://github.com/xpring-eng/xpring4j/pull/228 

### Context of Change

Java prefers `Id` to `ID`. This recases the first several classes. 

Because Java only allows one public class per file and MacOS is case insensitive, we can't have these files live side by side. As such, a new package, `idiomatic` is created. We'll migrate things there, free up the original namespace and then migrate them back to avoid breaking clients.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Extra classes added

## Test Plan

CI