### PR TITLE
Updates in response to breaking PayID changes - Public API

### DIFF
--- a/pay-id-api-spec/pay-id.v1.yml
+++ b/pay-id-api-spec/pay-id.v1.yml
@@ -143,21 +143,38 @@ components:
           type: string
       required:
         - address
-    PaymentInformation:
-      title: PaymentInformation
+    Address:
+      title: Address
       type: object
       properties:
+        paymentNetwork:
+          type: string
+        environment:
+          type: string
         addressDetailsType:
           type: string
         addressDetails:
           $ref: '#/components/schemas/CryptoAddressDetails'
-        proof_of_control_signature:
-          type: string
-        paymentPointer:
-          type: string
       required:
+        - paymentNetwork
         - addressDetailsType
         - addressDetails
+    PaymentInformation:
+      title: PaymentInformation
+      type: object
+      properties:
+        addresses:
+          type: array
+          items:
+            $ref: '#/components/schemas/Address'
+        proofOfControlSignature:
+          type: string
+        payId:
+          type: string
+        memo:
+          type: string
+      required:
+        - addresses
     Invoice:
       title: Invoice
       type: object

--- a/src/main/java/io/xpring/payid/PayIDClient.java
+++ b/src/main/java/io/xpring/payid/PayIDClient.java
@@ -124,8 +124,14 @@ public class PayIDClient {
       }.getType();
       ApiResponse<PaymentInformation> response = apiClient.execute(call, localVarReturnType);
       PaymentInformation result = response.getData();
-      // TODO(amiecorso): what if addresses is empty or has more than one address?
-      return result.getAddresses().get(0).getAddressDetails();
+      if (result.getAddresses().size() == 1 ) {
+        return result.getAddresses().get(0).getAddressDetails();
+      } else {
+        // With a specific network, exactly one address should be returned by a PayId lookup.
+        throw new PayIDException(PayIDExceptionType.UNEXPECTED_RESPONSE,
+                "Expected one address for " + payID + " on network " + this.network +
+                " but got " + result.getAddresses().size());
+      }
     } catch (ApiException exception) {
       int code = exception.getCode();
       if (code == 404) {

--- a/src/main/java/io/xpring/payid/PayIDClient.java
+++ b/src/main/java/io/xpring/payid/PayIDClient.java
@@ -124,6 +124,7 @@ public class PayIDClient {
       }.getType();
       ApiResponse<PaymentInformation> response = apiClient.execute(call, localVarReturnType);
       PaymentInformation result = response.getData();
+      // TODO(amiecorso): what if addresses is empty or has more than one address?
       return result.getAddresses().get(0).getAddressDetails();
     } catch (ApiException exception) {
       int code = exception.getCode();

--- a/src/main/java/io/xpring/payid/PayIDClient.java
+++ b/src/main/java/io/xpring/payid/PayIDClient.java
@@ -124,7 +124,7 @@ public class PayIDClient {
       }.getType();
       ApiResponse<PaymentInformation> response = apiClient.execute(call, localVarReturnType);
       PaymentInformation result = response.getData();
-      return result.getAddressDetails();
+      return result.getAddresses().get(0).getAddressDetails();
     } catch (ApiException exception) {
       int code = exception.getCode();
       if (code == 404) {

--- a/src/main/java/io/xpring/payid/PayIDClient.java
+++ b/src/main/java/io/xpring/payid/PayIDClient.java
@@ -129,8 +129,8 @@ public class PayIDClient {
       } else {
         // With a specific network, exactly one address should be returned by a PayId lookup.
         throw new PayIDException(PayIDExceptionType.UNEXPECTED_RESPONSE,
-                "Expected one address for " + payID + " on network " + this.network +
-                " but got " + result.getAddresses().size());
+                "Expected one address for " + payID + " on network " + this.network
+                + " but got " + result.getAddresses().size());
       }
     } catch (ApiException exception) {
       int code = exception.getCode();

--- a/src/test/java/io/xpring/payid/XRPPayIDClientTest.java
+++ b/src/test/java/io/xpring/payid/XRPPayIDClientTest.java
@@ -202,7 +202,7 @@ public class XRPPayIDClientTest {
   @Test
   public void testXRPAddressForPayIdMultipleAddressesReturned() throws PayIDException {
     // GIVEN a PayID client, a valid PayID and mocked networking to return multiple addresses.
-    String payID = "georgewashington$localhost:" + wireMockRule.httpsPort();
+    final String payID = "georgewashington$localhost:" + wireMockRule.httpsPort();
     XRPPayIDClient client = new XRPPayIDClient(XRPLNetwork.TEST);
     client.setEnableSSLVerification(false);
 

--- a/src/test/java/io/xpring/payid/XRPPayIDClientTest.java
+++ b/src/test/java/io/xpring/payid/XRPPayIDClientTest.java
@@ -50,10 +50,12 @@ public class XRPPayIDClientTest {
             .withStatus(200)
             .withHeader("Content-Type", "application/xrpl-mainnet+json")
             .withBody("{ "
+                + "addresses: [{"
                 + "addressDetailsType: 'CryptoAddressDetails', "
                 + "addressDetails: { "
                 + "address: '" + expectedAddress + "' "
                 + "}"
+                + "}]"
                 + "}"
             )
         )
@@ -85,10 +87,12 @@ public class XRPPayIDClientTest {
             .withStatus(200)
             .withHeader("Content-Type", "application/xrpl-mainnet+json")
             .withBody("{ "
+                + "addresses: [{"
                 + "addressDetailsType: 'CryptoAddressDetails', "
                 + "addressDetails: { "
                 + "address: '" + classicAddress.address() + "' "
                 + "}"
+                + "}]"
                 + "}"
             )
         )
@@ -121,11 +125,13 @@ public class XRPPayIDClientTest {
             .withStatus(200)
             .withHeader("Content-Type", "application/xrpl-mainnet+json")
             .withBody("{ "
+                + "addresses: [{"
                 + "addressDetailsType: 'CryptoAddressDetails', "
                 + "addressDetails: { "
                 + "address: '" + classicAddress.address() + "', "
                 + "tag: '" + classicAddress.tag().get() + "' "
                 + "}"
+                + "}]"
                 + "}"
             )
         )

--- a/src/test/java/io/xpring/payid/XRPPayIDClientTest.java
+++ b/src/test/java/io/xpring/payid/XRPPayIDClientTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.xpring.common.XRPLNetwork;
+import io.xpring.payid.idiomatic.PayIdException;
 import io.xpring.xrpl.ClassicAddress;
 import io.xpring.xrpl.ImmutableClassicAddress;
 import io.xpring.xrpl.Utils;
@@ -194,6 +195,48 @@ public class XRPPayIDClientTest {
 
     // WHEN an XRPAddress is requested THEN a unexpected response error is thrown.
     // TODO(keefertaylor): Tighten this condition to verify the exception is as expected.
+    expectedException.expect(PayIDException.class);
+    client.xrpAddressForPayID(payID);
+  }
+
+  @Test
+  public void testXRPAddressForPayIdMultipleAddressesReturned() throws PayIDException {
+    // GIVEN a PayID client, a valid PayID and mocked networking to return multiple addresses.
+    String payID = "georgewashington$localhost:" + wireMockRule.httpsPort();
+    XRPPayIDClient client = new XRPPayIDClient(XRPLNetwork.TEST);
+    client.setEnableSSLVerification(false);
+
+    ClassicAddress classicAddress = ImmutableClassicAddress.builder()
+            .address("rPEPPER7kfTD9w2To4CQk6UCfuHM9c6GDY")
+            .isTest(true)
+            .build();
+
+    String expectedAddress = Utils.encodeXAddress(classicAddress);
+
+    stubFor(get(urlEqualTo("/georgewashington"))
+            .willReturn(aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/xrpl-mainnet+json")
+                    .withBody("{ "
+                            + "addresses: [{"
+                            + "addressDetailsType: 'CryptoAddressDetails', "
+                            + "addressDetails: { "
+                            + "address: '" + classicAddress.address() + "' "
+                            + "}"
+                            + "}, "
+                            + "{"
+                            + "addressDetailsType: 'CryptoAddressDetails', "
+                            + "addressDetails: { "
+                            + "address: '" + classicAddress.address() + "' "
+                            + "}"
+                            + "}"
+                            + "]"
+                            + "}"
+                    )
+            )
+    );
+
+    // WHEN an XRPAddress is requested THEN a unexpected response error is thrown.
     expectedException.expect(PayIDException.class);
     client.xrpAddressForPayID(payID);
   }


### PR DESCRIPTION
## High Level Overview of Change
This PR updates the SDK to handle breaking changes made to PayID.  Specifically, the `PaymentInformation` type was changed to return addresses in the form of an array of `Address` (new type) objects. 

analogue in JS: https://github.com/xpring-eng/Xpring-JS/pull/474

@keefertaylor check out my TODO in here.

------------------------------------------------------------
New object structure in payid:

<img width="605" alt="Screen Shot 2020-05-21 at 6 42 45 PM" src="https://user-images.githubusercontent.com/24928141/82622532-efdd2700-9b92-11ea-9dbe-a81eef7aed36.png">


<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After
`PayIDClient` unit and integration tests pass again.
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
CI
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->


## Future Tasks
<!--
For future tasks related to PR.
-->
Update Swift SDK