### PR TITLE
Fix Destination Tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ## Fixed
-- Payments sent to a destination tag would drop their tag. This release contains a fix for this issue.
+- Destination tags were being dropped from payments. This release fixes the issue.
 
 ## 5.2.1 - 2020-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Fixed
+- Payments sent to a destination tag would drop their tag. This release contains a fix for this issue.
+
 ## 5.2.1 - 2020-06-16
 
 ### Added

--- a/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
+++ b/src/main/java/io/xpring/xrpl/DefaultXRPClient.java
@@ -174,7 +174,7 @@ public class DefaultXRPClient implements XRPClientDecorator {
     int openLedgerSequence = this.getOpenLedgerSequence();
 
     AccountAddress destinationAccountAddress = AccountAddress.newBuilder()
-        .setAddress(destinationClassicAddress.address())
+        .setAddress(destinationAddress)
         .build();
     AccountAddress sourceAccountAddress = AccountAddress.newBuilder()
         .setAddress(sourceClassicAddress.address())
@@ -183,17 +183,12 @@ public class DefaultXRPClient implements XRPClientDecorator {
     XRPDropsAmount dropsAmount = XRPDropsAmount.newBuilder().setDrops(drops.longValue()).build();
     CurrencyAmount currencyAmount = CurrencyAmount.newBuilder().setXrpAmount(dropsAmount).build();
     Amount amount = Amount.newBuilder().setValue(currencyAmount).build();
+
     Destination destination = Destination.newBuilder().setValue(destinationAccountAddress).build();
 
     Payment.Builder paymentBuilder = Payment.newBuilder()
         .setAmount(amount)
         .setDestination(destination);
-    if (destinationClassicAddress.tag().isPresent()) {
-      DestinationTag destinationTag = DestinationTag.newBuilder()
-          .setValue(destinationClassicAddress.tag().get())
-          .build();
-      paymentBuilder.setDestinationTag(destinationTag);
-    }
 
     Payment payment = paymentBuilder.build();
 

--- a/src/test/java/io/xpring/xrpl/XRPClientIntegrationTests.java
+++ b/src/test/java/io/xpring/xrpl/XRPClientIntegrationTests.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import io.xpring.common.XRPLNetwork;
 import io.xpring.xrpl.model.XRPTransaction;
+import io.xpring.xrpl.model.idiomatic.XrpPayment;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -72,6 +73,30 @@ public class XRPClientIntegrationTests {
     String transactionHash = xrpClient.send(AMOUNT, XRPL_ADDRESS, wallet);
     assertThat(transactionHash).isNotNull();
   }
+
+  @Test
+  public void sendXRPWithADestinationTag() throws XRPException {
+    // GIVEN a transaction hash representing a payment with a destination tag.
+    Wallet wallet = new Wallet(WALLET_SEED);
+    int tag = 123;
+    String address = "rPEPPER7kfTD9w2To4CQk6UCfuHM9c6GDY";
+    ClassicAddress classicAddressWithTag = ImmutableClassicAddress.builder()
+        .address(address)
+        .tag(tag)
+        .isTest(true)
+        .build();
+    String taggedAddress = Utils.encodeXAddress(classicAddressWithTag);
+    String transactionHash = xrpClient.send(AMOUNT, taggedAddress, wallet);
+
+    // WHEN the payment is retrieved
+    XRPTransaction transaction = xrpClient.getPayment(transactionHash);
+
+    // THEN the payment has the correct destination.
+    String destinationXAddress = transaction.paymentFields().destinationXAddress();
+    ClassicAddress destinationAddressComponents = Utils.decodeXAddress(destinationXAddress);
+    assertThat(destinationAddressComponents.address()).isEqualTo(address);
+    assertThat(destinationAddressComponents.tag()).isEqualTo(tag);
+ }
 
   @Test
   public void accountExistsTest() throws XRPException {

--- a/src/test/java/io/xpring/xrpl/XRPClientIntegrationTests.java
+++ b/src/test/java/io/xpring/xrpl/XRPClientIntegrationTests.java
@@ -95,7 +95,7 @@ public class XRPClientIntegrationTests {
     String destinationXAddress = transaction.paymentFields().destinationXAddress();
     ClassicAddress destinationAddressComponents = Utils.decodeXAddress(destinationXAddress);
     assertThat(destinationAddressComponents.address()).isEqualTo(address);
-    assertThat(destinationAddressComponents.tag()).isEqualTo(tag);
+    assertThat(destinationAddressComponents.tag().get()).isEqualTo(tag);
  }
 
   @Test

--- a/src/test/java/io/xpring/xrpl/XRPClientIntegrationTests.java
+++ b/src/test/java/io/xpring/xrpl/XRPClientIntegrationTests.java
@@ -96,7 +96,7 @@ public class XRPClientIntegrationTests {
     ClassicAddress destinationAddressComponents = Utils.decodeXAddress(destinationXAddress);
     assertThat(destinationAddressComponents.address()).isEqualTo(address);
     assertThat(destinationAddressComponents.tag().get()).isEqualTo(tag);
- }
+  }
 
   @Test
   public void accountExistsTest() throws XRPException {


### PR DESCRIPTION
## High Level Overview of Change

Fix an issue where Xpring4j drops destination tags on sends. 

Address #264 

### Context of Change

Our serialization library expects destination addresses to be in X-Address format and xpring4j was providing classic address / tag combinations. 

The serialization library shouldn't mess this up. That change is in https://github.com/xpring-eng/xpring-common-js/pull/346. 

This change fixes the immediate issue by passing through X-Addresses. Add an integration test to prove this works as expected. 

We will do a release ASAP after this change is merged. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Fixes a bug. 

## Test Plan

CI. New tests are provided. 
