### PR TITLE
spsp-test.xpring.io for ILP is dead. long live stage.xpring.money

### DIFF
--- a/src/test/java/io/xpring/ilp/IlpIntegrationTests.java
+++ b/src/test/java/io/xpring/ilp/IlpIntegrationTests.java
@@ -51,7 +51,7 @@ public class IlpIntegrationTests {
     // WHEN a payment is sent from the sender to the receiver
     PaymentRequest paymentRequest = PaymentRequest.builder()
         .amount(UnsignedLong.valueOf(10))
-        .destinationPaymentPointer("$spsp-test.xpring.io/sdk_account2")
+        .destinationPaymentPointer("$stage.xpring.money/sdk_account2")
         .senderAccountId("sdk_account1")
         .build();
 


### PR DESCRIPTION
fixes the ILP integration test by using stage.xpring.money. spsp-test.xpring.io is the old spsp server.