### PR TITLE
Creates XrpAccountDelete protobuf wrapper class

### DIFF
--- a/src/main/java/io/xpring/xrpl/model/XrpAccountDelete.java
+++ b/src/main/java/io/xpring/xrpl/model/XrpAccountDelete.java
@@ -1,0 +1,35 @@
+package io.xpring.xrpl.model;
+
+import org.immutables.value.Value;
+import org.xrpl.rpc.v1.AccountDelete;
+
+
+/**
+ * Represents an AccountDelete transaction on the XRP Ledger.
+ * <p>
+ * An AccountDelete transaction deletes an account and any objects it owns in the XRP Ledger,
+ * if possible, sending the account's remaining XRP to a specified destination account.
+ * </p>
+ *
+ * @see "https://xrpl.org/accountdelete.html"
+ */
+@Value.Immutable
+public interface XrpAccountDelete {
+  static ImmutableXrpAccountDelete.Builder builder() {
+    return ImmutableXrpAccountDelete.builder();
+  }
+
+  /**
+   * The address and destination tag of an account to receive any leftover XRP after deleting the
+   * sending account, encoded as an X-address.
+   * <p>
+   * Must be a funded account in the ledger, and must not be the sending account.
+   * </p>
+   *
+   * @return A {@link String} representing the address and destination tag of an account to receive any
+   *         leftover XRP after deleting the sending account, encoded as an X-address.
+   *
+   * @see "https://xrpaddress.info"
+   */
+  String destinationXAddress();
+}

--- a/src/main/java/io/xpring/xrpl/model/XrpAccountDelete.java
+++ b/src/main/java/io/xpring/xrpl/model/XrpAccountDelete.java
@@ -44,7 +44,9 @@ public interface XrpAccountDelete {
    *
    * @param accountDelete An {@link AccountDelete} (protobuf object) whose field values will be used
    *                      to construct an XrpAccountDelete
+   *
    * @return An {@link XrpAccountDelete} with its fields set via the analogous protobuf fields.
+   *
    * @see <a href="https://github.com/ripple/rippled/blob/3d86b49dae8173344b39deb75e53170a9b6c5284/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L118">
    * AccountDelete protocol buffer</a>
    */

--- a/src/main/java/io/xpring/xrpl/model/XrpAccountDelete.java
+++ b/src/main/java/io/xpring/xrpl/model/XrpAccountDelete.java
@@ -1,7 +1,14 @@
 package io.xpring.xrpl.model;
 
+import io.xpring.common.XrplNetwork;
+import io.xpring.xrpl.ClassicAddress;
+import io.xpring.xrpl.ImmutableClassicAddress;
+
+import io.xpring.xrpl.Utils;
 import org.immutables.value.Value;
 import org.xrpl.rpc.v1.AccountDelete;
+
+import java.util.Optional;
 
 
 /**
@@ -32,4 +39,28 @@ public interface XrpAccountDelete {
    * @see "https://xrpaddress.info"
    */
   String destinationXAddress();
+
+  static XrpAccountDelete from(AccountDelete accountDelete, XrplNetwork xrplNetwork) {
+    // Destination is required
+    if (!accountDelete.hasDestination() || accountDelete.getDestination().getValue().getAddress().isEmpty()) {
+      return null;
+    }
+    final String destination = accountDelete.getDestination().getValue().getAddress();
+
+    Optional<Integer> destinationTag = accountDelete.hasDestinationTag()
+        ? Optional.of(accountDelete.getDestinationTag().getValue())
+        : Optional.empty();
+
+    ClassicAddress classicAddress = ImmutableClassicAddress.builder()
+        .address(destination)
+        .tag(destinationTag)
+        .isTest(xrplNetwork == XrplNetwork.TEST)
+        .build();
+
+    final String destinationXAddress = Utils.encodeXAddress(classicAddress);
+
+    return builder()
+      .destinationXAddress(destinationXAddress)
+      .build();
+  }
 }

--- a/src/main/java/io/xpring/xrpl/model/XrpAccountDelete.java
+++ b/src/main/java/io/xpring/xrpl/model/XrpAccountDelete.java
@@ -9,7 +9,6 @@ import org.xrpl.rpc.v1.AccountDelete;
 
 import java.util.Optional;
 
-
 /**
  * Represents an AccountDelete transaction on the XRP Ledger.
  * <p>

--- a/src/main/java/io/xpring/xrpl/model/XrpAccountDelete.java
+++ b/src/main/java/io/xpring/xrpl/model/XrpAccountDelete.java
@@ -3,7 +3,6 @@ package io.xpring.xrpl.model;
 import io.xpring.common.XrplNetwork;
 import io.xpring.xrpl.ClassicAddress;
 import io.xpring.xrpl.ImmutableClassicAddress;
-
 import io.xpring.xrpl.Utils;
 import org.immutables.value.Value;
 import org.xrpl.rpc.v1.AccountDelete;
@@ -40,6 +39,15 @@ public interface XrpAccountDelete {
    */
   String destinationXAddress();
 
+  /**
+   * Constructs an XrpAccountDelete from an AccountDelete protocol buffer.
+   *
+   * @param accountDelete An {@link AccountDelete} (protobuf object) whose field values will be used
+   *                      to construct an XrpAccountDelete
+   * @return An {@link XrpAccountDelete} with its fields set via the analogous protobuf fields.
+   * @see <a href="https://github.com/ripple/rippled/blob/3d86b49dae8173344b39deb75e53170a9b6c5284/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L118">
+   * AccountDelete protocol buffer</a>
+   */
   static XrpAccountDelete from(AccountDelete accountDelete, XrplNetwork xrplNetwork) {
     // Destination is required
     if (!accountDelete.hasDestination() || accountDelete.getDestination().getValue().getAddress().isEmpty()) {

--- a/src/test/java/io/xpring/xrpl/FakeXrpTransactionProtobufs.java
+++ b/src/test/java/io/xpring/xrpl/FakeXrpTransactionProtobufs.java
@@ -99,20 +99,22 @@ public class FakeXrpTransactionProtobufs {
       .setAddress(testDestination)
       .build();
 
+  // Common.Destination proto
   public static Common.Destination destinationProto = Common.Destination.newBuilder()
       .setValue(accountAddressProto)
       .build();
 
+  // Common.DestinationTag proto
   public static Common.DestinationTag destinationTagProto = Common.DestinationTag.newBuilder()
       .setValue(testDestinationTag)
       .build();
 
-  public static AccountDelete accountDeleteProto = AccountDelete.newBuilder()
+  public static AccountDelete allFieldsAccountDelete = AccountDelete.newBuilder()
       .setDestination(destinationProto)
       .setDestinationTag(destinationTagProto)
       .build();
 
-  public static AccountDelete accountDeleteNoTagProto = AccountDelete.newBuilder()
+  public static AccountDelete noDestinationTagAccountDelete = AccountDelete.newBuilder()
       .setDestination(destinationProto)
       .build();
 }

--- a/src/test/java/io/xpring/xrpl/FakeXrpTransactionProtobufs.java
+++ b/src/test/java/io/xpring/xrpl/FakeXrpTransactionProtobufs.java
@@ -1,7 +1,9 @@
 package io.xpring.xrpl;
 
 import com.google.protobuf.ByteString;
+import org.xrpl.rpc.v1.AccountAddress;
 import org.xrpl.rpc.v1.AccountSet;
+import org.xrpl.rpc.v1.AccountDelete;
 import org.xrpl.rpc.v1.Common;
 
 import java.io.UnsupportedEncodingException;
@@ -37,6 +39,10 @@ public class FakeXrpTransactionProtobufs {
   public static Integer testSetFlag = 4;
   public static Integer testTransferRate = 1234567890;
   public static Integer testTickSize = 7;
+
+  // AccountDelete fake primitive test values
+  public static String testDestination = "rPEPPER7kfTD9w2To4CQk6UCfuHM9c6GDY";
+  public static Integer testDestinationTag = 13;
 
   // AccountSet protos
   // Common.ClearFlag proto
@@ -86,5 +92,27 @@ public class FakeXrpTransactionProtobufs {
 
   public static AccountSet oneFieldAccountSet = AccountSet.newBuilder()
       .setClearFlag(clearFlagProto)
+      .build();
+
+  // AccountDelete protos
+  public static AccountAddress accountAddressProto = AccountAddress.newBuilder()
+      .setAddress(testDestination)
+      .build();
+
+  public static Common.Destination destinationProto = Common.Destination.newBuilder()
+      .setValue(accountAddressProto)
+      .build();
+
+  public static Common.DestinationTag destinationTagProto = Common.DestinationTag.newBuilder()
+      .setValue(testDestinationTag)
+      .build();
+
+  public static AccountDelete accountDeleteProto = AccountDelete.newBuilder()
+      .setDestination(destinationProto)
+      .setDestinationTag(destinationTagProto)
+      .build();
+
+  public static AccountDelete accountDeleteNoTagProto = AccountDelete.newBuilder()
+      .setDestination(destinationProto)
       .build();
 }

--- a/src/test/java/io/xpring/xrpl/FakeXrpTransactionProtobufs.java
+++ b/src/test/java/io/xpring/xrpl/FakeXrpTransactionProtobufs.java
@@ -2,8 +2,8 @@ package io.xpring.xrpl;
 
 import com.google.protobuf.ByteString;
 import org.xrpl.rpc.v1.AccountAddress;
-import org.xrpl.rpc.v1.AccountSet;
 import org.xrpl.rpc.v1.AccountDelete;
+import org.xrpl.rpc.v1.AccountSet;
 import org.xrpl.rpc.v1.Common;
 
 import java.io.UnsupportedEncodingException;

--- a/src/test/java/io/xpring/xrpl/XrpAccountDeleteProtoConversionTest.java
+++ b/src/test/java/io/xpring/xrpl/XrpAccountDeleteProtoConversionTest.java
@@ -1,0 +1,55 @@
+package io.xpring.xrpl;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import io.xpring.common.XrplNetwork;
+import io.xpring.xrpl.model.XrpAccountDelete;
+import io.xpring.xrpl.model.XrpAccountSet;
+import org.junit.Test;
+import org.xrpl.rpc.v1.AccountDelete;
+import org.xrpl.rpc.v1.AccountSet;
+
+public class XrpAccountDeleteProtoConversionTest {
+  @Test
+  public void allFieldsSetTest() {
+    // GIVEN an AccountDelete protocol buffer with all fields set.
+    final AccountDelete accountDeleteProto = FakeXrpTransactionProtobufs.allFieldsAccountDelete;
+
+    // WHEN the protocol buffer is converted to a native Java object.
+    final XrpAccountDelete accountDelete = XrpAccountDelete.from(accountDeleteProto, XrplNetwork.TEST);
+
+    ClassicAddress classicAddress = ImmutableClassicAddress.builder()
+      .address(accountDeleteProto.getDestination().getValue().getAddress())
+      .tag(accountDeleteProto.getDestinationTag().getValue())
+      .isTest(true)
+      .build();
+    final String destinationXAddress = Utils.encodeXAddress(classicAddress);
+
+    // THEN the AccountDelete converted as expected.
+    assertThat(accountDelete.destinationXAddress()).isEqualTo(destinationXAddress);
+  }
+
+  @Test
+  public void destinationTagNotSetTest() {
+    // GIVEN an AccountDelete protocol buffer with no destination tag.
+    final AccountDelete accountDeleteProto = FakeXrpTransactionProtobufs.noDestinationTagAccountDelete;
+
+    // WHEN the protocol buffer is converted to a native Java object.
+    final XrpAccountDelete accountDelete = XrpAccountDelete.from(accountDeleteProto, XrplNetwork.TEST);
+
+    ClassicAddress classicAddress = ImmutableClassicAddress.builder()
+      .address(accountDeleteProto.getDestination().getValue().getAddress())
+      .isTest(true)
+      .build();
+    final String destinationXAddress = Utils.encodeXAddress(classicAddress);
+
+    // THEN the AccountDelete converted as expected.
+    assertThat(accountDelete.destinationXAddress()).isEqualTo(destinationXAddress);
+  }
+
+  @Test
+  public void missingDestinationTest() {
+    final XrpAccountDelete accountDelete = XrpAccountDelete.from(AccountDelete.newBuilder().build(), XrplNetwork.TEST);
+    assertThat(accountDelete).isNull();
+  }
+}

--- a/src/test/java/io/xpring/xrpl/XrpAccountDeleteProtoConversionTest.java
+++ b/src/test/java/io/xpring/xrpl/XrpAccountDeleteProtoConversionTest.java
@@ -4,10 +4,8 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import io.xpring.common.XrplNetwork;
 import io.xpring.xrpl.model.XrpAccountDelete;
-import io.xpring.xrpl.model.XrpAccountSet;
 import org.junit.Test;
 import org.xrpl.rpc.v1.AccountDelete;
-import org.xrpl.rpc.v1.AccountSet;
 
 public class XrpAccountDeleteProtoConversionTest {
   @Test

--- a/src/test/java/io/xpring/xrpl/XrpAccountDeleteProtoConversionTest.java
+++ b/src/test/java/io/xpring/xrpl/XrpAccountDeleteProtoConversionTest.java
@@ -17,10 +17,10 @@ public class XrpAccountDeleteProtoConversionTest {
     final XrpAccountDelete accountDelete = XrpAccountDelete.from(accountDeleteProto, XrplNetwork.TEST);
 
     ClassicAddress classicAddress = ImmutableClassicAddress.builder()
-      .address(accountDeleteProto.getDestination().getValue().getAddress())
-      .tag(accountDeleteProto.getDestinationTag().getValue())
-      .isTest(true)
-      .build();
+        .address(accountDeleteProto.getDestination().getValue().getAddress())
+        .tag(accountDeleteProto.getDestinationTag().getValue())
+        .isTest(true)
+        .build();
     final String destinationXAddress = Utils.encodeXAddress(classicAddress);
 
     // THEN the AccountDelete converted as expected.
@@ -36,9 +36,9 @@ public class XrpAccountDeleteProtoConversionTest {
     final XrpAccountDelete accountDelete = XrpAccountDelete.from(accountDeleteProto, XrplNetwork.TEST);
 
     ClassicAddress classicAddress = ImmutableClassicAddress.builder()
-      .address(accountDeleteProto.getDestination().getValue().getAddress())
-      .isTest(true)
-      .build();
+        .address(accountDeleteProto.getDestination().getValue().getAddress())
+        .isTest(true)
+        .build();
     final String destinationXAddress = Utils.encodeXAddress(classicAddress);
 
     // THEN the AccountDelete converted as expected.


### PR DESCRIPTION
## High Level Overview of Change
This PR implements the class XRPAccountDelete - a native Java class to wrap the AccountDelete protocol buffer. See also: https://xrpl.org/accountdelete.html.
<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
Effort to implement additional XRPL transaction types beyond Payment in the SDK.
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After
XRPAccountDelete class and conversion unit tests now exist.
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
Unit tests added to verify conversion. CI passes.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
