### PR TITLE
Adds X-Addresses to `XRPTransaction` and `XRPPayment` model objects

### DIFF
--- a/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
+++ b/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
@@ -4,6 +4,7 @@ import com.google.protobuf.ByteString;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
+import io.xpring.common.XRPLNetwork;
 import io.xpring.xrpl.model.XRPTransaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,15 +54,17 @@ public class DefaultXRPClient implements XRPClientDecorator {
 
   // Channel is the abstraction to connect to a service endpoint
   private final XRPLedgerAPIServiceBlockingStub stub;
+  private final XRPLNetwork xrplNetwork;
 
   /**
    * No-args Constructor.
    */
-  DefaultXRPClient(String grpcURL) {
+  DefaultXRPClient(String grpcURL, XRPLNetwork xrplNetwork) {
     this(ManagedChannelBuilder
         .forTarget(grpcURL)
         .usePlaintext()
-        .build()
+        .build(),
+        xrplNetwork
     );
   }
 
@@ -70,7 +73,9 @@ public class DefaultXRPClient implements XRPClientDecorator {
    *
    * @param channel A {@link ManagedChannel}.
    */
-  DefaultXRPClient(final ManagedChannel channel) {
+  DefaultXRPClient(final ManagedChannel channel, XRPLNetwork network) {
+    this.xrplNetwork = network;
+
     // It is up to the client to determine whether to block the call. Here we create a blocking stub, but an async
     // stub, or an async stub with Future are always possible.
     this.stub = XRPLedgerAPIServiceGrpc.newBlockingStub(channel);

--- a/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
+++ b/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
@@ -257,7 +257,7 @@ public class DefaultXRPClient implements XRPClientDecorator {
       Transaction transaction = transactionResponse.getTransaction();
       switch (transaction.getTransactionDataCase()) {
         case PAYMENT: {
-          XRPTransaction xrpTransaction = XRPTransaction.from(transactionResponse);
+          XRPTransaction xrpTransaction = XRPTransaction.from(transactionResponse, xrplNetwork);
           if (xrpTransaction == null) {
             throw XRPException.paymentConversionFailure;
           } else {
@@ -316,7 +316,7 @@ public class DefaultXRPClient implements XRPClientDecorator {
     GetTransactionRequest request = GetTransactionRequest.newBuilder()
             .setHash(transactionHashByteString).build();
     GetTransactionResponse response = this.stub.getTransaction(request);
-    return XRPTransaction.from(response);
+    return XRPTransaction.from(response, xrplNetwork);
   }
 
   public int getOpenLedgerSequence() throws XRPException {

--- a/src/main/java/io/xpring/xrpl/XRPClient.java
+++ b/src/main/java/io/xpring/xrpl/XRPClient.java
@@ -27,7 +27,7 @@ public class XRPClient implements XRPClientInterface {
    * @param network The network this XRPClient is connecting to.
    */
   public XRPClient(String grpcURL, XRPLNetwork network) {
-    XRPClientDecorator defaultXRPClient = new DefaultXRPClient(grpcURL);
+    XRPClientDecorator defaultXRPClient = new DefaultXRPClient(grpcURL, network);
     this.decoratedClient = new ReliableSubmissionXRPClient(defaultXRPClient);
 
     this.network = network;

--- a/src/test/java/io/xpring/xrpl/DefaultXRPClientTest.java
+++ b/src/test/java/io/xpring/xrpl/DefaultXRPClientTest.java
@@ -13,6 +13,7 @@ import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
 import io.xpring.common.Result;
+import io.xpring.common.XRPLNetwork;
 import io.xpring.xrpl.helpers.XRPTestUtils;
 import io.xpring.xrpl.model.XRPTransaction;
 import org.immutables.value.internal.$guava$.base.$Throwables;
@@ -575,7 +576,7 @@ public class DefaultXRPClientTest {
         InProcessChannelBuilder.forName(serverName).directExecutor().build());
 
     // Create a new XRPClient using the in-process channel;
-    return new DefaultXRPClient(channel);
+    return new DefaultXRPClient(channel, XRPLNetwork.TEST);
   }
 
 

--- a/src/test/java/io/xpring/xrpl/DefaultXRPClientTest.java
+++ b/src/test/java/io/xpring/xrpl/DefaultXRPClientTest.java
@@ -469,7 +469,11 @@ public class DefaultXRPClientTest {
     XRPTransaction transaction = xrpClient.getPayment(TRANSACTION_HASH);
 
     // THEN the returned transaction is as expected.
-    assertThat(transaction).isEqualTo(XRPTransaction.from(FakeXRPProtobufs.getTransactionResponsePaymentAllFields));
+    assertThat(transaction).isEqualTo(XRPTransaction.from(
+            FakeXRPProtobufs.getTransactionResponsePaymentAllFields,
+            XRPLNetwork.TEST
+      )
+    );
   }
 
   @Test

--- a/src/test/java/io/xpring/xrpl/FakeXRPProtobufs.java
+++ b/src/test/java/io/xpring/xrpl/FakeXRPProtobufs.java
@@ -50,8 +50,8 @@ public class FakeXRPProtobufs {
   public static String testCurrencyName = "currencyName";
   public static ByteString testCurrencyCode;
 
-  public static String fakeAddress1 = "r123";
-  public static String fakeAddress2 = "r456";
+  public static String fakeAddress1 = "rsKouRxYLWGseFwXSAo57qXjcGiNqR55wr";
+  public static String fakeAddress2 = "rPuNV4oA6f3SrKA4pLEpdVZW6QLvn3UJxK";
 
   static {
     try {

--- a/src/test/java/io/xpring/xrpl/ProtocolBufferConversionTest.java
+++ b/src/test/java/io/xpring/xrpl/ProtocolBufferConversionTest.java
@@ -206,7 +206,7 @@ public class ProtocolBufferConversionTest {
                     .isTest(false)
                     .build()
             )
-          );
+    );
     assertThat(xrpPayment.deliverMin().get())
             .isEqualTo(XRPCurrencyAmount.from(paymentProto.getDeliverMin().getValue()));
     assertThat(xrpPayment.invoiceID()).isEqualTo(paymentProto.getInvoiceId().getValue().toByteArray());

--- a/src/test/java/io/xpring/xrpl/ProtocolBufferConversionTest.java
+++ b/src/test/java/io/xpring/xrpl/ProtocolBufferConversionTest.java
@@ -2,6 +2,7 @@ package io.xpring.xrpl;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
+import io.xpring.common.XRPLNetwork;
 import io.xpring.xrpl.model.XRPCurrency;
 import io.xpring.xrpl.model.XRPCurrencyAmount;
 import io.xpring.xrpl.model.XRPIssuedCurrency;
@@ -11,6 +12,7 @@ import io.xpring.xrpl.model.XRPPathElement;
 import io.xpring.xrpl.model.XRPPayment;
 import io.xpring.xrpl.model.XRPSigner;
 import io.xpring.xrpl.model.XRPTransaction;
+import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -24,6 +26,7 @@ import org.xrpl.rpc.v1.Signer;
 import org.xrpl.rpc.v1.Transaction;
 
 import java.math.BigInteger;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class ProtocolBufferConversionTest {
@@ -196,6 +199,14 @@ public class ProtocolBufferConversionTest {
     assertThat(xrpPayment.amount()).isEqualTo(XRPCurrencyAmount.from(paymentProto.getAmount().getValue()));
     assertThat(xrpPayment.destination()).isEqualTo(paymentProto.getDestination().getValue().getAddress());
     assertThat(xrpPayment.destinationTag().get()).isEqualTo(paymentProto.getDestinationTag().getValue());
+    assertThat(xrpPayment.destinationXAddress()).isEqualTo(Utils.encodeXAddress(
+            ImmutableClassicAddress.builder()
+                    .address(xrpPayment.destination())
+                    .tag(xrpPayment.destinationTag())
+                    .isTest(false)
+                    .build()
+            )
+          );
     assertThat(xrpPayment.deliverMin().get())
             .isEqualTo(XRPCurrencyAmount.from(paymentProto.getDeliverMin().getValue()));
     assertThat(xrpPayment.invoiceID()).isEqualTo(paymentProto.getInvoiceId().getValue().toByteArray());
@@ -212,13 +223,20 @@ public class ProtocolBufferConversionTest {
     Payment paymentProto = FakeXRPProtobufs.paymentWithMandatoryFieldsSet;
 
     // WHEN the protocol buffer is converted to a native Java type.
-    XRPPayment xrpPayment = XRPPayment.from(paymentProto);
+    XRPPayment xrpPayment = XRPPayment.from(paymentProto, XRPLNetwork.TEST);
 
     // THEN the result is as expected.
     assertThat(xrpPayment.amount()).isEqualTo(XRPCurrencyAmount.from(paymentProto.getAmount().getValue()));
     assertThat(xrpPayment.destination()).isEqualTo(paymentProto.getDestination().getValue().getAddress());
     assertThat(xrpPayment.destinationTag()).isEmpty();
-    assertThat(xrpPayment.destinationTag()).isEmpty();
+    assertThat(xrpPayment.destinationXAddress()).isEqualTo(Utils.encodeXAddress(
+            ImmutableClassicAddress.builder()
+                    .address(xrpPayment.destination())
+                    .tag(xrpPayment.destinationTag())
+                    .isTest(true)
+                    .build()
+            )
+    );
     assertThat(xrpPayment.deliverMin()).isEmpty();
     assertThat(xrpPayment.invoiceID()).isEmpty();
     assertThat(xrpPayment.paths()).isEmpty();
@@ -314,6 +332,14 @@ public class ProtocolBufferConversionTest {
     assertThat(xrpTransaction.hash())
             .isEqualTo(Utils.byteArrayToHex(FakeXRPProtobufs.testTransactionHash.toByteArray()));
     assertThat(xrpTransaction.account()).isEqualTo(transactionProto.getAccount().getValue().getAddress());
+    assertThat(xrpTransaction.accountXAddress()).isEqualTo(Utils.encodeXAddress(
+            ImmutableClassicAddress.builder()
+                    .address(xrpTransaction.account())
+                    .tag(Optional.empty())
+                    .isTest(false)
+                    .build()
+            )
+    );
     assertThat(xrpTransaction.accountTransactionID())
         .isEqualTo(transactionProto.getAccountTransactionId().getValue().toByteArray());
     assertThat(xrpTransaction.fee()).isEqualTo(transactionProto.getFee().getDrops());
@@ -379,6 +405,14 @@ public class ProtocolBufferConversionTest {
     assertThat(xrpTransaction.hash())
             .isEqualTo(Utils.byteArrayToHex(FakeXRPProtobufs.testTransactionHash.toByteArray()));
     assertThat(xrpTransaction.account()).isEqualTo(transactionProto.getAccount().getValue().getAddress());
+    assertThat(xrpTransaction.accountXAddress()).isEqualTo(Utils.encodeXAddress(
+            ImmutableClassicAddress.builder()
+                    .address(xrpTransaction.account())
+                    .tag(Optional.empty())
+                    .isTest(false)
+                    .build()
+            )
+    );
     assertThat(xrpTransaction.accountTransactionID()).isEmpty();
     assertThat(xrpTransaction.fee()).isEqualTo(transactionProto.getFee().getDrops());
     assertThat(xrpTransaction.flags()).isEmpty();

--- a/src/test/java/io/xpring/xrpl/helpers/XRPTestUtils.java
+++ b/src/test/java/io/xpring/xrpl/helpers/XRPTestUtils.java
@@ -1,5 +1,6 @@
 package io.xpring.xrpl.helpers;
 
+import io.xpring.common.XRPLNetwork;
 import io.xpring.xrpl.model.XRPTransaction;
 import org.xrpl.rpc.v1.GetAccountTransactionHistoryResponse;
 import org.xrpl.rpc.v1.GetTransactionResponse;
@@ -30,7 +31,7 @@ public class XRPTestUtils {
       Transaction transaction = transactionResponse.getTransaction();
       switch (transaction.getTransactionDataCase()) {
         case PAYMENT: {
-          XRPTransaction xrpTransaction = XRPTransaction.from(transactionResponse);
+          XRPTransaction xrpTransaction = XRPTransaction.from(transactionResponse, XRPLNetwork.TEST);
           if (xrpTransaction != null) {
             payments.add(xrpTransaction);
           }


### PR DESCRIPTION
## High Level Overview of Change
This PR adds X-address to the `XRPPayment` and `XRPTransaction` model objects.  `XRPPayment` contains a `destination` and a `destinationTag` property, and now also contains a `destinationXAddress` property that is the X-address encoded version of this information. `XRPTransaction` contains an `account` property, and now also contains an `accountXAddress` property, which is the X-address encoded version of the originating account with no destination tag.

In order to create the correct X-address encoding, we need to know whether we're on Testnet or Mainnet.  Therefore the `.from` constructors for `XRPPayment` and `XRPTransaction` now have an additional `XRPLNetwork` parameter.  Tests and client code have been updated accordingly. 
<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] New feature (non-breaking change which adds functionality)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After
`XRPTransaction` and `XRPPayment` now contain X-address versions of address and tag properties. 
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
Unit tests for protocol buffer conversion into these objects have been updated to verify the X-address properties.
CI stil passes.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->


## Future Tasks
<!--
For future tasks related to PR.
-->
Questions for @keefertaylor 
- do we need to deprecate the classic address/tag fields, or just leave everything side-by-side?
- should a note about this go in the CHANGELOG?  The `XRPTransaction` and `XRPPayment` objects have an additional constructor parameter, but it's optional (defaults to Mainnet) and thus isn't a breaking change.
- should other classes that contain XRP addresses (such as `XRPPathElement` or `XRPIssuedCurrency`) also contain X-address versions of these?