### PR TITLE
Adds Utils.isTestNetwork

### DIFF
--- a/src/main/java/io/xpring/xrpl/Utils.java
+++ b/src/main/java/io/xpring/xrpl/Utils.java
@@ -223,6 +223,6 @@ public class Utils {
    * @return A boolean representing whether or not the {@link XrplNetwork} is a test network.
    */
   public static boolean isTestNetwork(XrplNetwork xrplNetwork) {
-    return xrplNetwork == XrplNetwork.TEST || xrplNetwork == XrplNetwork.DEV;
+    return xrplNetwork != XrplNetwork.MAIN;
   }
 }

--- a/src/main/java/io/xpring/xrpl/Utils.java
+++ b/src/main/java/io/xpring/xrpl/Utils.java
@@ -2,6 +2,7 @@ package io.xpring.xrpl;
 
 import com.google.common.base.Preconditions;
 import io.xpring.common.CommonUtils;
+import io.xpring.common.XrplNetwork;
 import io.xpring.xrpl.javascript.JavaScriptLoaderException;
 import io.xpring.xrpl.javascript.JavaScriptUtils;
 
@@ -213,5 +214,15 @@ public class Utils {
             .multiply(new BigDecimal(dropsPerXrp))
             .toBigInteger()
             .toString(10);
+  }
+
+  /**
+   * Check if the XrplNetwork is a test network.
+   *
+   * @param xrplNetwork - The {@link XrplNetwork} to check.
+   * @return A boolean representing whether or not the {@link XrplNetwork} is a test network.
+   */
+  public static boolean isTestNetwork(XrplNetwork xrplNetwork) {
+    return xrplNetwork == XrplNetwork.TEST || xrplNetwork == XrplNetwork.DEV;
   }
 }

--- a/src/main/java/io/xpring/xrpl/model/XrpAccountDelete.java
+++ b/src/main/java/io/xpring/xrpl/model/XrpAccountDelete.java
@@ -64,7 +64,7 @@ public interface XrpAccountDelete {
     ClassicAddress classicAddress = ImmutableClassicAddress.builder()
         .address(destination)
         .tag(destinationTag)
-        .isTest(xrplNetwork == XrplNetwork.TEST || xrplNetwork == XrplNetwork.DEV)
+        .isTest(Utils.isTestNetwork(xrplNetwork))
         .build();
 
     final String destinationXAddress = Utils.encodeXAddress(classicAddress);

--- a/src/main/java/io/xpring/xrpl/model/XrpCheckCreate.java
+++ b/src/main/java/io/xpring/xrpl/model/XrpCheckCreate.java
@@ -85,7 +85,7 @@ public interface XrpCheckCreate {
     ClassicAddress classicAddress = ImmutableClassicAddress.builder()
         .address(destination)
         .tag(destinationTag)
-        .isTest(xrplNetwork == XrplNetwork.TEST || xrplNetwork == XrplNetwork.DEV)
+        .isTest(Utils.isTestNetwork(xrplNetwork))
         .build();
 
     final String destinationXAddress = Utils.encodeXAddress(classicAddress);

--- a/src/main/java/io/xpring/xrpl/model/XrpDepositPreauth.java
+++ b/src/main/java/io/xpring/xrpl/model/XrpDepositPreauth.java
@@ -54,7 +54,7 @@ public interface XrpDepositPreauth {
    * @see "<https://github.com/ripple/rippled/blob/3d86b49dae8173344b39deb75e53170a9b6c5284/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L159"
    */
   static XrpDepositPreauth from(DepositPreauth depositPreauth, XrplNetwork xrplNetwork) {
-    final boolean isTestNetwork = xrplNetwork == XrplNetwork.TEST || xrplNetwork == XrplNetwork.DEV;
+    final boolean isTestNetwork = Utils.isTestNetwork(xrplNetwork);
 
     Optional<String> authorizeXAddress = Optional.empty();
     Optional<String> unauthorizeXAddress = Optional.empty();

--- a/src/main/java/io/xpring/xrpl/model/XrpEscrowCancel.java
+++ b/src/main/java/io/xpring/xrpl/model/XrpEscrowCancel.java
@@ -56,7 +56,7 @@ public interface XrpEscrowCancel {
 
     ClassicAddress ownerClassicAddress = ImmutableClassicAddress.builder()
         .address(escrowCancel.getOwner().getValue().getAddress())
-        .isTest(xrplNetwork == XrplNetwork.TEST || xrplNetwork == XrplNetwork.DEV)
+        .isTest(Utils.isTestNetwork(xrplNetwork))
         .build();
 
     final String ownerXAddress = Utils.encodeXAddress(ownerClassicAddress);

--- a/src/test/java/io/xpring/xrpl/UtilsTest.java
+++ b/src/test/java/io/xpring/xrpl/UtilsTest.java
@@ -1,6 +1,8 @@
 package io.xpring.xrpl;
 
-import static io.xpring.xrpl.Utils.*;
+import static io.xpring.xrpl.Utils.dropsToXrp;
+import static io.xpring.xrpl.Utils.isTestNetwork;
+import static io.xpring.xrpl.Utils.xrpToDrops;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;

--- a/src/test/java/io/xpring/xrpl/UtilsTest.java
+++ b/src/test/java/io/xpring/xrpl/UtilsTest.java
@@ -1,13 +1,13 @@
 package io.xpring.xrpl;
 
-import static io.xpring.xrpl.Utils.dropsToXrp;
-import static io.xpring.xrpl.Utils.xrpToDrops;
+import static io.xpring.xrpl.Utils.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import io.xpring.common.XrplNetwork;
 import org.junit.Test;
 
 import java.util.Optional;
@@ -411,5 +411,26 @@ public class UtilsTest {
     // GIVEN a null xrp value, WHEN converted to drops,
     // THEN an exception is thrown
     assertThrows("null argument", NullPointerException.class, () -> xrpToDrops(null));
+  }
+
+  @Test
+  public void isTestNetworkWithTest() {
+    // GIVEN an XrplNetwork of testnet, WHEN checked if it's a test network,
+    // THEN it is a test network
+    assertTrue("testnet not a test network", isTestNetwork(XrplNetwork.TEST));
+  }
+
+  @Test
+  public void isTestNetworkWithDev() {
+    // GIVEN an XrplNetwork of devnet, WHEN checked if it's a test network,
+    // THEN it is a test network
+    assertTrue("devnet not a test network", isTestNetwork(XrplNetwork.DEV));
+  }
+
+  @Test
+  public void isTestNetworkWithMain() {
+    // GIVEN an XrplNetwork of mainnet, WHEN checked if it's a test network,
+    // THEN it is not a test network
+    assertFalse("mainnet is a test network", isTestNetwork(XrplNetwork.MAIN));
   }
 }


### PR DESCRIPTION
## High Level Overview of Change
Adds `Utils.IsTestNetwork`, which returns whether or not the passed in `XrplNetwork` is a test network.
<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
Checks for `network == XrplNetwork.TEST || network == XrplNetwork.DEV` were very common while I was adding transaction types.
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After
`Utils.isTestNetwork` exists and is used in transaction types
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
Run tests + CI. They should pass
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
