### PR TITLE
Attempt to improve reliability of tests:

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,5 +73,3 @@ workflows:
     jobs:
       - build
       - ilp_integration_tests:
-          requires:
-            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: cimg/openjdk:11.0.5
     resource_class: large
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,4 +72,4 @@ workflows:
   commit:
     jobs:
       - build
-      - ilp_integration_tests:
+      - ilp_integration_tests

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <protobuf.version>3.13.0</protobuf.version>
         <slf4j.version>1.7.30</slf4j.version>
         <graalvm.version>20.2.0</graalvm.version>
+        <compiler.dir>${project.build.directory}/compiler</compiler.dir>
         <!-- org.apache.maven.plugins:maven-checkstyle-plugin -->
         <checkstyle.config.location>checkstyle.xml</checkstyle.config.location>
         <checkstyle.violationSeverity>error</checkstyle.violationSeverity>
@@ -591,7 +592,76 @@
                 </plugins>
             </build>
         </profile>
-
+        <profile>
+            <id>jdk11</id>
+            <activation>
+                <jdk>[11,</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.22.1</version>
+                        <configuration>
+                            <argLine>-XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI --module-path=${compiler.dir}
+                                --upgrade-module-path=${compiler.dir}/compiler.jar:${compiler.dir}/compiler-management.jar
+                            </argLine>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <version>2.10</version>
+                        <executions>
+                            <execution>
+                                <id>copy</id>
+                                <phase>process-test-classes</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.graalvm.compiler</groupId>
+                                            <artifactId>compiler</artifactId>
+                                            <version>${graalvm.version}</version>
+                                            <type>jar</type>
+                                            <overWrite>true</overWrite>
+                                            <destFileName>compiler.jar</destFileName>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>org.graalvm.compiler</groupId>
+                                            <artifactId>compiler-management</artifactId>
+                                            <version>${graalvm.version}</version>
+                                            <type>jar</type>
+                                            <overWrite>true</overWrite>
+                                            <destFileName>compiler-management.jar</destFileName>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>org.graalvm.truffle</groupId>
+                                            <artifactId>truffle-api</artifactId>
+                                            <version>${graalvm.version}</version>
+                                            <type>jar</type>
+                                            <overWrite>true</overWrite>
+                                            <destFileName>truffle-api.jar</destFileName>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>org.graalvm.sdk</groupId>
+                                            <artifactId>graal-sdk</artifactId>
+                                            <version>${graalvm.version}</version>
+                                            <type>jar</type>
+                                            <overWrite>true</overWrite>
+                                            <destFileName>graal-sdk.jar</destFileName>
+                                        </artifactItem>
+                                    </artifactItems>
+                                    <outputDirectory>${compiler.dir}</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -342,10 +342,13 @@
                     <encoding>UTF-8</encoding>
                     <consoleOutput>true</consoleOutput>
                     <linkXRef>false</linkXRef>
-                    <excludes>**/generated-sources/**/*</excludes>
+                    <excludes>**/generated-*sources/**/*</excludes>
                     <sourceDirectories>
                         <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
                     </sourceDirectories>
+                    <testSourceDirectories>
+                        <testSourceDirectory>${project.build.testSourceDirectory}</testSourceDirectory>
+                    </testSourceDirectories>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
                 </configuration>
                 <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <grpc.version>1.31.1</grpc.version>
         <protobuf.version>3.13.0</protobuf.version>
         <slf4j.version>1.7.30</slf4j.version>
+        <feign.version>11.0</feign.version>
         <graalvm.version>20.2.0</graalvm.version>
         <compiler.dir>${project.build.directory}/compiler</compiler.dir>
         <!-- org.apache.maven.plugins:maven-checkstyle-plugin -->
@@ -132,6 +133,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
@@ -188,6 +193,16 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-jackson</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>
@@ -211,6 +226,11 @@
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-stub</artifactId>
                 <version>${grpc.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>4.0.3</version>
             </dependency>
             <dependency>
                 <groupId>io.grpc</groupId>
@@ -282,6 +302,16 @@
                 <groupId>io.swagger.codegen.v3</groupId>
                 <artifactId>swagger-codegen-maven-plugin</artifactId>
                 <version>3.0.21</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.openfeign</groupId>
+                <artifactId>feign-core</artifactId>
+                <version>${feign.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.openfeign</groupId>
+                <artifactId>feign-jackson</artifactId>
+                <version>${feign.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/java/io/xpring/xrpl/ReliableSubmissionXrpClient.java
+++ b/src/main/java/io/xpring/xrpl/ReliableSubmissionXrpClient.java
@@ -122,16 +122,17 @@ public class ReliableSubmissionXrpClient implements XrpClientDecorator {
       String sourceClassicAddress = classicAddress.address();
 
       // Poll until the transaction is validated, or until the lastLedgerSequence has been passed.
-      final RawTransactionStatus finalTransactionStatus = newTransactionPoller().until(() -> {
-          // Retrieve the latest ledger index.
-          int latestLedgerSequence = this.getLatestValidatedLedgerSequence(sourceClassicAddress);
-          RawTransactionStatus status = this.getRawTransactionStatus(transactionHash);
-          if (latestLedgerSequence > lastLedgerSequence || status.getValidated()) {
-            return status;
-          }
-          return null;
-        },
-        Matchers.notNullValue());
+      final RawTransactionStatus finalTransactionStatus = newTransactionPoller().until(
+          () -> {
+            // Retrieve the latest ledger index.
+            int latestLedgerSequence = this.getLatestValidatedLedgerSequence(sourceClassicAddress);
+            RawTransactionStatus status = this.getRawTransactionStatus(transactionHash);
+            if (latestLedgerSequence > lastLedgerSequence || status.getValidated()) {
+              return status;
+            }
+            return null;
+          },
+          Matchers.notNullValue());
       return finalTransactionStatus;
     } catch (ConditionTimeoutException e) {
       throw new XrpException(

--- a/src/main/java/io/xpring/xrpl/ReliableSubmissionXrpClient.java
+++ b/src/main/java/io/xpring/xrpl/ReliableSubmissionXrpClient.java
@@ -1,13 +1,22 @@
 package io.xpring.xrpl;
 
+import static org.awaitility.Awaitility.await;
+
 import io.xpring.xrpl.model.SendXrpDetails;
 import io.xpring.xrpl.model.TransactionResult;
 import io.xpring.xrpl.model.XrpTransaction;
+import org.awaitility.core.ConditionFactory;
+import org.awaitility.core.ConditionTimeoutException;
+import org.hamcrest.Matchers;
 
 import java.math.BigInteger;
+import java.time.Duration;
 import java.util.List;
 
 public class ReliableSubmissionXrpClient implements XrpClientDecorator {
+  // ledgers close every 4 seconds on average but are bucketed into 10s intervals.
+  // wait up to 10s with a little wiggle room.
+  public static final int MAX_TRX_STATUS_WAIT_SECONDS = 11;
   XrpClientDecorator decoratedClient;
 
   public ReliableSubmissionXrpClient(XrpClientDecorator decoratedClient) {
@@ -80,12 +89,11 @@ public class ReliableSubmissionXrpClient implements XrpClientDecorator {
 
   private RawTransactionStatus awaitFinalTransactionResult(String transactionHash, Wallet sender) throws XrpException {
     try {
-      long ledgerCloseTime = 4 * 1000;
-      Thread.sleep(ledgerCloseTime);
-
       // Get transaction status.
-      RawTransactionStatus transactionStatus = this.getRawTransactionStatus(transactionHash);
-      int lastLedgerSequence = transactionStatus.getLastLedgerSequence();
+      final RawTransactionStatus initialTransactionStatus = newTransactionPoller().until(
+          () -> this.getRawTransactionStatus(transactionHash),
+          Matchers.notNullValue());
+      final int lastLedgerSequence = initialTransactionStatus.getLastLedgerSequence();
       if (lastLedgerSequence == 0) {
         throw new XrpException(
                 XrpExceptionType.UNKNOWN,
@@ -113,23 +121,27 @@ public class ReliableSubmissionXrpClient implements XrpClientDecorator {
       }
       String sourceClassicAddress = classicAddress.address();
 
-      // Retrieve the latest ledger index.
-      int latestLedgerSequence = this.getLatestValidatedLedgerSequence(sourceClassicAddress);
-
       // Poll until the transaction is validated, or until the lastLedgerSequence has been passed.
-      while (latestLedgerSequence <= lastLedgerSequence && !transactionStatus.getValidated()) {
-        Thread.sleep(ledgerCloseTime);
-
-        latestLedgerSequence = this.getLatestValidatedLedgerSequence(sourceClassicAddress);
-        transactionStatus = this.getRawTransactionStatus(transactionHash);
-      }
-
-      return transactionStatus;
-    } catch (InterruptedException e) {
+      final RawTransactionStatus finalTransactionStatus = newTransactionPoller().until(() -> {
+          // Retrieve the latest ledger index.
+          int latestLedgerSequence = this.getLatestValidatedLedgerSequence(sourceClassicAddress);
+          RawTransactionStatus status = this.getRawTransactionStatus(transactionHash);
+          if (latestLedgerSequence > lastLedgerSequence || status.getValidated()) {
+            return status;
+          }
+          return null;
+        },
+        Matchers.notNullValue());
+      return finalTransactionStatus;
+    } catch (ConditionTimeoutException e) {
       throw new XrpException(
               XrpExceptionType.UNKNOWN,
               "Reliable transaction submission project was interrupted."
       );
     }
+  }
+
+  private ConditionFactory newTransactionPoller() {
+    return await().atMost(Duration.ofSeconds(MAX_TRX_STATUS_WAIT_SECONDS)).pollInterval(Duration.ofSeconds(1));
   }
 }

--- a/src/test/java/io/xpring/xrpl/helpers/XrpTestUtils.java
+++ b/src/test/java/io/xpring/xrpl/helpers/XrpTestUtils.java
@@ -29,7 +29,7 @@ import java.util.Optional;
 public class XrpTestUtils {
 
   public static final FaucetClient faucetClient =
-    FaucetClient.construct(HttpUrl.parse("https://faucet.altnet.rippletest.net"));
+      FaucetClient.construct(HttpUrl.parse("https://faucet.altnet.rippletest.net"));
 
   /**
    * Converts a GetAccountTransactionHistoryResponse protocol buffer object into a list of XrpTransaction objects,
@@ -73,10 +73,9 @@ public class XrpTestUtils {
 
     FaucetAccountResponse response = faucetClient.generateFaucetAccount();
     Awaitility.await()
-      .atMost(Duration.ofSeconds(20))
-      .pollInterval(Duration.ofSeconds(1))
-      .until(() -> xrpClient.accountExists(response.account().xAddress()));
-
+        .atMost(Duration.ofSeconds(20))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(() -> xrpClient.accountExists(response.account().xAddress()));
 
     Wallet wallet = new Wallet(response.account().secret(), true);
 

--- a/src/test/java/io/xpring/xrpl/helpers/XrpTestUtils.java
+++ b/src/test/java/io/xpring/xrpl/helpers/XrpTestUtils.java
@@ -11,12 +11,14 @@ import io.xpring.xrpl.model.MemoField;
 import io.xpring.xrpl.model.XrpMemo;
 import io.xpring.xrpl.model.XrpTransaction;
 import okhttp3.HttpUrl;
+import org.awaitility.Awaitility;
 import org.xrpl.rpc.v1.GetAccountTransactionHistoryResponse;
 import org.xrpl.rpc.v1.GetTransactionResponse;
 import org.xrpl.rpc.v1.Transaction;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -70,6 +72,11 @@ public class XrpTestUtils {
     XrpClient xrpClient = new XrpClient(rippledUrl, XrplNetwork.TEST);
 
     FaucetAccountResponse response = faucetClient.generateFaucetAccount();
+    Awaitility.await()
+      .atMost(Duration.ofSeconds(20))
+      .pollInterval(Duration.ofSeconds(1))
+      .until(() -> xrpClient.accountExists(response.account().xAddress()));
+
 
     Wallet wallet = new Wallet(response.account().secret(), true);
 

--- a/src/test/java/io/xpring/xrpl/helpers/faucet/FaucetAccount.java
+++ b/src/test/java/io/xpring/xrpl/helpers/faucet/FaucetAccount.java
@@ -7,33 +7,38 @@ import io.xpring.xrpl.helpers.faucet.ImmutableFaucetAccount;
 import org.immutables.value.Value;
 
 /**
- * Faucet account details returned as part of a request to the /accounts API
+ * Faucet account details returned as part of a request to the /accounts API.
  */
 @Value.Immutable
 @JsonSerialize(as = ImmutableFaucetAccount.class)
 @JsonDeserialize(as = ImmutableFaucetAccount.class)
 public interface FaucetAccount {
 
+  @SuppressWarnings("checkstyle:MethodName")
   /**
    * X-address of the created account.
+   *
    * @return
    */
   String xAddress();
 
   /**
    * Classic address of the created account.
+   *
    * @return
    */
   String classicAddress();
 
   /**
    * Same value as classicAddress.
+   *
    * @return
    */
   String address();
 
   /**
    * Private secret/seed for the address.
+   *
    * @return
    */
   String secret();

--- a/src/test/java/io/xpring/xrpl/helpers/faucet/FaucetAccount.java
+++ b/src/test/java/io/xpring/xrpl/helpers/faucet/FaucetAccount.java
@@ -3,7 +3,7 @@ package io.xpring.xrpl.helpers.faucet;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import io.xpring.xrpl.helpers.ImmutableFaucetAccount;
+import io.xpring.xrpl.helpers.faucet.ImmutableFaucetAccount;
 import org.immutables.value.Value;
 
 /**

--- a/src/test/java/io/xpring/xrpl/helpers/faucet/FaucetAccount.java
+++ b/src/test/java/io/xpring/xrpl/helpers/faucet/FaucetAccount.java
@@ -1,0 +1,41 @@
+package io.xpring.xrpl.helpers.faucet;
+
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.xpring.xrpl.helpers.ImmutableFaucetAccount;
+import org.immutables.value.Value;
+
+/**
+ * Faucet account details returned as part of a request to the /accounts API
+ */
+@Value.Immutable
+@JsonSerialize(as = ImmutableFaucetAccount.class)
+@JsonDeserialize(as = ImmutableFaucetAccount.class)
+public interface FaucetAccount {
+
+  /**
+   * X-address of the created account.
+   * @return
+   */
+  String xAddress();
+
+  /**
+   * Classic address of the created account.
+   * @return
+   */
+  String classicAddress();
+
+  /**
+   * Same value as classicAddress.
+   * @return
+   */
+  String address();
+
+  /**
+   * Private secret/seed for the address.
+   * @return
+   */
+  String secret();
+
+}

--- a/src/test/java/io/xpring/xrpl/helpers/faucet/FaucetAccountResponse.java
+++ b/src/test/java/io/xpring/xrpl/helpers/faucet/FaucetAccountResponse.java
@@ -6,7 +6,7 @@ import io.xpring.xrpl.helpers.faucet.ImmutableFaucetAccountResponse;
 import org.immutables.value.Value.Immutable;
 
 /**
- * Response to a POST request to the /accounts API
+ * Response to a POST request to the /accounts API.
  */
 @Immutable
 @JsonSerialize(as = ImmutableFaucetAccountResponse.class)
@@ -15,18 +15,21 @@ public interface FaucetAccountResponse {
 
   /**
    * XRPL account that was created on testnet.
+   *
    * @return
    */
   FaucetAccount account();
 
   /**
    * Amount the faucet sent to the account.
+   *
    * @return
    */
   long amount();
 
   /**
    * Current balance of the account.
+   *
    * @return
    */
   long balance();

--- a/src/test/java/io/xpring/xrpl/helpers/faucet/FaucetAccountResponse.java
+++ b/src/test/java/io/xpring/xrpl/helpers/faucet/FaucetAccountResponse.java
@@ -2,7 +2,7 @@ package io.xpring.xrpl.helpers.faucet;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import io.xpring.xrpl.helpers.ImmutableFaucetAccountResponse;
+import io.xpring.xrpl.helpers.faucet.ImmutableFaucetAccountResponse;
 import org.immutables.value.Value.Immutable;
 
 /**

--- a/src/test/java/io/xpring/xrpl/helpers/faucet/FaucetAccountResponse.java
+++ b/src/test/java/io/xpring/xrpl/helpers/faucet/FaucetAccountResponse.java
@@ -1,0 +1,34 @@
+package io.xpring.xrpl.helpers.faucet;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.xpring.xrpl.helpers.ImmutableFaucetAccountResponse;
+import org.immutables.value.Value.Immutable;
+
+/**
+ * Response to a POST request to the /accounts API
+ */
+@Immutable
+@JsonSerialize(as = ImmutableFaucetAccountResponse.class)
+@JsonDeserialize(as = ImmutableFaucetAccountResponse.class)
+public interface FaucetAccountResponse {
+
+  /**
+   * XRPL account that was created on testnet.
+   * @return
+   */
+  FaucetAccount account();
+
+  /**
+   * Amount the faucet sent to the account.
+   * @return
+   */
+  long amount();
+
+  /**
+   * Current balance of the account.
+   * @return
+   */
+  long balance();
+
+}

--- a/src/test/java/io/xpring/xrpl/helpers/faucet/FaucetClient.java
+++ b/src/test/java/io/xpring/xrpl/helpers/faucet/FaucetClient.java
@@ -1,0 +1,46 @@
+package io.xpring.xrpl.helpers.faucet;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.Feign;
+import feign.Headers;
+import feign.RequestLine;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import feign.optionals.OptionalDecoder;
+import io.xpring.xrpl.helpers.ImmutableFaucetAccountResponse;
+import okhttp3.HttpUrl;
+
+import java.util.Objects;
+
+/**
+ * A feign HTTP client for interacting with the Testnet Faucet REST API
+ */
+public interface FaucetClient {
+
+  String HEADER_ACCEPT = "Accept";
+  String HEADER_CONTENT_TYPE = "Content-Type";
+  String APPLICATION_JSON = "application/json";
+
+  static FaucetClient construct(final HttpUrl faucetUrl) {
+    Objects.requireNonNull(faucetUrl);
+
+    final ObjectMapper objectMapper = new ObjectMapper();
+    return Feign.builder()
+      .encoder(new JacksonEncoder(objectMapper))
+      .decode404()
+      .decoder(new OptionalDecoder(new JacksonDecoder(objectMapper)))
+      .target(FaucetClient.class, faucetUrl.toString());
+  }
+
+  /**
+   * Request a new account to be created and funded by the test faucet.
+   * @return
+   */
+  @RequestLine("POST /accounts")
+  @Headers({
+    HEADER_ACCEPT + ": " + APPLICATION_JSON,
+    HEADER_CONTENT_TYPE + ": " + APPLICATION_JSON,
+  })
+  ImmutableFaucetAccountResponse generateFaucetAccount();
+
+}

--- a/src/test/java/io/xpring/xrpl/helpers/faucet/FaucetClient.java
+++ b/src/test/java/io/xpring/xrpl/helpers/faucet/FaucetClient.java
@@ -7,7 +7,7 @@ import feign.RequestLine;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 import feign.optionals.OptionalDecoder;
-import io.xpring.xrpl.helpers.ImmutableFaucetAccountResponse;
+import io.xpring.xrpl.helpers.faucet.ImmutableFaucetAccountResponse;
 import okhttp3.HttpUrl;
 
 import java.util.Objects;

--- a/src/test/java/io/xpring/xrpl/helpers/faucet/FaucetClient.java
+++ b/src/test/java/io/xpring/xrpl/helpers/faucet/FaucetClient.java
@@ -7,13 +7,12 @@ import feign.RequestLine;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 import feign.optionals.OptionalDecoder;
-import io.xpring.xrpl.helpers.faucet.ImmutableFaucetAccountResponse;
 import okhttp3.HttpUrl;
 
 import java.util.Objects;
 
 /**
- * A feign HTTP client for interacting with the Testnet Faucet REST API
+ * A feign HTTP client for interacting with the Testnet Faucet REST API.
  */
 public interface FaucetClient {
 
@@ -21,25 +20,32 @@ public interface FaucetClient {
   String HEADER_CONTENT_TYPE = "Content-Type";
   String APPLICATION_JSON = "application/json";
 
+  /**
+   * Constructs a new client for the given url.
+   *
+   * @param faucetUrl url for the faucet server.
+   * @return
+   */
   static FaucetClient construct(final HttpUrl faucetUrl) {
     Objects.requireNonNull(faucetUrl);
 
     final ObjectMapper objectMapper = new ObjectMapper();
     return Feign.builder()
-      .encoder(new JacksonEncoder(objectMapper))
-      .decode404()
-      .decoder(new OptionalDecoder(new JacksonDecoder(objectMapper)))
-      .target(FaucetClient.class, faucetUrl.toString());
+        .encoder(new JacksonEncoder(objectMapper))
+        .decode404()
+        .decoder(new OptionalDecoder(new JacksonDecoder(objectMapper)))
+        .target(FaucetClient.class, faucetUrl.toString());
   }
 
   /**
    * Request a new account to be created and funded by the test faucet.
+   *
    * @return
    */
   @RequestLine("POST /accounts")
-  @Headers({
-    HEADER_ACCEPT + ": " + APPLICATION_JSON,
-    HEADER_CONTENT_TYPE + ": " + APPLICATION_JSON,
+  @Headers( {
+      HEADER_ACCEPT + ": " + APPLICATION_JSON,
+      HEADER_CONTENT_TYPE + ": " + APPLICATION_JSON,
   })
   ImmutableFaucetAccountResponse generateFaucetAccount();
 


### PR DESCRIPTION
- Use Awaitility to poll the transaction status instead of using a strict 4 seconds
- Switch to using the testnet Faucet API to generate and fund a random account. This is also faster than generating the account locally
due to poor performance of the Javascript interpreter.
- Switch to using Feign HTTP client to call Testnet faucet REST API