### PR TITLE
Implements `randomWalletFromFaucet` for Improved `XrpClient` Integration Tests

### DIFF
--- a/src/test/java/io/xpring/xpring/XpringClientIntegrationTest.java
+++ b/src/test/java/io/xpring/xpring/XpringClientIntegrationTest.java
@@ -8,8 +8,10 @@ import io.xpring.payid.XrpPayIdClient;
 import io.xpring.xrpl.Wallet;
 import io.xpring.xrpl.XrpClient;
 import io.xpring.xrpl.XrpException;
+import io.xpring.xrpl.helpers.XrpTestUtils;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.math.BigInteger;
 
 public class XpringClientIntegrationTest {
@@ -35,10 +37,10 @@ public class XpringClientIntegrationTest {
 
   @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
   @Test
-  public void testSendXRP() throws XrpException, PayIdException {
+  public void testSendXRP() throws XrpException, PayIdException, IOException, InterruptedException {
     // GIVEN a Pay ID that will resolve and a wallet with a balance on TestNet.
     String payID = "alice$dev.payid.xpring.money";
-    Wallet wallet = new Wallet("snYP7oArxKepd3GPDcrjMsJYiJeJB");
+    Wallet wallet = XrpTestUtils.randomWalletFromFaucet();
 
     // WHEN XRP is sent to the Pay ID.
     String transactionHash = XPRING_CLIENT.send(new BigInteger("10"), payID, wallet);

--- a/src/test/java/io/xpring/xrpl/WalletTest.java
+++ b/src/test/java/io/xpring/xrpl/WalletTest.java
@@ -214,6 +214,6 @@ public class WalletTest {
     // AND it has a non-zero balance
     XrpClient xrpClient = new XrpClient("test.xrp.xpring.io:50051", XrplNetwork.TEST);
     BigInteger balance = xrpClient.getBalance(wallet.getAddress());
-    assertTrue(balance.compareTo(new BigInteger("0")) == 1);
+    assertTrue(balance.signum() == 1);
   }
 }

--- a/src/test/java/io/xpring/xrpl/WalletTest.java
+++ b/src/test/java/io/xpring/xrpl/WalletTest.java
@@ -5,9 +5,13 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import io.xpring.common.XrplNetwork;
+import io.xpring.xrpl.helpers.XrpTestUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import java.math.BigInteger;
 
 public class WalletTest {
   @Rule
@@ -196,5 +200,20 @@ public class WalletTest {
     String signature = "DEADBEEF";
 
     assertFalse(wallet.verify(message, signature));
+  }
+
+  @Test
+  public void testRandomWalletFromFaucet() throws Exception {
+    // GIVEN a new, randomly generated wallet that is funded by the Testnet faucet
+    Wallet wallet = XrpTestUtils.randomWalletFromFaucet();
+
+    // WHEN the wallet is examined
+    // THEN it exists
+    assertNotNull(wallet);
+
+    // AND it has a non-zero balance
+    XrpClient xrpClient = new XrpClient("test.xrp.xpring.io:50051", XrplNetwork.TEST);
+    BigInteger balance = xrpClient.getBalance(wallet.getAddress());
+    assertTrue(balance.compareTo(new BigInteger("0")) == 1);
   }
 }

--- a/src/test/java/io/xpring/xrpl/XrpClientIntegrationTests.java
+++ b/src/test/java/io/xpring/xrpl/XrpClientIntegrationTests.java
@@ -57,6 +57,9 @@ public class XrpClientIntegrationTests {
   private static final BigInteger AMOUNT = new BigInteger("1");
 
   @Before
+  /**
+   * Set up an XrpClient and Wallet for integration tests.
+   */
   public void setUp() throws Exception {
     this.xrpClient = new XrpClient(GRPC_URL, XrplNetwork.TEST);
 

--- a/src/test/java/io/xpring/xrpl/XrpClientIntegrationTests.java
+++ b/src/test/java/io/xpring/xrpl/XrpClientIntegrationTests.java
@@ -69,10 +69,9 @@ public class XrpClientIntegrationTests {
   }
 
   @Test
-  public void getPaymentStatusTest() throws XrpException, IOException, InterruptedException {
+  public void getPaymentStatusTest() throws XrpException {
     // GIVEN a hash of a payment transaction.
-    Wallet wallet = XrpTestUtils.randomWalletFromFaucet();
-    String transactionHash = xrpClient.send(AMOUNT, XRPL_ADDRESS, wallet);
+    String transactionHash = xrpClient.send(AMOUNT, XRPL_ADDRESS, WALLET);
 
     // WHEN the transaction status is retrieved.
     TransactionStatus transactionStatus = xrpClient.getPaymentStatus(transactionHash);

--- a/src/test/java/io/xpring/xrpl/XrpClientIntegrationTests.java
+++ b/src/test/java/io/xpring/xrpl/XrpClientIntegrationTests.java
@@ -146,7 +146,6 @@ public class XrpClientIntegrationTests {
   @Test(timeout = 20000)
   public void sendWithDetailsIncludingMemoTest() throws XrpException {
     // GIVEN an XrpClient, and some SendXrpDetails that include memos
-    Wallet wallet = new Wallet(WALLET_SEED);
     List<XrpMemo> memos = Arrays.asList(
             XrpTestUtils.iForgotToPickUpCarlMemo,
             XrpTestUtils.noDataMemo,
@@ -157,7 +156,7 @@ public class XrpClientIntegrationTests {
     SendXrpDetails sendXrpDetails = SendXrpDetails.builder()
             .amount(AMOUNT)
             .destination(XRPL_ADDRESS)
-            .sender(wallet)
+            .sender(WALLET)
             .memosList(memos)
             .build();
     String transactionHash = xrpClient.sendWithDetails(sendXrpDetails);

--- a/src/test/java/io/xpring/xrpl/XrpClientIntegrationTests.java
+++ b/src/test/java/io/xpring/xrpl/XrpClientIntegrationTests.java
@@ -56,10 +56,10 @@ public class XrpClientIntegrationTests {
    */
   private static final BigInteger AMOUNT = new BigInteger("1");
 
-  @Before
   /**
    * Set up an XrpClient and Wallet for integration tests.
    */
+  @Before
   public void setUp() throws Exception {
     this.xrpClient = new XrpClient(GRPC_URL, XrplNetwork.TEST);
 

--- a/src/test/java/io/xpring/xrpl/XrpClientIntegrationTests.java
+++ b/src/test/java/io/xpring/xrpl/XrpClientIntegrationTests.java
@@ -51,10 +51,13 @@ public class XrpClientIntegrationTests {
    * A Wallet with funds on Testnet.
    */
   private static Wallet WALLET = null;
+
   static {
     try {
       WALLET = XrpTestUtils.randomWalletFromFaucet();
-    } catch (Exception e) {}
+    } catch (Exception e) {
+      System.out.println(e.getStackTrace());
+    }
   }
 
   @Before

--- a/src/test/java/io/xpring/xrpl/helpers/XrpTestUtils.java
+++ b/src/test/java/io/xpring/xrpl/helpers/XrpTestUtils.java
@@ -86,8 +86,6 @@ public class XrpTestUtils {
     con.setDoOutput(true);
     String jsonInputString = String.format("{\"destination\": \"%s\"}", classicAddress);
 
-    System.out.println("Using classic address: " + classicAddress);
-
     try(OutputStream os = con.getOutputStream()) {
       byte[] input = jsonInputString.getBytes("utf-8");
       os.write(input, 0, input.length);
@@ -99,7 +97,6 @@ public class XrpTestUtils {
       while ((responseLine = br.readLine()) != null) {
         response.append(responseLine.trim());
       }
-      System.out.println(response.toString());
     }
 
     // Wait for the faucet to fund our account or until timeout

--- a/src/test/java/io/xpring/xrpl/helpers/XrpTestUtils.java
+++ b/src/test/java/io/xpring/xrpl/helpers/XrpTestUtils.java
@@ -60,11 +60,11 @@ public class XrpTestUtils {
    * Generates a random wallet and funds using the XRPL Testnet faucet.
    */
   public static Wallet randomWalletFromFaucet() throws XrpException, IOException, InterruptedException {
-    Integer timeoutInSeconds = 20;
+    final Integer timeoutInSeconds = 20;
 
     Wallet wallet = Wallet.generateRandomWallet(true).getWallet();
-    String xAddress = wallet.getAddress();
-    String classicAddress = Utils.decodeXAddress(xAddress).address();
+    String address = wallet.getAddress();
+    final String classicAddress = Utils.decodeXAddress(address).address();
 
     String rippledUrl = "test.xrp.xpring.io:50051";
     XrpClient xrpClient = new XrpClient(rippledUrl, XrplNetwork.TEST);
@@ -72,13 +72,13 @@ public class XrpTestUtils {
     // Balance prior to asking for more funds
     BigInteger startingBalance;
     try {
-      startingBalance = xrpClient.getBalance(xAddress);
+      startingBalance = xrpClient.getBalance(address);
     } catch (Exception exception) {
       startingBalance = new BigInteger("0");
     }
     // Ask the faucet to send funds to the given address
-    String faucetURL = "https://faucet.altnet.rippletest.net/accounts";
-    URL url = new URL(faucetURL);
+    String faucetUrl = "https://faucet.altnet.rippletest.net/accounts";
+    URL url = new URL(faucetUrl);
     HttpURLConnection con = (HttpURLConnection)url.openConnection();
     con.setRequestMethod("POST");
     con.setRequestProperty("Content-Type", "application/json");
@@ -86,11 +86,11 @@ public class XrpTestUtils {
     con.setDoOutput(true);
     String jsonInputString = String.format("{\"destination\": \"%s\"}", classicAddress);
 
-    try(OutputStream os = con.getOutputStream()) {
+    try (OutputStream os = con.getOutputStream()) {
       byte[] input = jsonInputString.getBytes("utf-8");
       os.write(input, 0, input.length);
     }
-    try(BufferedReader br = new BufferedReader(
+    try (BufferedReader br = new BufferedReader(
             new InputStreamReader(con.getInputStream(), "utf-8"))) {
       StringBuilder response = new StringBuilder();
       String responseLine;
@@ -109,7 +109,7 @@ public class XrpTestUtils {
       // Request our current balance
       BigInteger currentBalance;
       try {
-        currentBalance = xrpClient.getBalance(xAddress);
+        currentBalance = xrpClient.getBalance(address);
       } catch (Exception exception) {
         currentBalance = new BigInteger("0");
       }

--- a/src/test/java/io/xpring/xrpl/helpers/XrpTestUtils.java
+++ b/src/test/java/io/xpring/xrpl/helpers/XrpTestUtils.java
@@ -1,11 +1,23 @@
 package io.xpring.xrpl.helpers;
 
 import io.xpring.common.XrplNetwork;
+import io.xpring.xrpl.Utils;
+import io.xpring.xrpl.Wallet;
+import io.xpring.xrpl.XrpClient;
+import io.xpring.xrpl.XrpException;
+import io.xpring.xrpl.XrpExceptionType;
 import io.xpring.xrpl.model.XrpTransaction;
 import org.xrpl.rpc.v1.GetAccountTransactionHistoryResponse;
 import org.xrpl.rpc.v1.GetTransactionResponse;
 import org.xrpl.rpc.v1.Transaction;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -42,5 +54,81 @@ public class XrpTestUtils {
       }
     }
     return payments;
+  }
+
+  /**
+   * Generates a random wallet and funds using the XRPL Testnet faucet.
+   */
+  public static Wallet randomWalletFromFaucet() throws XrpException, IOException, InterruptedException {
+    Integer timeoutInSeconds = 20;
+
+    Wallet wallet = Wallet.generateRandomWallet(true).getWallet();
+    String xAddress = wallet.getAddress();
+    String classicAddress = Utils.decodeXAddress(xAddress).address();
+
+    String rippledUrl = "test.xrp.xpring.io:50051";
+    XrpClient xrpClient = new XrpClient(rippledUrl, XrplNetwork.TEST);
+
+    // Balance prior to asking for more funds
+    BigInteger startingBalance;
+    try {
+      startingBalance = xrpClient.getBalance(xAddress);
+    } catch (Exception exception) {
+      startingBalance = new BigInteger("0");
+    }
+    // Ask the faucet to send funds to the given address
+    String faucetURL = "https://faucet.altnet.rippletest.net/accounts";
+    URL url = new URL(faucetURL);
+    HttpURLConnection con = (HttpURLConnection)url.openConnection();
+    con.setRequestMethod("POST");
+    con.setRequestProperty("Content-Type", "application/json");
+    con.setRequestProperty("Accept", "application/json");
+    con.setDoOutput(true);
+    String jsonInputString = String.format("{\"destination\": \"%s\"}", classicAddress);
+
+    System.out.println("Using classic address: " + classicAddress);
+
+    try(OutputStream os = con.getOutputStream()) {
+      byte[] input = jsonInputString.getBytes("utf-8");
+      os.write(input, 0, input.length);
+    }
+    try(BufferedReader br = new BufferedReader(
+            new InputStreamReader(con.getInputStream(), "utf-8"))) {
+      StringBuilder response = new StringBuilder();
+      String responseLine;
+      while ((responseLine = br.readLine()) != null) {
+        response.append(responseLine.trim());
+      }
+      System.out.println(response.toString());
+    }
+
+    // Wait for the faucet to fund our account or until timeout
+    // Waits one second checks if balance has changed
+    // If balance doesn't change it will attempt again until timeoutInSeconds
+    for (Integer balanceCheckCounter = 0; balanceCheckCounter < timeoutInSeconds; balanceCheckCounter++) {
+      // Wait 1 second
+      Thread.sleep(1000);
+
+      // Request our current balance
+      BigInteger currentBalance;
+      try {
+        currentBalance = xrpClient.getBalance(xAddress);
+      } catch (Exception exception) {
+        currentBalance = new BigInteger("0");
+      }
+      // If our current balance has changed then return
+      if (!startingBalance.equals(currentBalance)) {
+        return wallet;
+      }
+
+      // In the future if we had a tx hash from the faucet
+      // We should check the status of the tx which would be more accurate
+    }
+
+    // Balance did not update
+    throw new XrpException(
+            XrpExceptionType.UNKNOWN,
+            String.format("Unable to fund address with faucet after waiting %d seconds", timeoutInSeconds)
+    );
   }
 }

--- a/src/test/java/io/xpring/xrpl/helpers/XrpTestUtils.java
+++ b/src/test/java/io/xpring/xrpl/helpers/XrpTestUtils.java
@@ -80,22 +80,23 @@ public class XrpTestUtils {
     } catch (Exception exception) {
       startingBalance = new BigInteger("0");
     }
+
     // Ask the faucet to send funds to the given address
     String faucetUrl = "https://faucet.altnet.rippletest.net/accounts";
     URL url = new URL(faucetUrl);
-    HttpURLConnection con = (HttpURLConnection)url.openConnection();
-    con.setRequestMethod("POST");
-    con.setRequestProperty("Content-Type", "application/json");
-    con.setRequestProperty("Accept", "application/json");
-    con.setDoOutput(true);
+    HttpURLConnection connection = (HttpURLConnection)url.openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Content-Type", "application/json");
+    connection.setRequestProperty("Accept", "application/json");
+    connection.setDoOutput(true);
     String jsonInputString = String.format("{\"destination\": \"%s\"}", classicAddress);
 
-    try (OutputStream os = con.getOutputStream()) {
+    try (OutputStream outputStream = connection.getOutputStream()) {
       byte[] input = jsonInputString.getBytes("utf-8");
-      os.write(input, 0, input.length);
+      outputStream.write(input, 0, input.length);
     }
     try (BufferedReader br = new BufferedReader(
-            new InputStreamReader(con.getInputStream(), "utf-8"))) {
+            new InputStreamReader(connection.getInputStream(), "utf-8"))) {
       StringBuilder response = new StringBuilder();
       String responseLine;
       while ((responseLine = br.readLine()) != null) {


### PR DESCRIPTION
## High Level Overview of Change
This PR implements the test utility `randomWalletFromFaucet`, which generates a random wallet and then requests funds via the XRPL Testnet faucet (https://xrpl.org/xrp-testnet-faucet.html).  Integration tests are refactored to use a new funded address each time, which should eliminate the failures that occur due to sequence number clashes when different clients (via different CI runs) send transactions on behalf of the same account.

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (non-breaking change that only restructures code)

## Before / After
New addresses are used for integration tests where relevant.
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
Refactor integration tests where necessary.  CI still passes.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
