### PR TITLE
Enable code coverage configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: 80%
+        threshold: 1%
+        base: auto 
+        if_ci_failed: error
+    project:
+      default:
+        target: 80%
+        threshold: 1%
+        base: auto 
+        if_ci_failed: error


### PR DESCRIPTION
## High Level Overview of Change

Add a codecov config to Xpring-Common-JS

### Context of Change

Configure two CI checks:
- Coverage repo-wide is at least 80%
- Any single PR decreases code coverage by less than 1%

Open to discussion on numbers, these are a straw man proposal.  I'm going to leave the check as non-blocking for now - this change will only make it so we have actual numbers (otherwise code cov just compares to the existing coverage). 

I don't think this works until I have this file on master, so no UI or checks will show up here, yet. 

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Better code!

## Test Plan

CI