### PR TITLE
Rename XRP Classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+<placeholder>
+
 - A new method, `getPayment`, added to `XRPClient` for retrieving payment transactions by hash.
 
 ## 5.1.1 - 2020-05-15

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ System.out.println(wallet.getPrivateKey()); // 0090802A50AA84EFB6CDB225F17C27616
 
 #### Signing / Verifying
 
-A wallet can also sign and verify arbitrary hex messages. Generally, users should use the functions on `XRPClient` to perform cryptographic functions rather than using these low level APIs.
+A wallet can also sign and verify arbitrary hex messages. Generally, users should use the functions on `XrpClient` to perform cryptographic functions rather than using these low level APIs.
 
 ```java
 import io.xpring.xrpl.Wallet;
@@ -149,31 +149,31 @@ String signature = wallet.sign(message);
 wallet.verify(message, signature); // true
 ```
 
-### XRPClient
+### XrpClient
 
-`XRPClient` is a gateway into the XRP Ledger. `XRPClient` is initialized with a two parameters:
+`XrpClient` is a gateway into the XRP Ledger. `XrpClient` is initialized with a two parameters:
 - The URL of the gRPC API on the remote rippled node
 - An enum representing the XRPL Network the remote rippled node is attached to
 
 ```java
-import io.xpring.common.XRPLNetwork;
-import io.xpring.xrpl.XRPClient;
+import io.xpring.common.idiomatic.XrplNetwork;
+import io.xpring.xrpl.idiomatic.XrpClient;
 
 String grpcURL = "test.xrp.xpring.io:50051"; // Testnet URL, use main.xrp.xpring.io:50051 for Mainnet
-XRPClient xrpClient = new XRPClient(grpcURL, XRPLNetwork.TEST);
+XrpClient xrpClient = new XrpClient(grpcURL, XrplNetwork.TEST);
 ```
 
 #### Retrieving a Balance
 
-An `XRPClient` can check the balance of an account on the XRP Ledger.
+An `XrpClient` can check the balance of an account on the XRP Ledger.
 
 ```java
-import io.xpring.common.XRPLNetwork;
-import io.xpring.xrpl.XRPClient;
+import io.xpring.common.idiomatic.XrplLNetwork;
+import io.xpring.xrpl.idiomatic.XrpClient;
 import java.math.BigInteger;
 
 String grpcURL = "test.xrp.xpring.io:50051"; // Testnet URL, use main.xrp.xpring.io:50051 for Mainnet
-XRPClient xrpClient = new XRPClient(grpcURL, XRPLNetwork.TEST);
+XrpClient xrpClient = new XrpClient(grpcURL, XrplNetwork.TEST);
 
 String address = "X7u4MQVhU2YxS4P9fWzQjnNuDRUkP3GM6kiVjTjcQgUU3Jr";
 BigInteger balance = xrpClient.getBalance(address);
@@ -182,7 +182,7 @@ System.out.println(balance); // Logs a balance in drops of XRP
 
 ### Checking Transaction Status
 
-A `XRPClient` can check the status of an payment on the XRP Ledger.
+A `XrpClient` can check the status of an payment on the XRP Ledger.
 
 This method can only determine the status of [payment transactions](https://xrpl.org/payment.html) which do not have the partial payment flag ([tfPartialPayment](https://xrpl.org/payment.html#payment-flags)) set.
 
@@ -197,12 +197,12 @@ Xpring4J returns the following transaction states:
 These states are determined by the `TransactionStatus` enum.
 
 ```java
-import io.xpring.common.XRPLNetwork;
-import io.xpring.xrpl.XRPClient;
+import io.xpring.common.idiomatic.XrplNetwork;
+import io.xpring.xrpl.idiomatic.XrpClient;
 import io.xpring.xrpl.TransactionStatus;
 
 String grpcURL = "test.xrp.xpring.io:50051"; // Testnet URL, use main.xrp.xpring.io:50051 for Mainnet
-XRPClient xrpClient = new XRPClient(grpcURL, XRPLNetwork.TEST);
+XrpClient xrpClient = new XrpClient(grpcURL, XrplNetwork.TEST);
 
 String transactionHash = "9FC7D277C1C8ED9CE133CC17AEA9978E71FC644CE6F5F0C8E26F1C635D97AF4A";
 TransactionStatus transactionStatus = xrpClient.getPaymentStatus(transactionHash); // TransactionStatus.SUCCEEDED
@@ -212,34 +212,34 @@ TransactionStatus transactionStatus = xrpClient.getPaymentStatus(transactionHash
 
 #### Payment history
 
-An `XRPClient` can return a list of payments to and from an account.
+An `XrpClient` can return a list of payments to and from an account.
 
 ```java
-import io.xpring.xrpl.XRPClient;
-import io.xpring.common.XRPLNetwork;
-import io.xpring.xrpl.model.XRPTransaction;
+import io.xpring.xrpl.idiomatic.XrpClient;
+import io.xpring.common.idiomatic.XrplNetwork;
+import io.xpring.xrpl.model.idiomatic.XrpTransaction;
 import java.util.List;
 
 String remoteURL = "test.xrp.xpring.io:50051"; // Testnet URL, use main.xrp.xpring.io:50051 for Mainnet
-XRPClient xrpClient = new XRPClient(remoteURL, XRPLNetwork.TEST);
+XrpClient xrpClient = new XrpClient(remoteURL, XrplNetwork.TEST);
 String address = "XVMFQQBMhdouRqhPMuawgBMN1AVFTofPAdRsXG5RkPtUPNQ";
-List<XRPTransaction> paymentHistory = xrpClient.paymentHistory(address);
+List<XrpTransaction> paymentHistory = xrpClient.paymentHistory(address);
 ```
 
 #### Sending XRP
 
-An `XRPClient` can send XRP to other [accounts](https://xrpl.org/accounts.html) on the XRP Ledger.
+An `XrpClient` can send XRP to other [accounts](https://xrpl.org/accounts.html) on the XRP Ledger.
 
 **Note:** The payment operation will block the calling thread until the operation reaches a definitive and irreversible success or failure state.
 
 ```java
 import io.xpring.xrpl.Wallet;
-import io.xpring.common.XRPLNetwork;
-import io.xpring.xrpl.XRPClient;
+import io.xpring.common.idiomatic.XrplNetwork;
+import io.xpring.xrpl.idiomatic.XrpClient;
 import java.math.BigInteger;
 
 String grpcURL = "test.xrp.xpring.io:50051"; // Testnet URL, use main.xrp.xpring.io:50051 for Mainnet
-XRPClient xrpClient = new XRPClient(grpcURL, XRPLNetwork.TEST);
+XrpClient xrpClient = new XrpClient(grpcURL, XrplNetwork.TEST);
 
 // Amount of XRP to send.
 BigInteger amount = new BigInteger("1");

--- a/pay-id-api-spec/pay-id.v1.yml
+++ b/pay-id-api-spec/pay-id.v1.yml
@@ -143,21 +143,38 @@ components:
           type: string
       required:
         - address
-    PaymentInformation:
-      title: PaymentInformation
+    Address:
+      title: Address
       type: object
       properties:
+        paymentNetwork:
+          type: string
+        environment:
+          type: string
         addressDetailsType:
           type: string
         addressDetails:
           $ref: '#/components/schemas/CryptoAddressDetails'
-        proof_of_control_signature:
-          type: string
-        paymentPointer:
-          type: string
       required:
+        - paymentNetwork
         - addressDetailsType
         - addressDetails
+    PaymentInformation:
+      title: PaymentInformation
+      type: object
+      properties:
+        addresses:
+          type: array
+          items:
+            $ref: '#/components/schemas/Address'
+        proofOfControlSignature:
+          type: string
+        payId:
+          type: string
+        memo:
+          type: string
+      required:
+        - addresses
     Invoice:
       title: Invoice
       type: object

--- a/src/main/java/io/xpring/common/XRPLNetwork.java
+++ b/src/main/java/io/xpring/common/XRPLNetwork.java
@@ -5,7 +5,7 @@ import io.xpring.common.idiomatic.XrplNetwork;
 /**
  * Possible networks to resolve.
  *
- * @deprecated Pleaseuse the idiomatically named {@link XrplNetwork} enum instead.
+ * @deprecated Please use the idiomatically named {@link XrplNetwork} enum instead.
  */
 @Deprecated
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")

--- a/src/main/java/io/xpring/common/XRPLNetwork.java
+++ b/src/main/java/io/xpring/common/XRPLNetwork.java
@@ -1,9 +1,11 @@
 package io.xpring.common;
 
+import io.xpring.common.idiomatic.XrplNetwork;
+
 /**
  * Possible networks to resolve.
  *
- * @deprecate Pleaseuse the idiomatically named {@link XrplNetwork} enum instead.
+ * @deprecated Pleaseuse the idiomatically named {@link XrplNetwork} enum instead.
  */
 @Deprecated
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")

--- a/src/main/java/io/xpring/common/XRPLNetwork.java
+++ b/src/main/java/io/xpring/common/XRPLNetwork.java
@@ -2,7 +2,10 @@ package io.xpring.common;
 
 /**
  * Possible networks to resolve.
+ *
+ * @deprecate Pleaseuse the idiomatically named {@link XrplNetwork} enum instead.
  */
+@Deprecated
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public enum XRPLNetwork {
   DEV("devnet"),

--- a/src/main/java/io/xpring/common/idiomatic/XrplNetwork.java
+++ b/src/main/java/io/xpring/common/idiomatic/XrplNetwork.java
@@ -1,0 +1,20 @@
+package io.xpring.common.idiomatic;
+
+/**
+ * Possible networks to resolve.
+ */
+public enum XrplNetwork {
+  DEV("devnet"),
+  TEST("testnet"),
+  MAIN("mainnet");
+
+  private String networkName;
+
+  XrplNetwork(String networkName) {
+    this.networkName = networkName;
+  }
+
+  public String getNetworkName() {
+    return networkName;
+  }
+}

--- a/src/main/java/io/xpring/payid/PayIDClient.java
+++ b/src/main/java/io/xpring/payid/PayIDClient.java
@@ -124,7 +124,14 @@ public class PayIDClient {
       }.getType();
       ApiResponse<PaymentInformation> response = apiClient.execute(call, localVarReturnType);
       PaymentInformation result = response.getData();
-      return result.getAddressDetails();
+      if (result.getAddresses().size() == 1 ) {
+        return result.getAddresses().get(0).getAddressDetails();
+      } else {
+        // With a specific network, exactly one address should be returned by a PayId lookup.
+        throw new PayIDException(PayIDExceptionType.UNEXPECTED_RESPONSE,
+                "Expected one address for " + payID + " on network " + this.network
+                + " but got " + result.getAddresses().size());
+      }
     } catch (ApiException exception) {
       int code = exception.getCode();
       if (code == 404) {

--- a/src/main/java/io/xpring/xrpl/XRPClient.java
+++ b/src/main/java/io/xpring/xrpl/XRPClient.java
@@ -2,6 +2,7 @@ package io.xpring.xrpl;
 
 import io.xpring.common.XRPLNetwork;
 import io.xpring.xrpl.idiomatic.DefaultXrpClient;
+import io.xpring.xrpl.idiomatic.XrpClient;
 import io.xpring.xrpl.model.XRPTransaction;
 
 import java.math.BigInteger;

--- a/src/main/java/io/xpring/xrpl/XRPClientInterface.java
+++ b/src/main/java/io/xpring/xrpl/XRPClientInterface.java
@@ -1,6 +1,8 @@
 package io.xpring.xrpl;
 
 import io.xpring.common.XRPLNetwork;
+import io.xpring.xrpl.idiomatic.XrpClient;
+import io.xpring.xrpl.idiomatic.XrpClientInterface;
 import io.xpring.xrpl.model.XRPTransaction;
 
 import java.math.BigInteger;

--- a/src/main/java/io/xpring/xrpl/XRPClientInterface.java
+++ b/src/main/java/io/xpring/xrpl/XRPClientInterface.java
@@ -7,6 +7,8 @@ import java.math.BigInteger;
 import java.util.List;
 
 /**
+ * An interface for an {@link XrpClient}.
+ *
  * @deprecated Please use the idiomatically named {@link XrpClientInterface} class instead.
  */
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")

--- a/src/main/java/io/xpring/xrpl/XRPException.java
+++ b/src/main/java/io/xpring/xrpl/XRPException.java
@@ -1,5 +1,7 @@
 package io.xpring.xrpl;
 
+import io.xpring.xrpl.idiomatic.XrpException;
+
 /**
  * Exceptions which occur when working with xpring4j.
  *

--- a/src/main/java/io/xpring/xrpl/XRPException.java
+++ b/src/main/java/io/xpring/xrpl/XRPException.java
@@ -2,8 +2,11 @@ package io.xpring.xrpl;
 
 /**
  * Exceptions which occur when working with xpring4j.
+ *
+ * @deprecated Please use the idiomatically named {@link XrpException} class instead.
  */
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+@Deprecated
 public class XRPException extends Exception {
   /**
    * Static exception for when a classic address is passed to an X-Address API.

--- a/src/main/java/io/xpring/xrpl/XRPExceptionType.java
+++ b/src/main/java/io/xpring/xrpl/XRPExceptionType.java
@@ -1,6 +1,10 @@
 package io.xpring.xrpl;
 
+/**
+ * @deprecated Please use the idiomatically named {@link XrpExceptionType} class instead.
+ */
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+@Deprecated
 public enum XRPExceptionType {
     INVALID_INPUTS,
     SIGNING_ERROR,

--- a/src/main/java/io/xpring/xrpl/XRPExceptionType.java
+++ b/src/main/java/io/xpring/xrpl/XRPExceptionType.java
@@ -1,5 +1,8 @@
 package io.xpring.xrpl;
 
+import io.xpring.xrpl.idiomatic.XrpException;
+import io.xpring.xrpl.idiomatic.XrpExceptionType;
+
 /**
  * Types of {@link XrpException}s.
  *

--- a/src/main/java/io/xpring/xrpl/XRPExceptionType.java
+++ b/src/main/java/io/xpring/xrpl/XRPExceptionType.java
@@ -1,6 +1,8 @@
 package io.xpring.xrpl;
 
 /**
+ * Types of {@link XrpException}s.
+ *
  * @deprecated Please use the idiomatically named {@link XrpExceptionType} class instead.
  */
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")

--- a/src/main/java/io/xpring/xrpl/idiomatic/DefaultXrpClient.java
+++ b/src/main/java/io/xpring/xrpl/idiomatic/DefaultXrpClient.java
@@ -1,11 +1,16 @@
-package io.xpring.xrpl;
+package io.xpring.xrpl.idiomatic;
 
 import com.google.protobuf.ByteString;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
-import io.xpring.xrpl.idiomatic.DefaultXrpClient;
-import io.xpring.xrpl.model.XRPTransaction;
+import io.xpring.xrpl.ClassicAddress;
+import io.xpring.xrpl.RawTransactionStatus;
+import io.xpring.xrpl.Signer;
+import io.xpring.xrpl.TransactionStatus;
+import io.xpring.xrpl.Utils;
+import io.xpring.xrpl.Wallet;
+import io.xpring.xrpl.model.idiomatic.XrpTransaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xrpl.rpc.v1.AccountAddress;
@@ -43,13 +48,9 @@ import java.util.concurrent.TimeUnit;
 /**
  * A client that can submit transactions to the XRP Ledger.
  *
- * @deprecated Please use the idiomatically named {@link DefaultXrpClient} class instead.
- *
  * @see "https://xrpl.org"
  */
-@Deprecated
-@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
-public class DefaultXRPClient implements XRPClientDecorator {
+public class DefaultXrpClient implements XrpClientDecorator {
   // A margin to pad the current ledger sequence with when submitting transactions.
   private static final int MAX_LEDGER_VERSION_OFFSET = 10;
 
@@ -61,7 +62,7 @@ public class DefaultXRPClient implements XRPClientDecorator {
   /**
    * No-args Constructor.
    */
-  DefaultXRPClient(String grpcURL) {
+  DefaultXrpClient(String grpcURL) {
     this(ManagedChannelBuilder
         .forTarget(grpcURL)
         .usePlaintext()
@@ -74,7 +75,7 @@ public class DefaultXRPClient implements XRPClientDecorator {
    *
    * @param channel A {@link ManagedChannel}.
    */
-  DefaultXRPClient(final ManagedChannel channel) {
+  DefaultXrpClient(final ManagedChannel channel) {
     // It is up to the client to determine whether to block the call. Here we create a blocking stub, but an async
     // stub, or an async stub with Future are always possible.
     this.stub = XRPLedgerAPIServiceGrpc.newBlockingStub(channel);
@@ -98,11 +99,11 @@ public class DefaultXRPClient implements XRPClientDecorator {
    *
    * @param xrplAccountAddress The X-Address to retrieve the balance for.
    * @return A {@link BigInteger} with the number of drops in this account.
-   * @throws XRPException If the given inputs were invalid.
+   * @throws XrpException If the given inputs were invalid.
    */
-  public BigInteger getBalance(final String xrplAccountAddress) throws XRPException {
+  public BigInteger getBalance(final String xrplAccountAddress) throws XrpException {
     if (!Utils.isValidXAddress(xrplAccountAddress)) {
-      throw XRPException.xAddressRequiredException;
+      throw XrpException.xAddressRequiredException;
     }
     ClassicAddress classicAddress = Utils.decodeXAddress(xrplAccountAddress);
 
@@ -124,7 +125,7 @@ public class DefaultXRPClient implements XRPClientDecorator {
    * @param transactionHash The hash of the transaction.
    * @return The status of the given transaction.
    */
-  public TransactionStatus getPaymentStatus(String transactionHash) throws XRPException {
+  public TransactionStatus getPaymentStatus(String transactionHash) throws XrpException {
     Objects.requireNonNull(transactionHash);
 
     RawTransactionStatus transactionStatus = getRawTransactionStatus(transactionHash);
@@ -146,19 +147,19 @@ public class DefaultXRPClient implements XRPClientDecorator {
    * @param destinationAddress The X-Address to send the XRP to.
    * @param sourceWallet       The {@link Wallet} which holds the XRP.
    * @return A transaction hash for the payment.
-   * @throws XRPException If the given inputs were invalid.
+   * @throws XrpException If the given inputs were invalid.
    */
   public String send(
       final BigInteger drops,
       final String destinationAddress,
       final Wallet sourceWallet
-  ) throws XRPException {
+  ) throws XrpException {
     Objects.requireNonNull(drops);
     Objects.requireNonNull(destinationAddress);
     Objects.requireNonNull(sourceWallet);
 
     if (!Utils.isValidXAddress(destinationAddress)) {
-      throw XRPException.xAddressRequiredException;
+      throw XrpException.xAddressRequiredException;
     }
 
     ClassicAddress destinationClassicAddress = Utils.decodeXAddress(destinationAddress);
@@ -233,11 +234,11 @@ public class DefaultXRPClient implements XRPClientDecorator {
    *
    * @param address The address (account) for which to retrieve payment history.
    * @return An array of transactions associated with the account.
-   * @throws XRPException If there was a problem communicating with the XRP Ledger.
+   * @throws XrpException If there was a problem communicating with the XRP Ledger.
    */
-  public List<XRPTransaction> paymentHistory(String address) throws XRPException {
+  public List<XrpTransaction> paymentHistory(String address) throws XrpException {
     if (!Utils.isValidXAddress(address)) {
-      throw XRPException.xAddressRequiredException;
+      throw XrpException.xAddressRequiredException;
     }
     ClassicAddress classicAddress = Utils.decodeXAddress(address);
 
@@ -249,16 +250,16 @@ public class DefaultXRPClient implements XRPClientDecorator {
 
     List<GetTransactionResponse> getTransactionResponses = transactionHistory.getTransactionsList();
 
-    // Filter transactions to payments only and convert them to XRPTransactions.
+    // Filter transactions to payments only and convert them to XrpTransactions.
     // If a payment transaction fails conversion, throw an error.
-    List<XRPTransaction> payments = new ArrayList<XRPTransaction>();
+    List<XrpTransaction> payments = new ArrayList<XrpTransaction>();
     for (GetTransactionResponse transactionResponse : getTransactionResponses) {
       Transaction transaction = transactionResponse.getTransaction();
       switch (transaction.getTransactionDataCase()) {
         case PAYMENT: {
-          XRPTransaction xrpTransaction = XRPTransaction.from(transactionResponse);
+          XrpTransaction xrpTransaction = XrpTransaction.from(transactionResponse);
           if (xrpTransaction == null) {
-            throw XRPException.paymentConversionFailure;
+            throw XrpException.paymentConversionFailure;
           } else {
             payments.add(xrpTransaction);
           }
@@ -276,12 +277,12 @@ public class DefaultXRPClient implements XRPClientDecorator {
    * Check if an address exists on the XRP Ledger.
    *
    * @param address The address to check the existence of.
-   * @return A boolean if the account is on the XRPLedger.
+   * @return A boolean if the account is on the XRP Ledger.
    */
   @Override
-  public boolean accountExists(String address) throws XRPException {
+  public boolean accountExists(String address) throws XrpException {
     if (!Utils.isValidXAddress(address)) {
-      throw XRPException.xAddressRequiredException;
+      throw XrpException.xAddressRequiredException;
     }
     try {
       this.getBalance(address);
@@ -304,10 +305,10 @@ public class DefaultXRPClient implements XRPClientDecorator {
    *       See the `validated` field to make this distinction.
    * </p>
    * @param transactionHash The hash of the transaction to retrieve.
-   * @return An XRPTransaction object representing an XRP Ledger transaction.
-   * @throws XRPException If the transaction hash was invalid.
+   * @return An XrpTransaction object representing an XRP Ledger transaction.
+   * @throws XrpException If the transaction hash was invalid.
    */
-  public XRPTransaction getPayment(String transactionHash) throws XRPException {
+  public XrpTransaction getPayment(String transactionHash) throws XrpException {
     Objects.requireNonNull(transactionHash);
 
     byte[] transactionHashBytes = Utils.hexStringToByteArray(transactionHash);
@@ -315,10 +316,10 @@ public class DefaultXRPClient implements XRPClientDecorator {
     GetTransactionRequest request = GetTransactionRequest.newBuilder()
             .setHash(transactionHashByteString).build();
     GetTransactionResponse response = this.stub.getTransaction(request);
-    return XRPTransaction.from(response);
+    return XrpTransaction.from(response);
   }
 
-  public int getOpenLedgerSequence() throws XRPException {
+  public int getOpenLedgerSequence() throws XrpException {
     return this.getFeeResponse().getLedgerCurrentIndex();
   }
 
@@ -338,7 +339,7 @@ public class DefaultXRPClient implements XRPClientDecorator {
    * @throws io.grpc.StatusRuntimeException If there was a problem communicating with the XRP Ledger.
    */
   @Override
-  public int getLatestValidatedLedgerSequence(String address) throws XRPException {
+  public int getLatestValidatedLedgerSequence(String address) throws XrpException {
     // rippled doesn't support a gRPC call that tells us the latest validated ledger sequence. To get around this,
     // query the account info for an account which will exist, using a shortcut for the latest validated ledger. The
     // response will contain the ledger the information was retrieved at.
@@ -357,7 +358,7 @@ public class DefaultXRPClient implements XRPClientDecorator {
   }
 
   @Override
-  public RawTransactionStatus getRawTransactionStatus(String transactionHash) throws XRPException {
+  public RawTransactionStatus getRawTransactionStatus(String transactionHash) throws XrpException {
     Objects.requireNonNull(transactionHash);
 
     byte[] transactionHashBytes = Utils.hexStringToByteArray(transactionHash);

--- a/src/main/java/io/xpring/xrpl/idiomatic/DefaultXrpClient.java
+++ b/src/main/java/io/xpring/xrpl/idiomatic/DefaultXrpClient.java
@@ -62,9 +62,9 @@ public class DefaultXrpClient implements XrpClientDecorator {
   /**
    * No-args Constructor.
    */
-  DefaultXrpClient(String grpcURL) {
+  DefaultXrpClient(String grpcUrl) {
     this(ManagedChannelBuilder
-        .forTarget(grpcURL)
+        .forTarget(grpcUrl)
         .usePlaintext()
         .build()
     );

--- a/src/main/java/io/xpring/xrpl/idiomatic/ReliableSubmissionXrpClient.java
+++ b/src/main/java/io/xpring/xrpl/idiomatic/ReliableSubmissionXrpClient.java
@@ -1,14 +1,14 @@
 package io.xpring.xrpl.idiomatic;
 
-import io.xpring.xrpl.TransactionStatus;
-import io.xpring.xrpl.Utils;
-import io.xpring.xrpl.model.idiomatic.XrpTransaction;
 import io.xpring.xrpl.ClassicAddress;
 import io.xpring.xrpl.RawTransactionStatus;
+import io.xpring.xrpl.TransactionStatus;
+import io.xpring.xrpl.Utils;
 import io.xpring.xrpl.Wallet;
+import io.xpring.xrpl.model.idiomatic.XrpTransaction;
 
-import java.util.List;
 import java.math.BigInteger;
+import java.util.List;
 
 public class ReliableSubmissionXrpClient implements XrpClientDecorator {
   XrpClientDecorator decoratedClient;

--- a/src/main/java/io/xpring/xrpl/idiomatic/ReliableSubmissionXrpClient.java
+++ b/src/main/java/io/xpring/xrpl/idiomatic/ReliableSubmissionXrpClient.java
@@ -1,0 +1,113 @@
+package io.xpring.xrpl.idiomatic;
+
+import io.xpring.xrpl.TransactionStatus;
+import io.xpring.xrpl.Utils;
+import io.xpring.xrpl.model.idiomatic.XrpTransaction;
+import io.xpring.xrpl.ClassicAddress;
+import io.xpring.xrpl.RawTransactionStatus;
+import io.xpring.xrpl.Wallet;
+
+import java.util.List;
+import java.math.BigInteger;
+
+public class ReliableSubmissionXrpClient implements XrpClientDecorator {
+  XrpClientDecorator decoratedClient;
+
+  public ReliableSubmissionXrpClient(XrpClientDecorator decoratedClient) {
+    this.decoratedClient = decoratedClient;
+  }
+
+  @Override
+  public BigInteger getBalance(String xrplAccountAddress) throws XrpException {
+    return this.decoratedClient.getBalance(xrplAccountAddress);
+  }
+
+  @Override
+  public TransactionStatus getPaymentStatus(String transactionHash) throws XrpException {
+    return this.decoratedClient.getPaymentStatus(transactionHash);
+  }
+
+  @Override
+  public String send(BigInteger amount, String destinationAddress, Wallet sourceWallet) throws XrpException {
+    try {
+      long ledgerCloseTime = 4 * 1000;
+
+      // Submit a transaction hash and wait for a ledger to close.
+      String transactionHash = decoratedClient.send(amount, destinationAddress, sourceWallet);
+      Thread.sleep(ledgerCloseTime);
+
+      // Get transaction status.
+      RawTransactionStatus transactionStatus = this.getRawTransactionStatus(transactionHash);
+      int lastLedgerSequence = transactionStatus.getLastLedgerSequence();
+      if (lastLedgerSequence == 0) {
+        throw new XrpException(
+            XrpExceptionType.UNKNOWN,
+            "The transaction did not have a lastLedgerSequence field so transaction status cannot be reliably "
+            + "determined."
+        );
+      }
+
+      // Decode the sending address to a classic address for use in determining the last ledger sequence.
+      // An invariant of `getLatestValidatedLedgerSequence` is that the given input address (1) exists when the method
+      // is called and (2) is in a classic address form.
+      //
+      // The sending address should always exist, except in the case where it is deleted. A deletion would supersede the
+      // transaction in flight, either by:
+      // 1) Consuming the nonce sequence number of the transaction, which would effectively cancel the transaction
+      // 2) Occur after the transaction has settled which is an unlikely enough case that we ignore it.
+      //
+      // This logic is brittle and should be replaced when we have an RPC that can give us this data.
+      ClassicAddress classicAddress = Utils.decodeXAddress(sourceWallet.getAddress());
+      if (classicAddress == null) {
+        throw new XrpException(
+            XrpExceptionType.UNKNOWN,
+            "The source wallet reported an address which could not be decoded to a classic address"
+        );
+      }
+      String sourceClassicAddress = classicAddress.address();
+
+      // Retrieve the latest ledger index.
+      int latestLedgerSequence = this.getLatestValidatedLedgerSequence(sourceClassicAddress);
+
+      // Poll until the transaction is validated, or until the lastLedgerSequence has been passed.
+      while (latestLedgerSequence <= lastLedgerSequence && !transactionStatus.getValidated()) {
+        Thread.sleep(ledgerCloseTime);
+
+        latestLedgerSequence = this.getLatestValidatedLedgerSequence(sourceClassicAddress);
+        transactionStatus = this.getRawTransactionStatus(transactionHash);
+      }
+
+      return transactionHash;
+    } catch (InterruptedException e) {
+      throw new XrpException(
+          XrpExceptionType.UNKNOWN,
+          "Reliable transaction submission project was interrupted."
+      );
+    }
+  }
+
+  @Override
+  public int getLatestValidatedLedgerSequence(String address) throws XrpException {
+    return this.decoratedClient.getLatestValidatedLedgerSequence(address);
+  }
+
+  @Override
+  public RawTransactionStatus getRawTransactionStatus(String transactionHash) throws XrpException {
+    return this.decoratedClient.getRawTransactionStatus(transactionHash);
+  }
+
+  @Override
+  public List<XrpTransaction> paymentHistory(String address) throws XrpException {
+    return this.decoratedClient.paymentHistory(address);
+  }
+
+  @Override
+  public boolean accountExists(String address) throws XrpException {
+    return this.decoratedClient.accountExists(address);
+  }
+
+  @Override
+  public XrpTransaction getPayment(String transactionHash) throws XrpException {
+    return this.decoratedClient.getPayment(transactionHash);
+  }
+}

--- a/src/main/java/io/xpring/xrpl/idiomatic/XrpClient.java
+++ b/src/main/java/io/xpring/xrpl/idiomatic/XrpClient.java
@@ -1,9 +1,9 @@
 package io.xpring.xrpl.idiomatic;
 
 import io.xpring.common.idiomatic.XrplNetwork;
-import io.xpring.xrpl.model.idiomatic.XrpTransaction;
 import io.xpring.xrpl.TransactionStatus;
 import io.xpring.xrpl.Wallet;
+import io.xpring.xrpl.model.idiomatic.XrpTransaction;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -24,11 +24,11 @@ public class XrpClient implements XrpClientInterface {
   /**
    * Initialize a new client with the given options.
    *
-   * @param grpcURL The remote URL to use for gRPC calls.
+   * @param grpcUrl The remote URL to use for gRPC calls.
    * @param network The network this XRPClient is connecting to.
    */
-  public XrpClient(String grpcURL, XrplNetwork network) {
-    XrpClientDecorator defaultXrpClient = new DefaultXrpClient(grpcURL);
+  public XrpClient(String grpcUrl, XrplNetwork network) {
+    XrpClientDecorator defaultXrpClient = new DefaultXrpClient(grpcUrl);
     this.decoratedClient = new ReliableSubmissionXrpClient(defaultXrpClient);
 
     this.network = network;

--- a/src/main/java/io/xpring/xrpl/idiomatic/XrpClient.java
+++ b/src/main/java/io/xpring/xrpl/idiomatic/XrpClient.java
@@ -1,8 +1,9 @@
-package io.xpring.xrpl;
+package io.xpring.xrpl.idiomatic;
 
-import io.xpring.common.XRPLNetwork;
-import io.xpring.xrpl.idiomatic.DefaultXrpClient;
-import io.xpring.xrpl.model.XRPTransaction;
+import io.xpring.common.idiomatic.XrplNetwork;
+import io.xpring.xrpl.model.idiomatic.XrpTransaction;
+import io.xpring.xrpl.TransactionStatus;
+import io.xpring.xrpl.Wallet;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -10,19 +11,15 @@ import java.util.List;
 /**
  * A client that can submit transactions to the XRP Ledger.
  *
- * @deprecated Please use the idiomatically named {@link XrpClient} class instead.
- *
  * @see "https://xrpl.org"
  */
-@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
-@Deprecated
-public class XRPClient implements XRPClientInterface {
-  private XRPClientDecorator decoratedClient;
+public class XrpClient implements XrpClientInterface {
+  private XrpClientDecorator decoratedClient;
 
   /**
    * The XRPL Network of the node that this client is communicating with.
    */
-  private XRPLNetwork network;
+  private XrplNetwork network;
 
   /**
    * Initialize a new client with the given options.
@@ -30,17 +27,17 @@ public class XRPClient implements XRPClientInterface {
    * @param grpcURL The remote URL to use for gRPC calls.
    * @param network The network this XRPClient is connecting to.
    */
-  public XRPClient(String grpcURL, XRPLNetwork network) {
-    XRPClientDecorator defaultXRPClient = new DefaultXRPClient(grpcURL);
-    this.decoratedClient = new ReliableSubmissionXRPClient(defaultXRPClient);
+  public XrpClient(String grpcURL, XrplNetwork network) {
+    XrpClientDecorator defaultXrpClient = new DefaultXrpClient(grpcURL);
+    this.decoratedClient = new ReliableSubmissionXrpClient(defaultXrpClient);
 
     this.network = network;
   }
 
   /**
-   * Retrieve the network that this XRPClient connects to.
+   * Retrieve the network that this XrpClient connects to.
    */
-  public XRPLNetwork getNetwork() {
+  public XrplNetwork getNetwork() {
     return this.network;
   }
 
@@ -50,9 +47,9 @@ public class XRPClient implements XRPClientInterface {
    *
    * @param xrplAccountAddress The X-Address to retrieve the balance for.
    * @return A {@link BigInteger} with the number of drops in this account.
-   * @throws XRPException If the given inputs were invalid.
+   * @throws XrpException If the given inputs were invalid.
    */
-  public BigInteger getBalance(final String xrplAccountAddress) throws XRPException {
+  public BigInteger getBalance(final String xrplAccountAddress) throws XrpException {
     return decoratedClient.getBalance(xrplAccountAddress);
   }
 
@@ -66,7 +63,7 @@ public class XRPClient implements XRPClientInterface {
    * @param transactionHash The hash of the transaction.
    * @return The status of the given transaction.
    */
-  public TransactionStatus getPaymentStatus(String transactionHash) throws XRPException {
+  public TransactionStatus getPaymentStatus(String transactionHash) throws XrpException {
     return decoratedClient.getPaymentStatus(transactionHash);
   }
 
@@ -77,13 +74,13 @@ public class XRPClient implements XRPClientInterface {
    * @param destinationAddress The X-Address to send the XRP to.
    * @param sourceWallet       The {@link Wallet} which holds the XRP.
    * @return A transaction hash for the payment.
-   * @throws XRPException If the given inputs were invalid.
+   * @throws XrpException If the given inputs were invalid.
    */
   public String send(
       final BigInteger amount,
       final String destinationAddress,
       final Wallet sourceWallet
-  ) throws XRPException {
+  ) throws XrpException {
     return decoratedClient.send(amount, destinationAddress, sourceWallet);
   }
 
@@ -92,9 +89,9 @@ public class XRPClient implements XRPClientInterface {
    *
    * @param xrplAccountAddress The address to check the existence of.
    * @return A boolean if the account is on the XRP Ledger.
-   * @throws XRPException If the given inputs were invalid.
+   * @throws XrpException If the given inputs were invalid.
    */
-  public boolean accountExists(final String xrplAccountAddress) throws XRPException {
+  public boolean accountExists(final String xrplAccountAddress) throws XrpException {
     return decoratedClient.accountExists(xrplAccountAddress);
   }
 
@@ -107,9 +104,9 @@ public class XRPClient implements XRPClientInterface {
    * </p>
    * @param xrplAccountAddress The address (account) for which to retrieve payment history.
    * @return An array of transactions associated with the account.
-   * @throws XRPException If there was a problem communicating with the XRP Ledger.
+   * @throws XrpException If there was a problem communicating with the XRP Ledger.
    */
-  public List<XRPTransaction> paymentHistory(String xrplAccountAddress) throws XRPException {
+  public List<XrpTransaction> paymentHistory(String xrplAccountAddress) throws XrpException {
     return decoratedClient.paymentHistory(xrplAccountAddress);
   }
 
@@ -120,10 +117,10 @@ public class XRPClient implements XRPClientInterface {
    *       See the `validated` field to make this distinction.
    * </p>
    * @param transactionHash The hash of the transaction to retrieve.
-   * @return An XRPTransaction object representing an XRP Ledger transaction.
+   * @return An XrpTransaction object representing an XRP Ledger transaction.
    * @throws io.grpc.StatusRuntimeException If the transaction hash was invalid.
    */
-  public XRPTransaction getPayment(String transactionHash) throws XRPException {
+  public XrpTransaction getPayment(String transactionHash) throws XrpException {
     return decoratedClient.getPayment(transactionHash);
   }
 }

--- a/src/main/java/io/xpring/xrpl/idiomatic/XrpClientDecorator.java
+++ b/src/main/java/io/xpring/xrpl/idiomatic/XrpClientDecorator.java
@@ -1,26 +1,25 @@
-package io.xpring.xrpl;
+package io.xpring.xrpl.idiomatic;
 
-import io.xpring.xrpl.model.XRPTransaction;
+import io.xpring.xrpl.model.idiomatic.XrpTransaction;
+import io.xpring.xrpl.RawTransactionStatus;
+import io.xpring.xrpl.TransactionStatus;
+import io.xpring.xrpl.Wallet;
 
 import java.math.BigInteger;
 import java.util.List;
 
 /**
  * An common interface shared between XRPClient and the internal hierarchy of decorators.
- *
- * @deprecated Please use the idiomatically named {@link XrpClientDecorator} class instead.
  */
-@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
-@Deprecated
-interface XRPClientDecorator {
+interface XrpClientDecorator {
   /**
    * Get the balance of the specified account on the XRP Ledger.
    *
    * @param xrplAccountAddress The X-Address to retrieve the balance for.
    * @return A {@link BigInteger} with the number of drops in this account.
-   * @throws XRPException If the given inputs were invalid.
+   * @throws XrpException If the given inputs were invalid.
    */
-  BigInteger getBalance(final String xrplAccountAddress) throws XRPException;
+  BigInteger getBalance(final String xrplAccountAddress) throws XrpException;
 
   /**
    * Retrieve the transaction status for a Payment given transaction hash.
@@ -32,9 +31,9 @@ interface XRPClientDecorator {
    *
    * @param transactionHash The hash of the transaction.
    * @return The status of the given transaction.
-   * @throws XRPException If the given inputs were invalid.
+   * @throws XrpException If the given inputs were invalid.
    */
-  public TransactionStatus getPaymentStatus(String transactionHash) throws XRPException;
+  public TransactionStatus getPaymentStatus(String transactionHash) throws XrpException;
 
   /**
    * Transact XRP between two accounts on the ledger.
@@ -43,13 +42,13 @@ interface XRPClientDecorator {
    * @param destinationAddress The X-Address to send the XRP to.
    * @param sourceWallet       The {@link Wallet} which holds the XRP.
    * @return A transaction hash for the payment.
-   * @throws XRPException If the given inputs were invalid.
+   * @throws XrpException If the given inputs were invalid.
    */
   String send(
       final BigInteger amount,
       final String destinationAddress,
       final Wallet sourceWallet
-  ) throws XRPException;
+  ) throws XrpException;
 
   /**
    * Retrieve the latest validated ledger sequence on the XRP Ledger.
@@ -64,18 +63,18 @@ interface XRPClientDecorator {
    * </p>
    * @param address An address that exists at the current time. The address is unchecked and must be a classic address.
    * @return The index of the latest validated ledger.
-   * @throws XRPException If there was a problem communicating with the XRP Ledger.
+   * @throws XrpException If there was a problem communicating with the XRP Ledger.
    */
-  int getLatestValidatedLedgerSequence(String address) throws XRPException;
+  int getLatestValidatedLedgerSequence(String address) throws XrpException;
 
   /**
    * Retrieve the raw transaction status for the given transaction hash.
    *
    * @param transactionHash The hash of the transaction.
    * @return an {@link RawTransactionStatus} containing the raw transaction status.
-   * @throws XRPException If the given inputs were invalid.
+   * @throws XrpException If the given inputs were invalid.
    */
-  RawTransactionStatus getRawTransactionStatus(String transactionHash) throws XRPException;
+  RawTransactionStatus getRawTransactionStatus(String transactionHash) throws XrpException;
 
   /**
    * Return the history of payments for the given account.
@@ -86,18 +85,18 @@ interface XRPClientDecorator {
    * </p>
    * @param address The address (account) for which to retrieve payment history.
    * @return An array of transactions associated with the account.
-   * @throws XRPException If there was a problem communicating with the XRP Ledger.
+   * @throws XrpException If there was a problem communicating with the XRP Ledger.
    */
-  List<XRPTransaction> paymentHistory(String address) throws XRPException;
+  List<XrpTransaction> paymentHistory(String address) throws XrpException;
 
   /**
    * Check if an address exists on the XRP Ledger.
    *
    * @param address The address to check the existence of.
    * @return A boolean if the account is on the XRPLedger.
-   * @throws XRPException If the given inputs were invalid.
+   * @throws XrpException If the given inputs were invalid.
    */
-  boolean accountExists(String address) throws XRPException;
+  boolean accountExists(String address) throws XrpException;
 
   /**
    * Retrieve the payment transaction corresponding to the given transaction hash.
@@ -109,5 +108,5 @@ interface XRPClientDecorator {
    * @return An XRPTransaction object representing an XRP Ledger transaction.
    * @throws io.grpc.StatusRuntimeException If the transaction hash was invalid.
    */
-  XRPTransaction getPayment(String transactionHash) throws XRPException;
+  XrpTransaction getPayment(String transactionHash) throws XrpException;
 }

--- a/src/main/java/io/xpring/xrpl/idiomatic/XrpClientDecorator.java
+++ b/src/main/java/io/xpring/xrpl/idiomatic/XrpClientDecorator.java
@@ -1,9 +1,9 @@
 package io.xpring.xrpl.idiomatic;
 
-import io.xpring.xrpl.model.idiomatic.XrpTransaction;
 import io.xpring.xrpl.RawTransactionStatus;
 import io.xpring.xrpl.TransactionStatus;
 import io.xpring.xrpl.Wallet;
+import io.xpring.xrpl.model.idiomatic.XrpTransaction;
 
 import java.math.BigInteger;
 import java.util.List;

--- a/src/main/java/io/xpring/xrpl/idiomatic/XrpClientInterface.java
+++ b/src/main/java/io/xpring/xrpl/idiomatic/XrpClientInterface.java
@@ -1,8 +1,8 @@
 package io.xpring.xrpl.idiomatic;
 
-import io.xpring.xrpl.Wallet;
-import io.xpring.xrpl.TransactionStatus;
 import io.xpring.common.idiomatic.XrplNetwork;
+import io.xpring.xrpl.TransactionStatus;
+import io.xpring.xrpl.Wallet;
 import io.xpring.xrpl.model.idiomatic.XrpTransaction;
 
 import java.math.BigInteger;

--- a/src/main/java/io/xpring/xrpl/idiomatic/XrpClientInterface.java
+++ b/src/main/java/io/xpring/xrpl/idiomatic/XrpClientInterface.java
@@ -1,32 +1,29 @@
-package io.xpring.xrpl;
+package io.xpring.xrpl.idiomatic;
 
-import io.xpring.common.XRPLNetwork;
-import io.xpring.xrpl.model.XRPTransaction;
+import io.xpring.xrpl.Wallet;
+import io.xpring.xrpl.TransactionStatus;
+import io.xpring.common.idiomatic.XrplNetwork;
+import io.xpring.xrpl.model.idiomatic.XrpTransaction;
 
 import java.math.BigInteger;
 import java.util.List;
 
-/**
- * @deprecated Please use the idiomatically named {@link XrpClientInterface} class instead.
- */
-@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
-@Deprecated
-public interface XRPClientInterface {
+public interface XrpClientInterface {
   /**
-   * Retrieve the network that this XRPClient connects to.
+   * Retrieve the network that this XrpClient connects to.
    *
-   * @return The {@link XRPLNetwork} of an {@link XRPClientInterface}
+   * @return The {@link XrplNetwork} of an {@link XrpClientInterface}
    */
-  public XRPLNetwork getNetwork();
+  public XrplNetwork getNetwork();
 
   /**
    * Get the balance of the specified account on the XRP Ledger.
    *
    * @param xrplAccountAddress The X-Address to retrieve the balance for.
    * @return A {@link BigInteger} with the number of drops in this account.
-   * @throws XRPException If the given inputs were invalid.
+   * @throws XrpException If the given inputs were invalid.
    */
-  BigInteger getBalance(final String xrplAccountAddress) throws XRPException;
+  BigInteger getBalance(final String xrplAccountAddress) throws XrpException;
 
   /**
    * Retrieve the transaction status for a Payment given transaction hash.
@@ -37,9 +34,9 @@ public interface XRPClientInterface {
    * </p>
    * @param transactionHash The hash of the transaction.
    * @return The status of the given transaction.
-   * @throws XRPException If the given inputs were invalid.
+   * @throws XrpException If the given inputs were invalid.
    */
-  TransactionStatus getPaymentStatus(String transactionHash) throws XRPException;
+  TransactionStatus getPaymentStatus(String transactionHash) throws XrpException;
 
   /**
    * Transact XRP between two accounts on the ledger.
@@ -48,9 +45,9 @@ public interface XRPClientInterface {
    * @param destinationAddress The X-Address to send the XRP to.
    * @param sourceWallet       The {@link Wallet} which holds the XRP.
    * @return A transaction hash for the payment.
-   * @throws XRPException If the given inputs were invalid.
+   * @throws XrpException If the given inputs were invalid.
    */
-  public String send(BigInteger amount, String destinationAddress, Wallet sourceWallet) throws XRPException;
+  public String send(BigInteger amount, String destinationAddress, Wallet sourceWallet) throws XrpException;
 
   /**
    * Return the history of payments for the given account.
@@ -61,9 +58,9 @@ public interface XRPClientInterface {
    * </p>
    * @param address The address (account) for which to retrieve payment history.
    * @return An array of transactions associated with the account.
-   * @throws XRPException If there was a problem communicating with the XRP Ledger.
+   * @throws XrpException If there was a problem communicating with the XRP Ledger.
    */
-  public List<XRPTransaction> paymentHistory(String address) throws XRPException;
+  public List<XrpTransaction> paymentHistory(String address) throws XrpException;
 
   /**
    * Retrieve the payment transaction corresponding to the given transaction hash.
@@ -72,8 +69,8 @@ public interface XRPClientInterface {
    *       See the `validated` field to make this distinction.
    * </p>
    * @param transactionHash The hash of the transaction to retrieve.
-   * @return An XRPTransaction object representing an XRP Ledger transaction.
+   * @return An XrpTransaction object representing an XRP Ledger transaction.
    * @throws io.grpc.StatusRuntimeException If the transaction hash was invalid.
    */
-  public XRPTransaction getPayment(String transactionHash) throws XRPException;
+  public XrpTransaction getPayment(String transactionHash) throws XrpException;
 }

--- a/src/main/java/io/xpring/xrpl/idiomatic/XrpException.java
+++ b/src/main/java/io/xpring/xrpl/idiomatic/XrpException.java
@@ -1,0 +1,53 @@
+package io.xpring.xrpl.idiomatic;
+
+/**
+ * Exceptions which occur when working with xpring4j.
+ */
+public class XrpException extends Exception {
+  /**
+   * Static exception for when a classic address is passed to an X-Address API.
+   */
+  public static XrpException xAddressRequiredException = new XrpException(
+      XrpExceptionType.X_ADDRESS_REQUIRED,
+      "Please use the X-Address format. See: https://xrpaddress.info/."
+  );
+
+  /**
+   * Static exception for when a payment transaction can't be converted to an XrpTransaction.
+   */
+  public static XrpException paymentConversionFailure = new XrpException(
+      XrpExceptionType.UNKNOWN,
+      "Could not convert payment transaction: (transaction). Please file a bug at https://github.com/xpring-eng/xpring4j/issues"
+  );
+
+  /**
+   * Static exception for when functionality is unimplemented.
+   */
+  public static XrpException unimplemented = new XrpException(XrpExceptionType.UNIMPLEMENTED, "Unimplemented");
+
+  /**
+   * The type of exception.
+   */
+  private XrpExceptionType type;
+
+  /**
+   * Create a new exception.
+   *
+   * @param type    The type of exception.
+   * @param message The message to to include in the exception
+   */
+  public XrpException(XrpExceptionType type, String message) {
+    super(message);
+
+    this.type = type;
+  }
+
+  /**
+   * The exception type of this {@link XrpException}.
+   *
+   * @return A {@link XrpExceptionType} representing the exception type.
+   */
+  public XrpExceptionType getType() {
+    return this.type;
+  }
+}

--- a/src/main/java/io/xpring/xrpl/idiomatic/XrpExceptionType.java
+++ b/src/main/java/io/xpring/xrpl/idiomatic/XrpExceptionType.java
@@ -1,0 +1,9 @@
+package io.xpring.xrpl.idiomatic;
+
+public enum XrpExceptionType {
+    INVALID_INPUTS,
+    SIGNING_ERROR,
+    UNIMPLEMENTED,
+    UNKNOWN,
+    X_ADDRESS_REQUIRED
+}

--- a/src/main/java/io/xpring/xrpl/model/XRPCurrency.java
+++ b/src/main/java/io/xpring/xrpl/model/XRPCurrency.java
@@ -1,5 +1,6 @@
 package io.xpring.xrpl.model;
 
+import io.xpring.xrpl.model.idiomatic.XrpCurrency;
 import org.immutables.value.Value;
 import org.xrpl.rpc.v1.Currency;
 

--- a/src/main/java/io/xpring/xrpl/model/XRPCurrencyAmount.java
+++ b/src/main/java/io/xpring/xrpl/model/XRPCurrencyAmount.java
@@ -1,6 +1,7 @@
 package io.xpring.xrpl.model;
 
 
+import io.xpring.xrpl.model.idiomatic.XrpCurrencyAmount;
 import org.immutables.value.Value;
 import org.xrpl.rpc.v1.CurrencyAmount;
 import org.xrpl.rpc.v1.IssuedCurrencyAmount;

--- a/src/main/java/io/xpring/xrpl/model/XRPIssuedCurrency.java
+++ b/src/main/java/io/xpring/xrpl/model/XRPIssuedCurrency.java
@@ -1,5 +1,6 @@
 package io.xpring.xrpl.model;
 
+import io.xpring.xrpl.model.idiomatic.XrpIssuedCurrency;
 import org.immutables.value.Value;
 import org.xrpl.rpc.v1.IssuedCurrencyAmount;
 

--- a/src/main/java/io/xpring/xrpl/model/XRPMemo.java
+++ b/src/main/java/io/xpring/xrpl/model/XRPMemo.java
@@ -1,6 +1,7 @@
 package io.xpring.xrpl.model;
 
 import com.google.protobuf.ByteString;
+import io.xpring.xrpl.model.idiomatic.XrpMemo;
 import org.immutables.value.Value;
 import org.xrpl.rpc.v1.Memo;
 

--- a/src/main/java/io/xpring/xrpl/model/XRPPath.java
+++ b/src/main/java/io/xpring/xrpl/model/XRPPath.java
@@ -9,8 +9,11 @@ import java.util.stream.Collectors;
 /**
  * A path in the XRP Ledger.
  *
+ * @deprecated Please use the idiomatically named {@link XrpPath} instead.
+ *
  * @see "https://xrpl.org/paths.html"
  */
+@Deprecated
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 @Value.Immutable
 public interface XRPPath {

--- a/src/main/java/io/xpring/xrpl/model/XRPPath.java
+++ b/src/main/java/io/xpring/xrpl/model/XRPPath.java
@@ -1,5 +1,6 @@
 package io.xpring.xrpl.model;
 
+import io.xpring.xrpl.model.idiomatic.XrpPath;
 import org.immutables.value.Value;
 import org.xrpl.rpc.v1.Payment.Path;
 

--- a/src/main/java/io/xpring/xrpl/model/XRPPathElement.java
+++ b/src/main/java/io/xpring/xrpl/model/XRPPathElement.java
@@ -1,5 +1,6 @@
 package io.xpring.xrpl.model;
 
+import io.xpring.xrpl.model.idiomatic.XrpPathElement;
 import org.immutables.value.Value;
 import org.xrpl.rpc.v1.Payment.PathElement;
 

--- a/src/main/java/io/xpring/xrpl/model/XRPPayment.java
+++ b/src/main/java/io/xpring/xrpl/model/XRPPayment.java
@@ -1,5 +1,6 @@
 package io.xpring.xrpl.model;
 
+import io.xpring.xrpl.model.idiomatic.XrpPayment;
 import org.immutables.value.Value;
 import org.xrpl.rpc.v1.Payment;
 

--- a/src/main/java/io/xpring/xrpl/model/XRPSigner.java
+++ b/src/main/java/io/xpring/xrpl/model/XRPSigner.java
@@ -1,5 +1,6 @@
 package io.xpring.xrpl.model;
 
+import io.xpring.xrpl.model.idiomatic.XrpSigner;
 import org.immutables.value.Value;
 import org.xrpl.rpc.v1.Signer;
 

--- a/src/main/java/io/xpring/xrpl/model/XRPTransaction.java
+++ b/src/main/java/io/xpring/xrpl/model/XRPTransaction.java
@@ -2,6 +2,7 @@ package io.xpring.xrpl.model;
 
 import io.xpring.xrpl.TransactionType;
 import io.xpring.xrpl.Utils;
+import io.xpring.xrpl.model.idiomatic.XrpTransaction;
 import org.immutables.value.Value;
 import org.xrpl.rpc.v1.CurrencyAmount;
 import org.xrpl.rpc.v1.GetTransactionResponse;

--- a/src/main/java/io/xpring/xrpl/model/idiomatic/XrpCurrency.java
+++ b/src/main/java/io/xpring/xrpl/model/idiomatic/XrpCurrency.java
@@ -1,4 +1,4 @@
-package io.xpring.xrpl.model;
+package io.xpring.xrpl.model.idiomatic;
 
 import org.immutables.value.Value;
 import org.xrpl.rpc.v1.Currency;
@@ -6,16 +6,13 @@ import org.xrpl.rpc.v1.Currency;
 /**
  * An issued currency on the XRP Ledger.
  *
- * @deprecated Please use the idiomatically named {@link XrpCurrency} instead.
- *
  * @see "https://xrpl.org/currency-formats.html#currency-codes"
  */
-@Deprecated
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 @Value.Immutable
-public interface XRPCurrency {
-  static ImmutableXRPCurrency.Builder builder() {
-    return ImmutableXRPCurrency.builder();
+public interface XrpCurrency {
+  static ImmutableXrpCurrency.Builder builder() {
+    return ImmutableXrpCurrency.builder();
   }
 
   /**
@@ -33,15 +30,15 @@ public interface XRPCurrency {
   byte[] code();
 
   /**
-   * Constructs an {@link XRPCurrency} from a {@link Currency}.
+   * Constructs an {@link XrpCurrency} from a {@link Currency}.
    *
    * @param currency a {@link Currency} (protobuf object) whose field values will be used
-   *                 to construct an {@link XRPCurrency}
-   * @return an {@link XRPCurrency} with its fields set via the analogous protobuf fields.
+   *                 to construct an {@link XrpCurrency}
+   * @return an {@link XrpCurrency} with its fields set via the analogous protobuf fields.
    * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/amount.proto#L41">
    * Currency protocol buffer</a>
    */
-  static XRPCurrency from(Currency currency) {
+  static XrpCurrency from(Currency currency) {
     return builder()
         .name(currency.getName())
         .code(currency.getCode().toByteArray())

--- a/src/main/java/io/xpring/xrpl/model/idiomatic/XrpCurrencyAmount.java
+++ b/src/main/java/io/xpring/xrpl/model/idiomatic/XrpCurrencyAmount.java
@@ -1,25 +1,21 @@
-package io.xpring.xrpl.model;
+package io.xpring.xrpl.model.idiomatic;
 
 
 import org.immutables.value.Value;
 import org.xrpl.rpc.v1.CurrencyAmount;
-import org.xrpl.rpc.v1.IssuedCurrencyAmount;
 
 import java.util.Optional;
 
 /**
  * An amount of currency on the XRP Ledger.
  *
- * @deprecated Please use the idiomatically named {@link XrpCurrencyAmount} instead.
- *
  * @see "https://xrpl.org/basic-data-types.html#specifying-currency-amounts"
  */
-@Deprecated
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 @Value.Immutable
-public interface XRPCurrencyAmount {
-  static ImmutableXRPCurrencyAmount.Builder builder() {
-    return ImmutableXRPCurrencyAmount.builder();
+public interface XrpCurrencyAmount {
+  static ImmutableXrpCurrencyAmount.Builder builder() {
+    return ImmutableXrpCurrencyAmount.builder();
   }
 
   /**
@@ -34,24 +30,24 @@ public interface XRPCurrencyAmount {
    * (Optional) An amount of an issued currency.
    * Note: Mutually exclusive fields - only drops XOR issuedCurrency should be set.
    *
-   * @return The Optional {@link XRPIssuedCurrency} of this {@link XRPCurrencyAmount}.
+   * @return The Optional {@link XrpIssuedCurrency} of this {@link XrpCurrencyAmount}.
    */
-  Optional<XRPIssuedCurrency> issuedCurrency();
+  Optional<XrpIssuedCurrency> issuedCurrency();
 
   /**
-   * Constructs an {@link XRPCurrencyAmount} from a {@link CurrencyAmount}.
+   * Constructs an {@link XrpCurrencyAmount} from a {@link CurrencyAmount}.
    *
    * @param currencyAmount a {@link CurrencyAmount} (protobuf object) whose field values will be used
-   *                       to construct an {@link XRPCurrencyAmount}
-   * @return an {@link XRPCurrencyAmount} with its fields set via the analogous protobuf fields.
+   *                       to construct an {@link XrpCurrencyAmount}
+   * @return an {@link XrpCurrencyAmount} with its fields set via the analogous protobuf fields.
    * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/amount.proto#L10">
    * CurrencyAmount protocol buffer</a>
    */
-  static XRPCurrencyAmount from(CurrencyAmount currencyAmount) throws NumberFormatException {
+  static XrpCurrencyAmount from(CurrencyAmount currencyAmount) throws NumberFormatException {
     switch (currencyAmount.getAmountCase()) {
       // Mutually exclusive: either drops or issuedCurrency is set in an XRPCurrencyAmount
       case ISSUED_CURRENCY_AMOUNT: {
-        XRPIssuedCurrency xrpIssuedCurrency = XRPIssuedCurrency.from(currencyAmount.getIssuedCurrencyAmount());
+        XrpIssuedCurrency xrpIssuedCurrency = XrpIssuedCurrency.from(currencyAmount.getIssuedCurrencyAmount());
         if (xrpIssuedCurrency != null) {
           return builder().issuedCurrency(xrpIssuedCurrency).build();
         }

--- a/src/main/java/io/xpring/xrpl/model/idiomatic/XrpIssuedCurrency.java
+++ b/src/main/java/io/xpring/xrpl/model/idiomatic/XrpIssuedCurrency.java
@@ -1,4 +1,4 @@
-package io.xpring.xrpl.model;
+package io.xpring.xrpl.model.idiomatic;
 
 import org.immutables.value.Value;
 import org.xrpl.rpc.v1.IssuedCurrencyAmount;
@@ -8,24 +8,21 @@ import java.math.BigInteger;
 /**
  * An issued currency on the XRP Ledger.
  *
- * @deprecated Please use the idiomatically named {@link XrpIssuedCurrency} instead.
- *
  * @see "https://xrpl.org/basic-data-types.html#specifying-currency-amounts"
  */
-@Deprecated
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 @Value.Immutable
-public interface XRPIssuedCurrency {
-  static ImmutableXRPIssuedCurrency.Builder builder() {
-    return ImmutableXRPIssuedCurrency.builder();
+public interface XrpIssuedCurrency {
+  static ImmutableXrpIssuedCurrency.Builder builder() {
+    return ImmutableXrpIssuedCurrency.builder();
   }
 
   /**
-   * The {@link XRPCurrency} used to value the amount.
+   * The {@link XrpCurrency} used to value the amount.
    *
-   * @return The {@link XRPCurrency} used to value the amount.
+   * @return The {@link XrpCurrency} used to value the amount.
    */
-  XRPCurrency currency();
+  XrpCurrency currency();
 
   /**
    * The value of the amount.
@@ -42,15 +39,15 @@ public interface XRPIssuedCurrency {
   String issuer();
 
   /**
-   * Constructs an {@link XRPIssuedCurrency} from a {@link IssuedCurrencyAmount}.
+   * Constructs an {@link XrpIssuedCurrency} from a {@link IssuedCurrencyAmount}.
    *
    * @param issuedCurrency a {@link IssuedCurrencyAmount} (protobuf object) whose field values will be used
-   *                       to construct an {@link XRPIssuedCurrency}
-   * @return an {@link XRPIssuedCurrency} with its fields set via the analogous protobuf fields.
+   *                       to construct an {@link XrpIssuedCurrency}
+   * @return an {@link XrpIssuedCurrency} with its fields set via the analogous protobuf fields.
    * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/amount.proto#L28">
    * IssuedCurrencyAmount protocol buffer</a>
    */
-  static XRPIssuedCurrency from(IssuedCurrencyAmount issuedCurrency) {
+  static XrpIssuedCurrency from(IssuedCurrencyAmount issuedCurrency) {
     BigInteger value;
     try {
       value = new BigInteger((issuedCurrency.getValue()));
@@ -59,7 +56,7 @@ public interface XRPIssuedCurrency {
     }
 
     return builder()
-        .currency(XRPCurrency.from(issuedCurrency.getCurrency()))
+        .currency(XrpCurrency.from(issuedCurrency.getCurrency()))
         .value(value)
         .issuer(issuedCurrency.getIssuer().getAddress())
         .build();

--- a/src/main/java/io/xpring/xrpl/model/idiomatic/XrpMemo.java
+++ b/src/main/java/io/xpring/xrpl/model/idiomatic/XrpMemo.java
@@ -1,4 +1,4 @@
-package io.xpring.xrpl.model;
+package io.xpring.xrpl.model.idiomatic;
 
 import com.google.protobuf.ByteString;
 import org.immutables.value.Value;
@@ -7,16 +7,13 @@ import org.xrpl.rpc.v1.Memo;
 /**
  * Represents a memo on the XRPLedger.
  *
- * @deprecated Please use the idiomatically named {@link XrpMemo} instead.
- *
  * @see "https://xrpl.org/transaction-common-fields.html#memos-field"
  */
-@Deprecated
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 @Value.Immutable
-public interface XRPMemo {
-  static ImmutableXRPMemo.Builder builder() {
-    return ImmutableXRPMemo.builder();
+public interface XrpMemo {
+  static ImmutableXrpMemo.Builder builder() {
+    return ImmutableXrpMemo.builder();
   }
 
   /**
@@ -52,15 +49,15 @@ public interface XRPMemo {
   }
 
   /**
-   * Constructs an {@link XRPMemo} from a {@link Memo}.
+   * Constructs an {@link XrpMemo} from a {@link Memo}.
    *
    * @param memo a {@link Memo} (protobuf object) whose field values will be used
-   *             to construct an {@link XRPMemo}
-   * @return an {@link XRPMemo} with its fields set via the analogous protobuf fields.
+   *             to construct an {@link XrpMemo}
+   * @return an {@link XrpMemo} with its fields set via the analogous protobuf fields.
    * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L80">
    * Memo protocol buffer</a>
    */
-  static XRPMemo from(Memo memo) {
+  static XrpMemo from(Memo memo) {
     ByteString memoData = memo.getMemoData().getValue();
     byte[] data = memoData.toByteArray();
 
@@ -70,7 +67,7 @@ public interface XRPMemo {
     ByteString memoType = memo.getMemoType().getValue();
     byte[] type = memoType.toByteArray();
 
-    return XRPMemo.builder()
+    return XrpMemo.builder()
         .data(data)
         .format(format)
         .type(type)

--- a/src/main/java/io/xpring/xrpl/model/idiomatic/XrpPath.java
+++ b/src/main/java/io/xpring/xrpl/model/idiomatic/XrpPath.java
@@ -1,0 +1,46 @@
+package io.xpring.xrpl.model.idiomatic;
+
+import org.immutables.value.Value;
+import org.xrpl.rpc.v1.Payment.Path;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A path in the XRP Ledger.
+ *
+ * @see "https://xrpl.org/paths.html"
+ */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+@Value.Immutable
+public interface XrpPath {
+  static ImmutableXrpPath.Builder builder() {
+    return ImmutableXrpPath.builder();
+  }
+
+  /**
+   * The elements of this {@link XrpPath}.
+   *
+   * @return A List of {@link XrpPathElement}s that make up this {@link XrpPath}.
+   */
+  List<XrpPathElement> pathElements();
+
+  /**
+   * Constructs an {@link XrpPath} from a {@link org.xrpl.rpc.v1.Payment.Path}.
+   *
+   * @param path a {@link org.xrpl.rpc.v1.Payment.Path} (protobuf object) whose field values will be used
+   *             to construct an {@link XrpPath}.
+   * @return an {@link XrpPath} with its fields set via the analogous protobuf fields.
+   * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L237">
+   * Path protocol buffer</a>
+   */
+  static XrpPath from(Path path) {
+    List<XrpPathElement> pathElements = path.getElementsList()
+        .stream()
+        .map(XrpPathElement::from)
+        .collect(Collectors.toList());
+    return builder()
+        .pathElements(pathElements)
+        .build();
+  }
+}

--- a/src/main/java/io/xpring/xrpl/model/idiomatic/XrpPathElement.java
+++ b/src/main/java/io/xpring/xrpl/model/idiomatic/XrpPathElement.java
@@ -1,4 +1,4 @@
-package io.xpring.xrpl.model;
+package io.xpring.xrpl.model.idiomatic;
 
 import org.immutables.value.Value;
 import org.xrpl.rpc.v1.Payment.PathElement;
@@ -8,23 +8,20 @@ import java.util.Optional;
 /**
  * A path step in an XRP Ledger Path.
  *
- * @deprecated Please use the idiomatically named {@link XrpPathElement} instead.
- *
  * @see "https://xrpl.org/paths.html#path-steps"
  */
-@Deprecated
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 @Value.Immutable
-public interface XRPPathElement {
-  static ImmutableXRPPathElement.Builder builder() {
-    return ImmutableXRPPathElement.builder();
+public interface XrpPathElement {
+  static ImmutableXrpPathElement.Builder builder() {
+    return ImmutableXrpPathElement.builder();
   }
 
   /**
    * (Optional) If present, this path step represents rippling through the specified address.
    * MUST NOT be provided if this path element specifies the currency or issuer fields.
    *
-   * @return An Optional {@link String} representing the account of this {@link XRPPathElement}.
+   * @return An Optional {@link String} representing the account of this {@link XrpPathElement}.
    */
   Optional<String> account();
 
@@ -33,9 +30,9 @@ public interface XRPPathElement {
    * The currency specified indicates the new currency. MUST NOT be provided if this path
    * element specifies the account field.
    *
-   * @return The Optional {@link XRPCurrency} of this {@link XRPPathElement}.
+   * @return The Optional {@link XrpCurrency} of this {@link XrpPathElement}.
    */
-  Optional<XRPCurrency> currency();
+  Optional<XrpCurrency> currency();
 
   /**
    * (Optional) If present, this path element represents changing currencies and this address
@@ -49,24 +46,24 @@ public interface XRPPathElement {
   Optional<String> issuer();
 
   /**
-   * Constructs an {@link XRPPathElement} from a {@link org.xrpl.rpc.v1.Payment.PathElement}.
+   * Constructs an {@link XrpPathElement} from a {@link org.xrpl.rpc.v1.Payment.PathElement}.
    *
    * @param pathElement a {@link org.xrpl.rpc.v1.Payment.PathElement} (protobuf object) whose field values will be used
-   *                    to construct an {@link XRPPathElement}
-   * @return an {@link XRPPathElement} with its fields set via the analogous protobuf fields.
+   *                    to construct an {@link XrpPathElement}
+   * @return an {@link XrpPathElement} with its fields set via the analogous protobuf fields.
    * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L227">
    * PathElement protocol buffer</a>
    */
-  static XRPPathElement from(PathElement pathElement) {
+  static XrpPathElement from(PathElement pathElement) {
     Optional<String> account = Optional.empty();
     if (pathElement.hasAccount()) {
       account = Optional.ofNullable(pathElement.getAccount().getAddress().isEmpty()
               ? null : pathElement.getAccount().getAddress());
     }
 
-    Optional<XRPCurrency> currency = Optional.empty();
+    Optional<XrpCurrency> currency = Optional.empty();
     if (pathElement.hasCurrency()) {
-      currency = Optional.ofNullable(XRPCurrency.from(pathElement.getCurrency()));
+      currency = Optional.ofNullable(XrpCurrency.from(pathElement.getCurrency()));
     }
 
     Optional<String> issuer = Optional.empty();

--- a/src/main/java/io/xpring/xrpl/model/idiomatic/XrpPayment.java
+++ b/src/main/java/io/xpring/xrpl/model/idiomatic/XrpPayment.java
@@ -1,4 +1,4 @@
-package io.xpring.xrpl.model;
+package io.xpring.xrpl.model.idiomatic;
 
 import org.immutables.value.Value;
 import org.xrpl.rpc.v1.Payment;
@@ -11,24 +11,21 @@ import java.util.stream.Collectors;
 /**
  * A payment on the XRP Ledger.
  *
- * @deprecated Please use the idiomatically named {@link XrpPayment} instead.
- *
  * @see "https://xrpl.org/payment.html"
  */
-@Deprecated
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 @Value.Immutable
-public interface XRPPayment {
-  static ImmutableXRPPayment.Builder builder() {
-    return ImmutableXRPPayment.builder();
+public interface XrpPayment {
+  static ImmutableXrpPayment.Builder builder() {
+    return ImmutableXrpPayment.builder();
   }
 
   /**
    * The amount of currency to deliver.
    *
-   * @return An {@link XRPCurrencyAmount} representing the amount of currency to deliver.
+   * @return An {@link XrpCurrencyAmount} representing the amount of currency to deliver.
    */
-  XRPCurrencyAmount amount();
+  XrpCurrencyAmount amount();
 
   /**
    * The unique address of the account receiving the payment.
@@ -47,10 +44,10 @@ public interface XRPPayment {
   /**
    * (Optional) Minimum amount of destination currency this transaction should deliver.
    *
-   * @return An {@link XRPCurrencyAmount} representing the minimum amount of destination currency this
+   * @return An {@link XrpCurrencyAmount} representing the minimum amount of destination currency this
    *          transaction should deliver.
    */
-  Optional<XRPCurrencyAmount> deliverMin();
+  Optional<XrpCurrencyAmount> deliverMin();
 
   /**
    * (Optional) Arbitrary 256-bit hash representing a specific reason or identifier for this payment.
@@ -66,33 +63,33 @@ public interface XRPPayment {
    * (Optional) Array of payment paths to be used for this transaction.
    * Must be omitted for XRP-to-XRP transactions.
    *
-   * @return A {@link List} of {@link XRPPath}s containing the paths to be used for this transaction.
+   * @return A {@link List} of {@link XrpPath}s containing the paths to be used for this transaction.
    */
   @Value.Default
-  default List<XRPPath> paths() {
+  default List<XrpPath> paths() {
     return new ArrayList<>();
   }
 
   /**
    * (Optional) Highest amount of source currency this transaction is allowed to cost.
    *
-   * @return An {@link XRPCurrencyAmount} representing the highest amount of source currency this
+   * @return An {@link XrpCurrencyAmount} representing the highest amount of source currency this
    *          transaction is allowed to cost.
    */
-  Optional<XRPCurrencyAmount> sendMax();
+  Optional<XrpCurrencyAmount> sendMax();
 
   /**
-   * Constructs an {@link XRPPayment} from a {@link org.xrpl.rpc.v1.Payment}.
+   * Constructs an {@link XrpPayment} from a {@link org.xrpl.rpc.v1.Payment}.
    *
    * @param payment a {@link org.xrpl.rpc.v1.Payment} (protobuf object) whose field values will be used
-   *                to construct an {@link XRPPayment}
-   * @return an {@link XRPPayment} with its fields set via the analogous protobuf fields.
+   *                to construct an {@link XrpPayment}
+   * @return an {@link XrpPayment} with its fields set via the analogous protobuf fields.
    * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L224">
    * Payment protocol buffer</a>
    */
-  static XRPPayment from(Payment payment) {
+  static XrpPayment from(Payment payment) {
     // amount is required
-    XRPCurrencyAmount amount = XRPCurrencyAmount.from(payment.getAmount().getValue());
+    XrpCurrencyAmount amount = XrpCurrencyAmount.from(payment.getAmount().getValue());
     if (amount == null) {
       return null;
     }
@@ -109,9 +106,9 @@ public interface XRPPayment {
     }
 
     // If the deliverMin field is set, it must be able to be transformed into an XRPCurrencyAmount.
-    Optional<XRPCurrencyAmount> deliverMin = Optional.empty();
+    Optional<XrpCurrencyAmount> deliverMin = Optional.empty();
     if (payment.hasDeliverMin()) {
-      deliverMin = Optional.ofNullable(XRPCurrencyAmount.from(payment.getDeliverMin().getValue()));
+      deliverMin = Optional.ofNullable(XrpCurrencyAmount.from(payment.getDeliverMin().getValue()));
       if (!deliverMin.isPresent()) {
         return null;
       }
@@ -119,15 +116,15 @@ public interface XRPPayment {
 
     byte[] invoiceID = payment.getInvoiceId().getValue().toByteArray();
 
-    List<XRPPath> paths = payment.getPathsList()
+    List<XrpPath> paths = payment.getPathsList()
         .stream()
-        .map(XRPPath::from)
+        .map(XrpPath::from)
         .collect(Collectors.toList());
 
     // If the sendMax field is set, it must be able to be transformed into an XRPCurrencyAmount.
-    Optional<XRPCurrencyAmount> sendMax = Optional.empty();
+    Optional<XrpCurrencyAmount> sendMax = Optional.empty();
     if (payment.hasSendMax()) {
-      sendMax = Optional.ofNullable(XRPCurrencyAmount.from(payment.getSendMax().getValue()));
+      sendMax = Optional.ofNullable(XrpCurrencyAmount.from(payment.getSendMax().getValue()));
       if (!sendMax.isPresent()) {
         return null;
       }

--- a/src/main/java/io/xpring/xrpl/model/idiomatic/XrpSigner.java
+++ b/src/main/java/io/xpring/xrpl/model/idiomatic/XrpSigner.java
@@ -1,4 +1,4 @@
-package io.xpring.xrpl.model;
+package io.xpring.xrpl.model.idiomatic;
 
 import org.immutables.value.Value;
 import org.xrpl.rpc.v1.Signer;
@@ -6,16 +6,13 @@ import org.xrpl.rpc.v1.Signer;
 /**
  * Represents a signer of a transaction on the XRP Ledger.
  *
- * @deprecated Please use the idiomatically named {@link XrpSigner} instead.
- *
  * @see "https://xrpl.org/transaction-common-fields.html#signers-field"
  */
-@Deprecated
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 @Value.Immutable
-public interface XRPSigner {
-  static ImmutableXRPSigner.Builder builder() {
-    return ImmutableXRPSigner.builder();
+public interface XrpSigner {
+  static ImmutableXrpSigner.Builder builder() {
+    return ImmutableXrpSigner.builder();
   }
 
   /**
@@ -40,22 +37,22 @@ public interface XRPSigner {
   byte[] transactionSignature();
 
   /**
-   * Constructs an {@link XRPSigner} from a {@link Signer}.
+   * Constructs an {@link XrpSigner} from a {@link Signer}.
    *
    * @param signer a {@link Signer} (protobuf object) whose field values will be used
-   *               to construct an {@link XRPSigner}
-   * @return an {@link XRPSigner} with its fields set via the analogous protobuf fields.
+   *               to construct an {@link XrpSigner}
+   * @return an {@link XrpSigner} with its fields set via the analogous protobuf fields.
    * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L90">
    * Signer protocol buffer</a>
    */
-  static XRPSigner from(Signer signer) {
+  static XrpSigner from(Signer signer) {
     String account = signer.getAccount().getValue().getAddress();
 
     byte[] signingPublicKey = signer.getSigningPublicKey().getValue().toByteArray();
 
     byte[] transactionSignature = signer.getTransactionSignature().getValue().toByteArray();
 
-    return XRPSigner.builder()
+    return XrpSigner.builder()
         .account(account)
         .signingPublicKey(signingPublicKey)
         .transactionSignature(transactionSignature)

--- a/src/main/java/io/xpring/xrpl/model/idiomatic/XrpTransaction.java
+++ b/src/main/java/io/xpring/xrpl/model/idiomatic/XrpTransaction.java
@@ -1,4 +1,4 @@
-package io.xpring.xrpl.model;
+package io.xpring.xrpl.model.idiomatic;
 
 import io.xpring.xrpl.TransactionType;
 import io.xpring.xrpl.Utils;
@@ -16,17 +16,14 @@ import java.util.stream.Collectors;
 /**
  * A transaction on the XRP Ledger.
  *
- * @deprecated Please use the idiomatically named {@link XrpTransaction} instead.
- *
  * @see "https://xrpl.org/transaction-formats.html"
  */
 // TODO(amiecorso): Modify this object to use X-Address format.
-@Deprecated
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 @Value.Immutable
-public interface XRPTransaction {
-  static ImmutableXRPTransaction.Builder builder() {
-    return ImmutableXRPTransaction.builder();
+public interface XrpTransaction {
+  static ImmutableXrpTransaction.Builder builder() {
+    return ImmutableXrpTransaction.builder();
   }
 
   /**
@@ -81,10 +78,10 @@ public interface XRPTransaction {
   /**
    * (Optional) Additional arbitrary information used to identify this transaction.
    *
-   * @return A {@link List} of {@link XRPMemo}s containing additional information for this transaction.
+   * @return A {@link List} of {@link XrpMemo}s containing additional information for this transaction.
    */
   @Value.Default
-  default List<XRPMemo> memos() {
+  default List<XrpMemo> memos() {
     return new ArrayList<>();
   }
 
@@ -100,11 +97,11 @@ public interface XRPTransaction {
   /**
    * (Optional) A collection of signers that represent a multi-signature which authorizes this transaction.
    *
-   * @return An optional {@link List} of {@link XRPSigner}s that represent a multi-signature which
+   * @return An optional {@link List} of {@link XrpSigner}s that represent a multi-signature which
    *          authorizes this transaction.
    */
   @Value.Default
-  default List<XRPSigner> signers() {
+  default List<XrpSigner> signers() {
     return new ArrayList<>();
   }
 
@@ -141,12 +138,12 @@ public interface XRPTransaction {
   TransactionType type();
 
   /**
-   * Additional fields present in an {@link XRPPayment}.
+   * Additional fields present in an {@link XrpPayment}.
    *
-   * @return A {@link XRPPayment} representing the additional fields present in an {@link XRPPayment}.
+   * @return A {@link XrpPayment} representing the additional fields present in an {@link XrpPayment}.
    * @see "https://xrpl.org/payment.html#payment-fields"
    */
-  XRPPayment paymentFields();
+  XrpPayment paymentFields();
 
   /**
    * (Optional) The timestamp of the transaction reported in Unix time (seconds).
@@ -181,15 +178,15 @@ public interface XRPTransaction {
   int ledgerIndex();
 
   /**
-   * Constructs an {@link XRPTransaction} from a {@link GetTransactionResponse}.
+   * Constructs an {@link XrpTransaction} from a {@link GetTransactionResponse}.
    *
    * @param getTransactionResponse a {@link GetTransactionResponse} (protobuf object) whose field values will be used
-   *                    to construct an {@link XRPTransaction}
-   * @return an {@link XRPTransaction} with its fields set via the analogous protobuf fields.
+   *                    to construct an {@link XrpTransaction}
+   * @return an {@link XrpTransaction} with its fields set via the analogous protobuf fields.
    * @see <a href="https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/get_transaction.proto#L31">
    * GetTransactionResponse protocol buffer</a>
    */
-  static XRPTransaction from(GetTransactionResponse getTransactionResponse) {
+  static XrpTransaction from(GetTransactionResponse getTransactionResponse) {
     final Transaction transaction = getTransactionResponse.getTransaction();
     if (transaction == null) {
       return null;
@@ -214,16 +211,16 @@ public interface XRPTransaction {
       lastLedgerSequence = Optional.of(transaction.getLastLedgerSequence().getValue());
     }
 
-    final List<XRPMemo> memos = transaction.getMemosList()
+    final List<XrpMemo> memos = transaction.getMemosList()
         .stream()
-        .map(XRPMemo::from)
+        .map(XrpMemo::from)
         .collect(Collectors.toList());
 
     final Integer sequence = transaction.getSequence().getValue();
 
-    final List<XRPSigner> signers = transaction.getSignersList()
+    final List<XrpSigner> signers = transaction.getSignersList()
         .stream()
-        .map(XRPSigner::from)
+        .map(XrpSigner::from)
         .collect(Collectors.toList());
 
     final byte[] signingPublicKey = transaction.getSigningPublicKey().getValue().toByteArray();
@@ -236,11 +233,11 @@ public interface XRPTransaction {
     final byte[] transactionSignature = transaction.getTransactionSignature().getValue().toByteArray();
 
     TransactionType type;
-    XRPPayment paymentFields;
+    XrpPayment paymentFields;
     switch (transaction.getTransactionDataCase()) {
       case PAYMENT: {
         Payment payment = transaction.getPayment();
-        paymentFields = XRPPayment.from(payment);
+        paymentFields = XrpPayment.from(payment);
         if (paymentFields == null) {
           return null;
         }
@@ -283,7 +280,7 @@ public interface XRPTransaction {
 
     final int ledgerIndex = getTransactionResponse.getLedgerIndex();
 
-    return XRPTransaction.builder()
+    return XrpTransaction.builder()
         .hash(hash)
         .account(account)
         .accountTransactionID(accountTransactionID)

--- a/src/test/java/io/xpring/payid/XRPPayIDClientTest.java
+++ b/src/test/java/io/xpring/payid/XRPPayIDClientTest.java
@@ -9,7 +9,6 @@ import static org.junit.Assert.assertEquals;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.xpring.common.XRPLNetwork;
-import io.xpring.payid.idiomatic.PayIdException;
 import io.xpring.xrpl.ClassicAddress;
 import io.xpring.xrpl.ImmutableClassicAddress;
 import io.xpring.xrpl.Utils;


### PR DESCRIPTION
## High Level Overview of Change

Java prefers to case classes as `Xrp` rather than `XRP`.

### Context of Change

This is a one shot PR to re-case all the java classes. Existing classes are deprecated.

Due to Java's requirement that all file names are the same as the class and MacOS's case insensitive file system, we need to place the new classes in a new `idiomatic` package. A future migration will remove this package after the original namespace is freed. 

### Type of Change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release


## Before / After

Clients are advised to move to idiomatically named classes.

## Test Plan

CI