### PR TITLE
port X-address / Classic address encoding and decoding to pure Java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,10 @@
             <artifactId>feign-jackson</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>
@@ -312,6 +316,11 @@
                 <groupId>io.github.openfeign</groupId>
                 <artifactId>feign-jackson</artifactId>
                 <version>${feign.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk15on</artifactId>
+                <version>1.64</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/java/io/xpring/codec/addresses/ClassicAddressCodec.java
+++ b/src/main/java/io/xpring/codec/addresses/ClassicAddressCodec.java
@@ -8,13 +8,13 @@ public class ClassicAddressCodec {
   public static final B58 codec = new B58("rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz");
 
   // Otherwise known as `family seed`
-  public static final B58.Version SEED_K256 = new B58.Version(
+  public static final B58.Version SEED_K256_VERSION = new B58.Version(
       33, "seedK256", 16);
 
-  public static final B58.Version SEED_ED25519 = new B58.Version(
+  public static final B58.Version SEED_ED25519_VERSION = new B58.Version(
       "01E14B", "seedEd25519", 16);
 
-  public static final B58.Version ACCOUNT_ID = new B58.Version(
+  public static final B58.Version ACCOUNT_ID_VERSION = new B58.Version(
       0, "accountId", 20);
 
   public static final B58.Version NODE_PUBLIC_KEY = new B58.Version(
@@ -32,24 +32,24 @@ public class ClassicAddressCodec {
   }
 
   public static byte[] decodeSeedToBytes(String seed) {
-    return codec.decodeVersioned(seed, SEED_K256, SEED_ED25519)
+    return codec.decodeVersioned(seed, SEED_K256_VERSION, SEED_ED25519_VERSION)
         .payload;
   }
 
   public static B58.Decoded decodeSeed(String seed) {
-    return codec.decodeVersioned(seed, SEED_K256, SEED_ED25519);
+    return codec.decodeVersioned(seed, SEED_K256_VERSION, SEED_ED25519_VERSION);
   }
 
   public static String encodeSeedK256(byte[] bytes) {
-    return encode(bytes, SEED_K256);
+    return encode(bytes, SEED_K256_VERSION);
   }
 
   public static String encodeAccountID(byte[] bytes) {
-    return encode(bytes, ACCOUNT_ID);
+    return encode(bytes, ACCOUNT_ID_VERSION);
   }
 
   public static byte[] decodeAccountID(String id) {
-    return decode(id, ACCOUNT_ID);
+    return decode(id, ACCOUNT_ID_VERSION);
   }
 
   public static String encodeNodePublic(byte[] bytes) {
@@ -77,6 +77,6 @@ public class ClassicAddressCodec {
   }
 
   public static boolean isValidAccountID(String encoded) {
-    return isValid(encoded, ACCOUNT_ID);
+    return isValid(encoded, ACCOUNT_ID_VERSION);
   }
 }

--- a/src/main/java/io/xpring/codec/addresses/ClassicAddressCodec.java
+++ b/src/main/java/io/xpring/codec/addresses/ClassicAddressCodec.java
@@ -1,0 +1,82 @@
+package io.xpring.codec.addresses;
+
+
+import io.xpring.codec.base58.B58;
+import io.xpring.codec.basex.EncodingFormatException;
+
+public class ClassicAddressCodec {
+  public static final B58 codec = new B58("rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz");
+
+  // Otherwise known as `family seed`
+  public static final B58.Version SEED_K256 = new B58.Version(
+      33, "seedK256", 16);
+
+  public static final B58.Version SEED_ED25519 = new B58.Version(
+      "01E14B", "seedEd25519", 16);
+
+  public static final B58.Version ACCOUNT_ID = new B58.Version(
+      0, "accountId", 20);
+
+  public static final B58.Version NODE_PUBLIC_KEY = new B58.Version(
+      28, "nodePublicKey", 33);
+
+  public static final B58.Version NODE_PRIVATE_KEY = new B58.Version(
+      33, "nodePrivateKey", 32);
+
+  public static byte[] decode(String encoded, B58.Version version) {
+    return codec.decodeVersioned(encoded, version).payload;
+  }
+
+  public static String encode(byte[] bytes, B58.Version version) {
+    return codec.encodeVersioned(bytes, version);
+  }
+
+  public static byte[] decodeSeedToBytes(String seed) {
+    return codec.decodeVersioned(seed, SEED_K256, SEED_ED25519)
+        .payload;
+  }
+
+  public static B58.Decoded decodeSeed(String seed) {
+    return codec.decodeVersioned(seed, SEED_K256, SEED_ED25519);
+  }
+
+  public static String encodeSeedK256(byte[] bytes) {
+    return encode(bytes, SEED_K256);
+  }
+
+  public static String encodeAccountID(byte[] bytes) {
+    return encode(bytes, ACCOUNT_ID);
+  }
+
+  public static byte[] decodeAccountID(String id) {
+    return decode(id, ACCOUNT_ID);
+  }
+
+  public static String encodeNodePublic(byte[] bytes) {
+    return encode(bytes, NODE_PUBLIC_KEY);
+  }
+
+  public static byte[] decodeNodePublic(String base58) {
+    return decode(base58, NODE_PUBLIC_KEY);
+  }
+
+  /**
+   * Checks if the encoded value can be decoded using any of the provides versions.
+   *
+   * @param encoded the value to check.
+   * @param versions the versions to validate with.
+   * @return true if valid.
+   */
+  public static boolean isValid(String encoded, B58.Version... versions) {
+    try {
+      codec.decodeVersioned(encoded, versions);
+      return true;
+    } catch (EncodingFormatException e) {
+      return false;
+    }
+  }
+
+  public static boolean isValidAccountID(String encoded) {
+    return isValid(encoded, ACCOUNT_ID);
+  }
+}

--- a/src/main/java/io/xpring/codec/addresses/XAddressCodec.java
+++ b/src/main/java/io/xpring/codec/addresses/XAddressCodec.java
@@ -1,0 +1,126 @@
+package io.xpring.codec.addresses;
+
+import static com.google.common.io.BaseEncoding.base16;
+
+import com.google.common.base.Preconditions;
+import io.xpring.codec.base58.B58;
+import io.xpring.codec.basex.IBaseX;
+import io.xpring.xrpl.ClassicAddress;
+
+import java.util.Optional;
+
+/**
+ * Encodes and decodes X-Address as defined by the spec: https://github.com/xrp-community/standards-drafts/issues/6.
+ */
+public class XAddressCodec {
+
+  private static final int XADDRESS_EXPECTED_LENGTH = 30;
+  private static final int ACCOUNT_ID_EXPECTED_LENGTH = 20;
+  private static final int ACCOUNT_ID_VERSION = 0;
+  private static final String TAG_PRESENT_FLAG = "01";
+  private static final long MAX_TAG = (long) Math.pow(2, 32) - 1;
+  // XRPL uses Base58 but with an alphabet in a peculiar order (see https://xrpl.org/base58-encodings.html)
+  private static B58 codec = new B58("rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz");
+  private static String RESERVED_SUFFIX = "00000000";
+
+  /**
+   * Encodes a classic address to an x-address.
+   *
+   * @param classicAddress the address to encode.
+   * @return encoded x-address.
+   */
+  public static String encode(ClassicAddress classicAddress) {
+    // To compute the X-Address, several hex values are computed and concatenated together, then encoded
+    // using Base58 with a XRPL version
+    try {
+      Prefix prefix = classicAddress.isTest() ? Prefix.TESTNET : Prefix.MAINNET;
+      String addressBytes = base16().encode(ClassicAddressCodec.decodeAccountID(classicAddress.address()));
+      String tagFlag = classicAddress.tag().isPresent() ? TAG_PRESENT_FLAG : "00";
+      String tagBytes = encodeTag(classicAddress.tag());
+      byte [] xaddress = base16().decode(prefix.prefix + addressBytes + tagFlag + tagBytes + RESERVED_SUFFIX);
+      return encodeAddress(prefix.version, xaddress, XADDRESS_EXPECTED_LENGTH);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  /**
+   * Decodes an x-address to a classic address.
+   *
+   * @param xaddress the address to encode.
+   * @return encoded x-address.
+   */
+  public static ClassicAddress decode(String xaddress) {
+    Preconditions.checkArgument(xaddress.length() == 47, "X-address must be exactly 47 characters long");
+    boolean isMainnet = xaddress.startsWith("X");
+    boolean isTestnet = xaddress.startsWith("T");
+    Preconditions.checkArgument(isMainnet || isTestnet, "X-address must start with X or T");
+
+    Prefix prefix = isMainnet ? Prefix.MAINNET : Prefix.TESTNET;
+    IBaseX.Decoded decoded =
+        codec.decodeVersioned(xaddress, new IBaseX.Version(prefix.version, "accountId", XADDRESS_EXPECTED_LENGTH));
+
+    // encoded address is a hex string with 60 characters, with parts at the following indexes:
+    // NETWORK [0-1] | ADDRESS [2-41] | TAG_FLAG [42-43] | TAG [44-51] | PADDING [52-59]
+    // since the second argument to String.substring is exclusive, it will be 1 above these values.
+    String encodedAddress = base16().encode(decoded.payload);
+    String classicAddress = encodedAddress.substring(2, 42);
+    String tagFlag = encodedAddress.substring(42, 44);
+    String encodedTag = encodedAddress.substring(44, 52);
+    return ClassicAddress.builder()
+        .address(encodeAddress(ACCOUNT_ID_VERSION, base16().decode(classicAddress), ACCOUNT_ID_EXPECTED_LENGTH))
+        .isTest(isTestnet)
+        .tag(decodeTag(tagFlag, encodedTag))
+        .build();
+  }
+
+  private static String encodeAddress(int version, byte[] decode, int expectedLength) {
+    return codec.encodeVersioned(decode, new IBaseX.Version(version, "accountId", expectedLength));
+  }
+
+  private static String encodeTag(Optional<Integer> tag) {
+    return base16().encode(tagToLittleEndian(tag.orElse(0)));
+  }
+
+  private static Optional<Integer> decodeTag(String tagFlag, String encodedTag) {
+    if (!tagFlag.equals(TAG_PRESENT_FLAG)) {
+      return Optional.empty();
+    }
+    return Optional.of(littleEndianToTag(encodedTag));
+  }
+
+  private static byte[] tagToLittleEndian(long value) {
+    Preconditions.checkArgument(value <= MAX_TAG, "tag cannot be greater than " + MAX_TAG);
+    Preconditions.checkArgument(value >= 0, "tag cannot be negative");
+    byte[] bytes = new byte[4];
+    bytes[0] = (byte) (value & 0xFF);
+    bytes[1] = (byte) ((value >> 8) & 0xFF);
+    bytes[2] = (byte) ((value >> 16) & 0xFF);
+    bytes[3] = (byte) ((value >> 24) & 0xFF);
+    return bytes;
+  }
+
+  private static int littleEndianToTag(String encodedTag) {
+    byte [] bytes = base16().decode(encodedTag);
+    return ((bytes[3] & 0xFF) << 24) | ((bytes[2] & 0xFF) << 16)
+        | ((bytes[1] & 0xFF) << 8) | (bytes[0] & 0xFF);
+  }
+
+  /**
+   * The X-Address spec embeds a prefix in the encoded X-address. The prefix consists of an XRPL object version
+   * and a network prefix.
+   */
+  private enum Prefix {
+    MAINNET(5, "44"),
+    TESTNET(4, "93");
+
+    private final int version;
+    private final String prefix;
+
+    Prefix(int version, String prefix) {
+      this.version = version;
+      this.prefix = prefix;
+    }
+  }
+
+}

--- a/src/main/java/io/xpring/codec/addresses/XAddressCodec.java
+++ b/src/main/java/io/xpring/codec/addresses/XAddressCodec.java
@@ -47,18 +47,19 @@ public class XAddressCodec {
   /**
    * Decodes an x-address to a classic address.
    *
-   * @param xaddress the address to encode.
+   * @param xAddress the address to encode.
    * @return encoded x-address.
    */
-  public static ClassicAddress decode(String xaddress) {
-    Preconditions.checkArgument(xaddress.length() == 47, "X-address must be exactly 47 characters long");
-    boolean isMainnet = xaddress.startsWith("X");
-    boolean isTestnet = xaddress.startsWith("T");
+  @SuppressWarnings("checkstyle:ParameterName")
+  public static ClassicAddress decode(String xAddress) {
+    Preconditions.checkArgument(xAddress.length() == 47, "X-address must be exactly 47 characters long");
+    boolean isMainnet = xAddress.startsWith("X");
+    boolean isTestnet = xAddress.startsWith("T");
     Preconditions.checkArgument(isMainnet || isTestnet, "X-address must start with X or T");
 
     Prefix prefix = isMainnet ? Prefix.MAINNET : Prefix.TESTNET;
     IBaseX.Decoded decoded =
-        codec.decodeVersioned(xaddress, new IBaseX.Version(prefix.version, "accountId", XADDRESS_EXPECTED_LENGTH));
+        codec.decodeVersioned(xAddress, new IBaseX.Version(prefix.version, "accountId", XADDRESS_EXPECTED_LENGTH));
 
     // encoded address is a hex string with 60 characters, with parts at the following indexes:
     // NETWORK [0-1] | ADDRESS [2-41] | TAG_FLAG [42-43] | TAG [44-51] | PADDING [52-59]

--- a/src/main/java/io/xpring/codec/base58/B58.java
+++ b/src/main/java/io/xpring/codec/base58/B58.java
@@ -1,0 +1,9 @@
+package io.xpring.codec.base58;
+
+import io.xpring.codec.basex.BaseX;
+
+public class B58 extends BaseX {
+  public B58(String alphabet) {
+    super(alphabet);
+  }
+}

--- a/src/main/java/io/xpring/codec/basex/BaseX.java
+++ b/src/main/java/io/xpring/codec/basex/BaseX.java
@@ -10,7 +10,7 @@ public class BaseX implements IBaseX {
   protected final int[] indexes;
 
   /**
-   * creates a new instance with the given alphabet.
+   * Creates a new instance with the given alphabet.
    *
    * @param alphabet the alphabet to use for encoding.
    */

--- a/src/main/java/io/xpring/codec/basex/BaseX.java
+++ b/src/main/java/io/xpring/codec/basex/BaseX.java
@@ -1,0 +1,246 @@
+package io.xpring.codec.basex;
+
+import io.xpring.common.HashUtils;
+
+import java.util.Arrays;
+
+public class BaseX implements IBaseX {
+  private char[] alphabet;
+  private final char encodedZero;
+  protected final int[] indexes;
+
+  /**
+   * creates a new instance with the given alphabet.
+   *
+   * @param alphabet the alphabet to use for encoding.
+   */
+  public BaseX(String alphabet) {
+    if (alphabet.length() > 256) {
+      throw new IllegalArgumentException();
+    }
+    this.alphabet = alphabet.toCharArray();
+    indexes = new int[128];
+    encodedZero = this.alphabet[0];
+    Arrays.fill(indexes, -1);
+    for (int i = 0; i < this.alphabet.length; i++) {
+      indexes[this.alphabet[i]] = i;
+    }
+  }
+
+  private static String repeat(int times, char repeated) {
+    char[] chars = new char[times];
+    Arrays.fill(chars, repeated);
+    return new String(chars);
+  }
+
+  /**
+   * Encodes the given bytes as a base58 string (no checksum is appended).
+   *
+   * @param input the bytes to encode
+   * @return the base58-encoded string
+   */
+  @Override
+  public String encode(byte[] input) {
+    if (input.length == 0) {
+      return "";
+    }
+    // Count leading zeros.
+    int zeros = 0;
+    while (zeros < input.length && input[zeros] == 0) {
+      ++zeros;
+    }
+    // Convert base-256 digits to base-58 digits (plus conversion to ASCII characters)
+    input = Arrays.copyOf(input, input.length); // since we modify it in-place
+    char[] encoded = new char[input.length * 2]; // upper bound
+    int outputStart = encoded.length;
+    for (int inputStart = zeros; inputStart < input.length; ) {
+      encoded[--outputStart] = alphabet[divmod(input, inputStart, 256, 58)];
+      if (input[inputStart] == 0) {
+        ++inputStart; // optimization - skip leading zeros
+      }
+    }
+    // Preserve exactly as many leading encoded zeros in output as there were leading zeros in input.
+    while (outputStart < encoded.length && encoded[outputStart] == encodedZero) {
+      ++outputStart;
+    }
+    while (--zeros >= 0) {
+      encoded[--outputStart] = encodedZero;
+    }
+    // Return encoded string (including encoded leading zeros).
+    return new String(encoded, outputStart, encoded.length - outputStart);
+  }
+
+  /**
+   * Decodes the given base58 string into the original data bytes.
+   *
+   * @param input the base58-encoded string to decode
+   * @return the decoded data bytes
+   * @throws EncodingFormatException if the given string is not a valid base58 string
+   */
+  @Override
+  public byte[] decode(String input) throws EncodingFormatException {
+    if (input.length() == 0) {
+      return new byte[0];
+    }
+    // Convert the base58-encoded ASCII chars to a base58 byte sequence (base58 digits).
+    byte[] input58 = new byte[input.length()];
+    for (int i = 0; i < input.length(); ++i) {
+      char character = input.charAt(i);
+      int digit = character < 128 ? indexes[character] : -1;
+      if (digit < 0) {
+        throw new EncodingFormatException("Illegal character " + character + " at position " + i);
+      }
+      input58[i] = (byte) digit;
+    }
+    // Count leading zeros.
+    int zeros = 0;
+    while (zeros < input58.length && input58[zeros] == 0) {
+      ++zeros;
+    }
+    // Convert base-58 digits to base-256 digits.
+    byte[] decoded = new byte[input.length()];
+    int outputStart = decoded.length;
+    for (int inputStart = zeros; inputStart < input58.length; ) {
+      decoded[--outputStart] = divmod(input58, inputStart, 58, 256);
+      if (input58[inputStart] == 0) {
+        ++inputStart; // optimization - skip leading zeros
+      }
+    }
+    // Ignore extra leading zeroes that were added during the calculation.
+    while (outputStart < decoded.length && decoded[outputStart] == 0) {
+      ++outputStart;
+    }
+    // Return decoded data (including original number of leading zeros).
+    return Arrays.copyOfRange(decoded, outputStart - zeros, decoded.length);
+  }
+
+  /**
+   * Decodes the given base58 string into the original data bytes, using the checksum in the
+   * last 4 bytes of the decoded data to verify that the rest are correct. The checksum is
+   * removed from the returned data.
+   *
+   * @param input the base58-encoded string to decode (which should include the checksum)
+   * @throws EncodingFormatException if the input is not base 58 or the checksum does not validate.
+   */
+  public byte[] decodeChecked(String input) throws EncodingFormatException {
+    byte[] decoded = decode(input);
+    if (decoded.length < 4) {
+      throw new EncodingFormatException("Input too short");
+    }
+    byte[] data = Arrays.copyOfRange(decoded, 0, decoded.length - 4);
+    byte[] checksum = Arrays.copyOfRange(decoded, decoded.length - 4, decoded.length);
+    byte[] actualChecksum = Arrays.copyOfRange(HashUtils.doubleDigest(data), 0, 4);
+    if (!Arrays.equals(checksum, actualChecksum)) {
+      throw new EncodingFormatException("Checksum does not validate");
+    }
+    return data;
+  }
+
+  /**
+   * Divides a number, represented as an array of bytes each containing a single digit
+   * in the specified base, by the given divisor. The given number is modified in-place
+   * to contain the quotient, and the return value is the remainder.
+   *
+   * @param number     the number to divide
+   * @param firstDigit the index within the array of the first non-zero digit
+   *                   (this is used for optimization by skipping the leading zeros)
+   * @param base       the base in which the number's digits are represented (up to 256)
+   * @param divisor    the number to divide by (up to 256)
+   * @return the remainder of the division operation
+   */
+  private byte divmod(byte[] number, int firstDigit, int base, int divisor) {
+    // this is just long division which accounts for the base of the input digits
+    int remainder = 0;
+    for (int i = firstDigit; i < number.length; i++) {
+      int digit = (int) number[i] & 0xFF;
+      int temp = remainder * base + digit;
+      number[i] = (byte) (temp / divisor);
+      remainder = temp % divisor;
+    }
+    return (byte) remainder;
+  }
+
+  @Override
+  public byte[] findPrefix(int payLoadLength, String desiredPrefix) {
+    if (alphabet.length != 58) {
+      throw new IllegalStateException("Must be base58");
+    }
+    int totalLength = payLoadLength + 4; // for the checksum
+    double chars = Math.log(Math.pow(256, totalLength)) / Math.log(58);
+    int requiredChars = (int) Math.ceil(chars + 0.2D);
+    // Mess with this to see stability tests fail
+    int charPos = (alphabet.length / 2) - 1;
+    char padding = alphabet[(charPos)];
+    String template = desiredPrefix + repeat(requiredChars, padding);
+    byte[] decoded = decode(template);
+    return copyOfRange(decoded, 0, decoded.length - totalLength);
+  }
+
+  @Override
+  public String encodeVersioned(byte[] input, Version version) {
+    if (input.length != version.expectedLength) {
+      throw new IllegalArgumentException(
+          "input length=" + input.length
+              + ", expected=" + version.expectedLength);
+    }
+    return encode(concatVersionAndAddChecksum(input, version.bytes));
+  }
+
+  private byte[] concatVersionAndAddChecksum(byte[] input, byte[] version) {
+    byte[] buffer = new byte[input.length + version.length];
+    System.arraycopy(version, 0, buffer, 0, version.length);
+    System.arraycopy(input, 0, buffer, version.length, input.length);
+    byte[] checkSum = copyOfRange(HashUtils.doubleDigest(buffer), 0, 4);
+    byte[] output = new byte[buffer.length + checkSum.length];
+    System.arraycopy(buffer, 0, output, 0, buffer.length);
+    System.arraycopy(checkSum, 0, output, buffer.length, checkSum.length);
+    return output;
+  }
+
+  /**
+   * Attempts to decodes the input using the provided versions.
+   *
+   * @param input value to decode.
+   * @param possibleVersions versions to try.
+   * @return decoded value.
+   * @throws EncodingFormatException if input cannot be decoded.
+   */
+  public Decoded decodeVersioned(String input,
+                                 Version... possibleVersions) throws EncodingFormatException {
+
+    byte[] buffer = decodeChecked(input);
+
+    Version foundVersion = null;
+    int expectedLength = possibleVersions[0].expectedLength;
+    int versionLength = buffer.length - expectedLength;
+    byte[] versionBytes = copyOfRange(buffer, 0, versionLength);
+
+    for (Version possible : possibleVersions) {
+      if (possible.expectedLength != expectedLength) {
+        throw new IllegalStateException();
+      }
+
+      if (Arrays.equals(possible.bytes, versionBytes)) {
+        foundVersion = possible;
+        break;
+      }
+    }
+    if (foundVersion == null) {
+      throw new EncodingFormatException("Incorrect version");
+    }
+
+    byte[] bytes = copyOfRange(buffer, versionLength, buffer.length);
+    if (bytes.length != expectedLength) {
+      throw new EncodingFormatException("Incorrect length");
+    }
+
+    return new Decoded(foundVersion, bytes);
+  }
+
+  private byte[] copyOfRange(byte[] source, int from, int to) {
+    byte[] range = new byte[to - from];
+    System.arraycopy(source, from, range, 0, range.length);
+    return range;
+  }
+
+}

--- a/src/main/java/io/xpring/codec/basex/EncodingFormatException.java
+++ b/src/main/java/io/xpring/codec/basex/EncodingFormatException.java
@@ -1,0 +1,7 @@
+package io.xpring.codec.basex;
+
+public class EncodingFormatException extends RuntimeException {
+  public EncodingFormatException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/io/xpring/codec/basex/IBaseX.java
+++ b/src/main/java/io/xpring/codec/basex/IBaseX.java
@@ -1,0 +1,45 @@
+package io.xpring.codec.basex;
+
+import com.google.common.io.BaseEncoding;
+
+public interface IBaseX {
+  String encode(byte[] input);
+
+  byte[] decode(String input);
+
+  byte[] findPrefix(int payLoadLength, String desiredPrefix);
+
+  String encodeVersioned(byte[] input, Version version);
+
+  Decoded decodeVersioned(String input, Version... possibleVersions);
+
+  class Decoded {
+    public final Version version;
+    public final byte[] payload;
+
+    Decoded(Version version, byte[] payload) {
+      this.version = version;
+      this.payload = payload;
+    }
+  }
+
+  class Version {
+    public final byte[] bytes;
+    public final String name;
+    public final int expectedLength;
+
+    public Version(byte[] bytes, String name, int length) {
+      this.bytes = bytes;
+      this.name = name;
+      this.expectedLength = length;
+    }
+
+    public Version(int value, String name, int length) {
+      this(new byte[] {(byte) value}, name, length);
+    }
+
+    public Version(String hex, String name, int length) {
+      this(BaseEncoding.base16().decode(hex), name, length);
+    }
+  }
+}

--- a/src/main/java/io/xpring/common/HashUtils.java
+++ b/src/main/java/io/xpring/common/HashUtils.java
@@ -1,0 +1,49 @@
+package io.xpring.common;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class HashUtils {
+  private static final MessageDigest digest;
+
+  static {
+    try {
+      digest = MessageDigest.getInstance("SHA-256");
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);  // Can't happen.
+    }
+  }
+
+  /**
+   * See {@link HashUtils#doubleDigest(byte[], int, int)}.
+   */
+  public static byte[] doubleDigest(byte[] input) {
+    return doubleDigest(input, 0, input.length);
+  }
+
+  /**
+   * Calculates the SHA-256 hash of the given byte range, and then hashes the resulting hash again. This is
+   * standard procedure in Bitcoin. The resulting hash is in big endian form.
+   */
+  public static byte[] doubleDigest(byte[] input, int offset, int length) {
+    synchronized (digest) {
+      digest.reset();
+      digest.update(input, offset, length);
+      byte[] first = digest.digest();
+      return digest.digest(first);
+    }
+  }
+
+  public static byte[] halfSha512(byte[] bytes) {
+    return new Sha512(bytes).finish256();
+  }
+
+  public static byte[] quarterSha512(byte[] bytes) {
+    return new Sha512(bytes).finish128();
+  }
+
+  public static byte[] sha512(byte[] bytes) {
+    return new Sha512(bytes).finish();
+  }
+
+}

--- a/src/main/java/io/xpring/common/Sha512.java
+++ b/src/main/java/io/xpring/common/Sha512.java
@@ -1,0 +1,61 @@
+package io.xpring.common;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class Sha512 {
+  private MessageDigest messageDigest;
+
+  /**
+   * Default constructor.
+   */
+  public Sha512() {
+    try {
+      messageDigest = MessageDigest.getInstance("SHA-512");
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public Sha512(byte[] start) {
+    this();
+    add(start);
+  }
+
+  public Sha512 add(byte[] bytes) {
+    messageDigest.update(bytes);
+    return this;
+  }
+
+  /**
+   * Calculates sha512 hash for the given value.
+   *
+   * @param value value to hash.
+   * @return hash result.
+   */
+  public Sha512 addU32(int value) {
+    messageDigest.update((byte) ((value >>> 24) & 0xFF));
+    messageDigest.update((byte) ((value >>> 16) & 0xFF));
+    messageDigest.update((byte) ((value >>> 8) & 0xFF));
+    messageDigest.update((byte) ((value) & 0xFF));
+    return this;
+  }
+
+  private byte[] finishTaking(int size) {
+    byte[] hash = new byte[size];
+    System.arraycopy(messageDigest.digest(), 0, hash, 0, size);
+    return hash;
+  }
+
+  public byte[] finish128() {
+    return finishTaking(16);
+  }
+
+  public byte[] finish256() {
+    return finishTaking(32);
+  }
+
+  public byte[] finish() {
+    return messageDigest.digest();
+  }
+}

--- a/src/main/java/io/xpring/xrpl/ClassicAddress.java
+++ b/src/main/java/io/xpring/xrpl/ClassicAddress.java
@@ -9,6 +9,11 @@ import java.util.Optional;
  */
 @Value.Immutable
 public interface ClassicAddress {
+
+  static ImmutableClassicAddress.Builder builder() {
+    return ImmutableClassicAddress.builder();
+  }
+
   /**
    * The address component of the classic address.
    *

--- a/src/main/java/io/xpring/xrpl/Utils.java
+++ b/src/main/java/io/xpring/xrpl/Utils.java
@@ -1,6 +1,8 @@
 package io.xpring.xrpl;
 
 import com.google.common.base.Preconditions;
+import io.xpring.codec.addresses.ClassicAddressCodec;
+import io.xpring.codec.addresses.XAddressCodec;
 import io.xpring.common.CommonUtils;
 import io.xpring.common.XrplNetwork;
 import io.xpring.xrpl.javascript.JavaScriptLoaderException;
@@ -38,7 +40,7 @@ public class Utils {
    * @return A boolean indicating whether this was a valid address.
    */
   public static boolean isValidAddress(String address) {
-    return javaScriptUtils.isValidAddress(address);
+    return isValidClassicAddress(address) || isValidXAddress(address);
   }
 
   /**
@@ -74,7 +76,7 @@ public class Utils {
    * @see <a href="https://xrpaddress.info/">https://xrpaddress.info/</a>
    */
   public static String encodeXAddress(ClassicAddress classicAddress) {
-    return javaScriptUtils.encodeXAddress(classicAddress);
+    return XAddressCodec.encode(classicAddress);
   }
 
   /**
@@ -86,7 +88,11 @@ public class Utils {
    */
   @SuppressWarnings("checkstyle:ParameterName")
   public static ClassicAddress decodeXAddress(String xAddress) {
-    return javaScriptUtils.decodeXAddress(xAddress);
+    try {
+      return XAddressCodec.decode(xAddress);
+    } catch (Exception e) {
+      return null;
+    }
   }
 
   /**
@@ -96,7 +102,11 @@ public class Utils {
    * @return A boolean indicating whether this was a valid X-Address.
    */
   public static boolean isValidXAddress(String address) {
-    return javaScriptUtils.isValidXAddress(address);
+    try {
+      return XAddressCodec.decode(address) != null;
+    } catch (Exception e) {
+      return false;
+    }
   }
 
   /**
@@ -106,7 +116,11 @@ public class Utils {
    * @return A boolean indicating whether this was a valid clssic address.
    */
   public static boolean isValidClassicAddress(String address) {
-    return javaScriptUtils.isValidClassicAddress(address);
+    try {
+      return ClassicAddressCodec.decodeAccountID(address) != null;
+    } catch (Exception e) {
+      return false;
+    }
   }
 
   /**

--- a/src/main/java/io/xpring/xrpl/javascript/JavaScriptUtils.java
+++ b/src/main/java/io/xpring/xrpl/javascript/JavaScriptUtils.java
@@ -1,12 +1,9 @@
 package io.xpring.xrpl.javascript;
 
-import io.xpring.xrpl.ClassicAddress;
-import io.xpring.xrpl.ImmutableClassicAddress;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Value;
 
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * Provides JavaScript based Utils functionality.
@@ -27,97 +24,6 @@ public class JavaScriptUtils {
     Value javaScriptUtils = JavaScriptLoader.loadResource("XrpUtils", context);
 
     this.javaScriptUtils = javaScriptUtils;
-  }
-
-  /**
-   * Check if the given string is a valid address on the XRP Ledger.
-   *
-   * @param address A string to validate.
-   * @return A boolean indicating whether this was a valid address.
-   */
-  public boolean isValidAddress(String address) {
-    Objects.requireNonNull(address);
-
-    Value isValidAddressFunction = javaScriptUtils.getMember("isValidAddress");
-    return isValidAddressFunction.execute(address).asBoolean();
-  }
-
-  /**
-   * Encode the given {@link ClassicAddress} and tag into an X-Address.
-   *
-   * @param classicAddress A {@link ClassicAddress} to encode
-   * @return A new X-Address if inputs were valid, otherwise null.
-   * @see <a href="https://xrpaddress.info/">https://xrpaddress.info/</a>
-   */
-  @SuppressWarnings("checkstyle:LocalVariableName")
-  public String encodeXAddress(ClassicAddress classicAddress) {
-    Objects.requireNonNull(classicAddress);
-
-    Value encodeXAddressFunction = javaScriptUtils.getMember("encodeXAddress");
-
-    if (classicAddress.tag().isPresent()) {
-      Value xAddress = encodeXAddressFunction.execute(
-          classicAddress.address(),
-          classicAddress.tag().get(),
-          classicAddress.isTest()
-      );
-      return xAddress.asString();
-    } else {
-      Value undefined = JavaScriptLoader.getContext().eval("js", "undefined");
-      Value xAddress = encodeXAddressFunction.execute(classicAddress.address(), undefined, classicAddress.isTest());
-      return xAddress.asString();
-    }
-  }
-
-  /**
-   * Decode a {@link ClassicAddress} from a given X-Address.
-   *
-   * @param xAddress The xAddress to decode.
-   * @return A {@link ClassicAddress} if the inputs were valid, otherwise null.
-   * @see <a href="https://xrpaddress.info/">https://xrpaddress.info/</a>
-   */
-  @SuppressWarnings("checkstyle:ParameterName")
-  public ClassicAddress decodeXAddress(String xAddress) {
-    Objects.requireNonNull(xAddress);
-
-    Value decodeXAddressFunction = javaScriptUtils.getMember("decodeXAddress");
-    Value result = decodeXAddressFunction.execute(xAddress);
-
-    if (result.isNull()) {
-      return null;
-    }
-
-    String address = result.getMember("address").asString();
-    Integer tag = result.getMember("tag").isNull() ? null : result.getMember("tag").asInt();
-    boolean isTest = result.getMember("test").asBoolean();
-
-    return ImmutableClassicAddress.builder().address(address).tag(Optional.ofNullable(tag)).isTest(isTest).build();
-  }
-
-  /**
-   * Check if the given string is a valid X-Address on the XRP Ledger.
-   *
-   * @param address A string to validate.
-   * @return A boolean indicating whether this was a valid X-Address.
-   */
-  public boolean isValidXAddress(String address) {
-    Objects.requireNonNull(address);
-
-    Value isValidXAddressFunction = javaScriptUtils.getMember("isValidXAddress");
-    return isValidXAddressFunction.execute(address).asBoolean();
-  }
-
-  /**
-   * Check if the given string is a valid classic address on the XRP Ledger.
-   *
-   * @param address A string to validate.
-   * @return A boolean indicating whether this was a valid clssic address.
-   */
-  public boolean isValidClassicAddress(String address) {
-    Objects.requireNonNull(address);
-
-    Value isValidClassicAddressFunction = javaScriptUtils.getMember("isValidClassicAddress");
-    return isValidClassicAddressFunction.execute(address).asBoolean();
   }
 
   /**

--- a/src/test/java/io/xpring/codec/addresses/XAddressCodecTest.java
+++ b/src/test/java/io/xpring/codec/addresses/XAddressCodecTest.java
@@ -62,4 +62,59 @@ public class XAddressCodecTest {
         .isEqualTo(address);
   }
 
+  @Test
+  public void testEncodeTestnetNoTag() {
+    ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
+        .isTest(true)
+        .build();
+    assertThat(XAddressCodec.encode(address)).isEqualTo("TVE26TYGhfLC7tQDno7G8dGtxSkYQn49b3qD26PK7FcGSKE");
+  }
+
+  @Test
+  public void testEncodeTestnetWithTag() {
+    ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
+        .tag(1)
+        .isTest(true)
+        .build();
+    assertThat(XAddressCodec.encode(address)).isEqualTo("TVE26TYGhfLC7tQDno7G8dGtxSkYQnSz1uDimDdPYXzSpyw");
+  }
+
+  @Test
+  public void testEncodeTestnetWithLargeTag() {
+    ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
+        .tag(16781933)
+        .isTest(true)
+        .build();
+    assertThat(XAddressCodec.encode(address)).isEqualTo("TVE26TYGhfLC7tQDno7G8dGtxSkYQnVsw45sDtGHhLi27Qa");
+  }
+
+  @Test
+  public void testDecodeTestnetNoTag() {
+    ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
+        .isTest(true)
+        .build();
+    assertThat(XAddressCodec.decode("TVE26TYGhfLC7tQDno7G8dGtxSkYQn49b3qD26PK7FcGSKE"))
+        .isEqualTo(address);
+  }
+
+  @Test
+  public void testDecodeTestnetWithTag() {
+    ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
+        .tag(1)
+        .isTest(true)
+        .build();
+    assertThat(XAddressCodec.decode("TVE26TYGhfLC7tQDno7G8dGtxSkYQnSz1uDimDdPYXzSpyw"))
+        .isEqualTo(address);
+  }
+
+  @Test
+  public void testDecodeTestnetWithLargeTag() {
+    ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
+        .tag(16781933)
+        .isTest(true)
+        .build();
+    assertThat(XAddressCodec.decode("TVE26TYGhfLC7tQDno7G8dGtxSkYQnVsw45sDtGHhLi27Qa"))
+        .isEqualTo(address);
+  }
+
 }

--- a/src/test/java/io/xpring/codec/addresses/XAddressCodecTest.java
+++ b/src/test/java/io/xpring/codec/addresses/XAddressCodecTest.java
@@ -5,116 +5,156 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.xpring.xrpl.ClassicAddress;
 import org.junit.Test;
 
+/**
+ * Test cases modeled after the example under the "Encoding Example" section of the X-Address spec:
+ * https://github.com/xrp-community/standards-drafts/issues/6
+ */
 public class XAddressCodecTest {
 
   @Test
   public void testEncodeMainnetNoTag() {
+    // GIVEN a classic address for mainnet without a tag
     ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
         .isTest(false)
         .build();
+    // WHEN encoded
+    // THEN it should match the expected address per the spec examples
     assertThat(XAddressCodec.encode(address)).isEqualTo("XVLhHMPHU98es4dbozjVtdWzVrDjtV5fdx1mHp98tDMoQXb");
   }
 
   @Test
   public void testEncodeMainnetWithTag() {
+    // GIVEN a classic address for mainnet with a tag
     ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
         .tag(1)
         .isTest(false)
         .build();
+    // WHEN encoded
+    // THEN it should match the expected address per the spec examples
     assertThat(XAddressCodec.encode(address)).isEqualTo("XVLhHMPHU98es4dbozjVtdWzVrDjtV8xvjGQTYPiAx6gwDC");
   }
 
   @Test
   public void testEncodeMainnetWithLargeTag() {
+    // GIVEN a classic address for mainnet with a long tag
     ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
         .tag(16781933)
         .isTest(false)
         .build();
+    // WHEN encoded
+    // THEN it should match the expected address per the spec examples
     assertThat(XAddressCodec.encode(address)).isEqualTo("XVLhHMPHU98es4dbozjVtdWzVrDjtVqrDUk2vDpkTjPsY73");
   }
 
   @Test
   public void testDecodeMainnetNoTag() {
-    ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
+    ClassicAddress expected = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
         .isTest(false)
         .build();
+    // GIVEN an X-address representing a mainnet address without a tag
+    // WHEN decoded
+    // THEN it should match the expected classic address from the spec examples
     assertThat(XAddressCodec.decode("XVLhHMPHU98es4dbozjVtdWzVrDjtV5fdx1mHp98tDMoQXb"))
-        .isEqualTo(address);
+        .isEqualTo(expected);
   }
 
   @Test
   public void testDecodeMainnetWithTag() {
-    ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
+    ClassicAddress expected = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
         .tag(1)
         .isTest(false)
         .build();
+    // GIVEN an X-address representing a mainnet address with a tag
+    // WHEN decoded
+    // THEN it should match the expected classic address from the spec examples
     assertThat(XAddressCodec.decode("XVLhHMPHU98es4dbozjVtdWzVrDjtV8xvjGQTYPiAx6gwDC"))
-        .isEqualTo(address);
+        .isEqualTo(expected);
   }
 
   @Test
   public void testDecodeMainnetWithLargeTag() {
-    ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
+    ClassicAddress expected = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
         .tag(16781933)
         .isTest(false)
         .build();
+    // GIVEN an X-address representing a mainnet address with a large tag
+    // WHEN decoded
+    // THEN it should match the expected classic address from the spec examples
     assertThat(XAddressCodec.decode("XVLhHMPHU98es4dbozjVtdWzVrDjtVqrDUk2vDpkTjPsY73"))
-        .isEqualTo(address);
+        .isEqualTo(expected);
   }
 
   @Test
   public void testEncodeTestnetNoTag() {
+    // GIVEN a classic address for testnet without a tag
     ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
         .isTest(true)
         .build();
+    // WHEN encoded
+    // THEN it should match the expected address per the spec examples
     assertThat(XAddressCodec.encode(address)).isEqualTo("TVE26TYGhfLC7tQDno7G8dGtxSkYQn49b3qD26PK7FcGSKE");
   }
 
   @Test
   public void testEncodeTestnetWithTag() {
+    // GIVEN a classic address for testnet with a tag
     ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
         .tag(1)
         .isTest(true)
         .build();
+    // WHEN encoded
+    // THEN it should match the expected address per the spec examples
     assertThat(XAddressCodec.encode(address)).isEqualTo("TVE26TYGhfLC7tQDno7G8dGtxSkYQnSz1uDimDdPYXzSpyw");
   }
 
   @Test
   public void testEncodeTestnetWithLargeTag() {
+    // GIVEN a classic address for testnet with a long tag
     ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
         .tag(16781933)
         .isTest(true)
         .build();
+    // WHEN encoded
+    // THEN it should match the expected address per the spec examples
     assertThat(XAddressCodec.encode(address)).isEqualTo("TVE26TYGhfLC7tQDno7G8dGtxSkYQnVsw45sDtGHhLi27Qa");
   }
 
   @Test
   public void testDecodeTestnetNoTag() {
-    ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
+    ClassicAddress expected = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
         .isTest(true)
         .build();
+    // GIVEN an X-address representing a testnet address without a tag
+    // WHEN decoded
+    // THEN it should match the expected classic address from the spec examples
     assertThat(XAddressCodec.decode("TVE26TYGhfLC7tQDno7G8dGtxSkYQn49b3qD26PK7FcGSKE"))
-        .isEqualTo(address);
+        .isEqualTo(expected);
   }
 
   @Test
   public void testDecodeTestnetWithTag() {
-    ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
+    ClassicAddress expected = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
         .tag(1)
         .isTest(true)
         .build();
+    // GIVEN an X-address representing a testnet address with a tag
+    // WHEN decoded
+    // THEN it should match the expected classic address from the spec examples
     assertThat(XAddressCodec.decode("TVE26TYGhfLC7tQDno7G8dGtxSkYQnSz1uDimDdPYXzSpyw"))
-        .isEqualTo(address);
+        .isEqualTo(expected);
   }
 
   @Test
   public void testDecodeTestnetWithLargeTag() {
-    ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
+    ClassicAddress expected = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
         .tag(16781933)
         .isTest(true)
         .build();
+    // GIVEN an X-address representing a testnet address with a large tag
+    // WHEN decoded
+    // THEN it should match the expected classic address from the spec examples
     assertThat(XAddressCodec.decode("TVE26TYGhfLC7tQDno7G8dGtxSkYQnVsw45sDtGHhLi27Qa"))
-        .isEqualTo(address);
+        .isEqualTo(expected);
   }
 
 }

--- a/src/test/java/io/xpring/codec/addresses/XAddressCodecTest.java
+++ b/src/test/java/io/xpring/codec/addresses/XAddressCodecTest.java
@@ -1,0 +1,65 @@
+package io.xpring.codec.addresses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.xpring.xrpl.ClassicAddress;
+import org.junit.Test;
+
+public class XAddressCodecTest {
+
+  @Test
+  public void testEncodeMainnetNoTag() {
+    ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
+        .isTest(false)
+        .build();
+    assertThat(XAddressCodec.encode(address)).isEqualTo("XVLhHMPHU98es4dbozjVtdWzVrDjtV5fdx1mHp98tDMoQXb");
+  }
+
+  @Test
+  public void testEncodeMainnetWithTag() {
+    ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
+        .tag(1)
+        .isTest(false)
+        .build();
+    assertThat(XAddressCodec.encode(address)).isEqualTo("XVLhHMPHU98es4dbozjVtdWzVrDjtV8xvjGQTYPiAx6gwDC");
+  }
+
+  @Test
+  public void testEncodeMainnetWithLargeTag() {
+    ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
+        .tag(16781933)
+        .isTest(false)
+        .build();
+    assertThat(XAddressCodec.encode(address)).isEqualTo("XVLhHMPHU98es4dbozjVtdWzVrDjtVqrDUk2vDpkTjPsY73");
+  }
+
+  @Test
+  public void testDecodeMainnetNoTag() {
+    ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
+        .isTest(false)
+        .build();
+    assertThat(XAddressCodec.decode("XVLhHMPHU98es4dbozjVtdWzVrDjtV5fdx1mHp98tDMoQXb"))
+        .isEqualTo(address);
+  }
+
+  @Test
+  public void testDecodeMainnetWithTag() {
+    ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
+        .tag(1)
+        .isTest(false)
+        .build();
+    assertThat(XAddressCodec.decode("XVLhHMPHU98es4dbozjVtdWzVrDjtV8xvjGQTYPiAx6gwDC"))
+        .isEqualTo(address);
+  }
+
+  @Test
+  public void testDecodeMainnetWithLargeTag() {
+    ClassicAddress address = ClassicAddress.builder().address("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
+        .tag(16781933)
+        .isTest(false)
+        .build();
+    assertThat(XAddressCodec.decode("XVLhHMPHU98es4dbozjVtdWzVrDjtVqrDUk2vDpkTjPsY73"))
+        .isEqualTo(address);
+  }
+
+}

--- a/src/test/java/io/xpring/codec/base58/B58Test.java
+++ b/src/test/java/io/xpring/codec/base58/B58Test.java
@@ -1,0 +1,52 @@
+package io.xpring.codec.base58;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.io.BaseEncoding;
+import io.xpring.codec.addresses.ClassicAddressCodec;
+import org.bouncycastle.util.Arrays;
+import org.junit.Test;
+
+public class B58Test {
+
+  @Test
+  public void testFindsEdPrefix() throws Exception {
+    String prefix = "sEd";
+    byte[] versionBytes = ClassicAddressCodec.codec.findPrefix(16, prefix);
+    testStability(16, prefix, versionBytes);
+    assertEncodesTo("01E14B", versionBytes);
+  }
+
+  @Test
+  public void testFindsecp256k1Prefix() throws Exception {
+    String prefix = "secp256k1";
+    byte[] versionBytes = ClassicAddressCodec.codec.findPrefix(16, prefix);
+    testStability(16, prefix, versionBytes);
+    assertEncodesTo("13984B20F2BD93", versionBytes);
+  }
+
+  private void testStability(@SuppressWarnings("SameParameterValue")
+                                 int length, String prefix, byte[] versionBytes) {
+    B58.Version version = new B58.Version(versionBytes, "test", length);
+    testStabilityWithAllByteValuesAtIx(0, length, prefix, version);
+    testStabilityWithAllByteValuesAtIx(length - 1, length, prefix, version);
+  }
+
+  private void testStabilityWithAllByteValuesAtIx(int ix,
+                                                  int length,
+                                                  String prefix,
+                                                  B58.Version version) {
+    byte[] sample = new byte[length];
+    Arrays.fill(sample, (byte) 0xff);
+
+    for (int i = 0; i < 256; i++) {
+      sample[ix] = (byte) i;
+      String encoded = ClassicAddressCodec.encode(sample, version);
+      assertEquals(prefix, encoded.substring(0, prefix.length()));
+    }
+  }
+
+  public void assertEncodesTo(String expected, byte[] actual) {
+    assertEquals(expected, BaseEncoding.base16().encode(actual));
+  }
+}


### PR DESCRIPTION
## High Level Overview of Change

So begins the migration to native Java instead of using Java -> Javascript for XRPL functions. First we begin by rewriting the X-address / Classic address encoding and decoding to pure Java.


### Context of Change

The current architecture uses GraalVM to call XpringCommonJS for XRPL signing, encoding stuffs. This has proven to be slow and does not work on Android. 

This PR rewrites the  X-address / Classic address encoding and decoding to pure Java. Most the code was lifted from ripple-lib-java-unmaintained which is not available as a maven dependency.  

The new class I created from scratch is XAddressCodecs. I also updated the Utils library to call these new classes. And I removed the unused Javascript functions that are now in Java.

Otherwise, all the other classes were copied from ripple-lib-java-unmaintained and cleaned up (mostly formatting and javadoc).

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Unit test coverage is pretty good on the refactored code. Mainly relying on these for test validation.
